### PR TITLE
chore: add Justfile and .markdownlint.jsonc, update README

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,0 +1,27 @@
+// Project-wide markdownlint configuration.
+// Docs: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+{
+  "default": true,
+
+  // Line length: disabled. CHANGELOG entries, badge URLs and inline code
+  // references frequently exceed 80 columns; soft-wrap is handled by the
+  // renderer, not by hard line breaks in source.
+  "MD013": false,
+
+  // Duplicate headings: permitted across sibling scopes. Keep a Changelog
+  // mandates repeated `### Added` / `### Changed` / `### Removed` under each
+  // version, but we still flag accidental duplicates within the same scope.
+  "MD024": { "siblings_only": true },
+
+  // Inline HTML: permitted. README uses <p align="center">, <img>, <a> and
+  // similar elements for badges, centered headers and tables.
+  "MD033": false,
+
+  // Emphasis used as heading: permitted. Lightweight **bold** section labels
+  // are common in changelogs and migration blocks.
+  "MD036": false,
+
+  // First line must be a top-level heading: disabled. README typically opens
+  // with badges or centered logo blocks before the `# Title` heading.
+  "MD041": false
+}

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,53 @@
+# Justfile for Rust project using Cargo
+
+all: fmt clippy-fix
+
+# Build the project with all features enabled in release mode
+build:
+    cargo build --workspace --release --all-features
+
+# Check the project for compilation errors without producing binaries
+check:
+    cargo check --workspace --all-features
+
+# Update dependencies to their latest compatible versions
+update:
+    cargo update
+
+# Run the project with all features enabled in release mode
+run:
+    cargo run --release --all-features
+
+# Run all tests with all features enabled
+test:
+    cargo test --workspace --all-features
+
+# Run benchmarks with all features enabled
+bench:
+    cargo bench --all-features
+
+# Run Clippy linter with nightly toolchain (check only, for CI)
+# Uses workspace lints from Cargo.toml
+clippy:
+    cargo +nightly clippy --workspace \
+        --all-targets \
+        --all-features \
+        -- -D warnings
+
+# Run Clippy linter with auto-fix (for development)
+clippy-fix:
+    cargo +nightly clippy --workspace \
+        --fix \
+        --all-targets \
+        --all-features \
+        --allow-dirty \
+        --allow-staged \
+        -- -D warnings
+
+# Format the code using rustfmt with nightly toolchain
+fmt:
+    cargo +nightly fmt
+
+# Generate documentation for all crates and open it in the browser
+doc:
+    cargo +nightly doc --all-features --no-deps --open

--- a/README.md
+++ b/README.md
@@ -4,13 +4,14 @@
 
 Embedded micro-VM sandbox for running AI agents, powered by [libkrun](https://github.com/containers/libkrun) with KVM (Linux) or Hypervisor.framework (macOS).
 
+---
+
 <div align="center">
 
-A **[QNTX](https://qntx.fun)** open-source project.
+A **[QuantX](https://qntx.fun)** open-source project.
 
-<a href="https://qntx.fun"><img alt="QNTX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx-banner.svg" /></a>
+<a href="https://qntx.fun"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
 
-<!--prettier-ignore-->
 Code is law. We write both.
 
 </div>


### PR DESCRIPTION
# Description

<!-- Brief summary of what this PR does -->
Add common development tooling and update the README.
## Changes

<!-- Link to related issues: Fixes #123, Closes #456 -->
- Add `Justfile` for task running
- Add `.markdownlint.jsonc` for Markdown linting
- Update `README.md`