### PR TITLE
fix: correct copyright holder in MIT license

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 pyroth.sol
+Copyright (c) 2025 QuantX
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Description

Correct the copyright holder in the MIT License file. The existing `pyroth.sol` entry is incorrect and has been replaced with the correct copyright holder name.

## Changes

* Updated the copyright holder in `LICENSE`
* Removed the incorrect `pyroth.sol` attribution

Closes #36 