### PR TITLE
fix: use libc::Ioctl type for FIFREEZE/FITHAW constants (#38)

### DIFF
--- a/crates/bux-guest/src/mounts.rs
+++ b/crates/bux-guest/src/mounts.rs
@@ -62,9 +62,9 @@ const SKIP_FS_TYPES: &[&str] = &[
 //   #define FIFREEZE  _IOWR('X', 119, int)  = 0xC0045877
 //   #define FITHAW    _IOWR('X', 120, int)  = 0xC0045878
 /// `FIFREEZE` ioctl — flush dirty pages and block new writes.
-const FIFREEZE: libc::c_ulong = 0xC004_5877;
+const FIFREEZE: libc::Ioctl = 0xC004_5877_u64 as libc::Ioctl;
 /// `FITHAW` ioctl — unblock writes on a frozen filesystem.
-const FITHAW: libc::c_ulong = 0xC004_5878;
+const FITHAW: libc::Ioctl = 0xC004_5878_u64 as libc::Ioctl;
 
 /// Sets up minimal network configuration so DNS resolution works.
 ///


### PR DESCRIPTION
# Description

Fixes a compile-time type mismatch in [`bux-guest`](https://github.com/qntx/bux/tree/main/crates/bux-guest) when targeting `aarch64-unknown-linux-musl`. The `FIFREEZE` and `FITHAW` ioctl constants were typed as `libc::c_ulong`, which matches glibc's `ioctl` signature but not musl's (`c_int`). Changed them to the `libc::Ioctl` type alias to match the `ioctl` request parameter on all targets.

## Changes

- Replaced `libc::c_ulong` with `libc::Ioctl` for the `FIFREEZE` and `FITHAW` constants in [`crates/bux-guest/src/mounts.rs`](https://github.com/qntx/bux/blob/main/crates/bux-guest/src/mounts.rs)

Closes #38