### PR TITLE
Fix/43 inject into disk missing parent dir

### DIFF
--- a/crates/bux-e2fs/src/error.rs
+++ b/crates/bux-e2fs/src/error.rs
@@ -64,6 +64,7 @@ fn describe_ext2fs_error(code: i64) -> String {
         25 => "short read".into(),
         26 => "short write".into(),
         28 => "filesystem too large".into(),
+        79 => "directory already exists".into(),
         85 => "journal too small".into(),
         _ => format!("libext2fs error {code:#x}"),
     }

--- a/crates/bux-e2fs/src/ext4.rs
+++ b/crates/bux-e2fs/src/ext4.rs
@@ -23,7 +23,7 @@
 
 use std::ffi::CString;
 use std::fs::OpenOptions;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 use crate::sys;
@@ -589,6 +589,16 @@ pub fn create_from_dir(source_dir: &Path, output: &Path, size_bytes: u64) -> Res
 /// Returns an error if the image cannot be opened or the write fails.
 pub fn inject_file(image: &Path, host_file: &Path, guest_path: &str) -> Result<()> {
     let mut fs = Filesystem::open(image)?;
+    if let Some(parent) = Path::new(guest_path).parent() {
+        let mut current_path = PathBuf::new();
+        for component in parent {
+            current_path.push(component);
+            match fs.mkdir(&current_path.to_string_lossy()) {
+                Ok(()) | Err(Error::Ext2fs { code: 2_133_571_344, .. }) => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
     fs.write_file(host_file, guest_path)
 }
 

--- a/crates/bux-e2fs/src/ext4.rs
+++ b/crates/bux-e2fs/src/ext4.rs
@@ -588,13 +588,14 @@ pub fn create_from_dir(source_dir: &Path, output: &Path, size_bytes: u64) -> Res
 ///
 /// Returns an error if the image cannot be opened or the write fails.
 pub fn inject_file(image: &Path, host_file: &Path, guest_path: &str) -> Result<()> {
+    const EXT2_ET_DIR_EXISTS: i64 = 2_133_571_328 + 79;
     let mut fs = Filesystem::open(image)?;
     if let Some(parent) = Path::new(guest_path).parent() {
         let mut current_path = PathBuf::new();
         for component in parent {
             current_path.push(component);
             match fs.mkdir(&current_path.to_string_lossy()) {
-                Ok(()) | Err(Error::Ext2fs { code: 2_133_571_344, .. }) => {}
+                Ok(()) | Err(Error::Ext2fs { code: EXT2_ET_DIR_EXISTS, .. }) => {}
                 Err(e) => return Err(e),
             }
         }

--- a/crates/bux-e2fs/src/ext4.rs
+++ b/crates/bux-e2fs/src/ext4.rs
@@ -595,7 +595,11 @@ pub fn inject_file(image: &Path, host_file: &Path, guest_path: &str) -> Result<(
         for component in parent {
             current_path.push(component);
             match fs.mkdir(&current_path.to_string_lossy()) {
-                Ok(()) | Err(Error::Ext2fs { code: EXT2_ET_DIR_EXISTS, .. }) => {}
+                Ok(())
+                | Err(Error::Ext2fs {
+                    code: EXT2_ET_DIR_EXISTS,
+                    ..
+                }) => {}
                 Err(e) => return Err(e),
             }
         }


### PR DESCRIPTION
# Description

Fix `inject_file` failing when the guest binary's parent directory (`bux/bin`) does not exist in the ext4 image.

## Changes

- `crates/bux-e2fs/src/ext4.rs`: create parent directories before writing; treat `EXT2_ET_DIR_EXISTS` (79) as success; use a named constant instead of the magic number
- `crates/bux-e2fs/src/error.rs`: add readable error mapping for error code 79

Closes #43