### PR TITLE
docs: fix doctest in bux-gvproxy lib.rs quick-start example

### DIFF
--- a/crates/bux-gvproxy/src/lib.rs
+++ b/crates/bux-gvproxy/src/lib.rs
@@ -26,7 +26,7 @@
 //!     PathBuf::from("/tmp/my-vm/net.sock"),
 //!     vec![(8080, 80), (8443, 443)],
 //! );
-//! let instance = GvproxyInstance::new(config)?;
+//! let instance = GvproxyInstance::new(&config)?;
 //! let stats = instance.get_stats()?;
 //! eprintln!("bytes sent: {}", stats.bytes_sent);
 //! # Ok::<(), bux_gvproxy::Error>(())


### PR DESCRIPTION
# Description

Fix a broken doctest in [bux-gvproxy](cci:9://file:///Users/liu/Documents/GitHub/bux/crates/bux-gvproxy:0:0-0:0)'s quick-start example. The example passed `config` by value to [GvproxyInstance::new()](cci:1://file:///Users/liu/Documents/GitHub/bux/crates/bux-gvproxy/src/instance.rs:37:4-55:5), but the function signature expects `&GvproxyConfig`.

## Changes

- [crates/bux-gvproxy/src/lib.rs](cci:7://file:///Users/liu/Documents/GitHub/bux/crates/bux-gvproxy/src/lib.rs:0:0-0:0): changed [GvproxyInstance::new(config)](cci:1://file:///Users/liu/Documents/GitHub/bux/crates/bux-gvproxy/src/instance.rs:37:4-55:5) to [GvproxyInstance::new(&config)](cci:1://file:///Users/liu/Documents/GitHub/bux/crates/bux-gvproxy/src/instance.rs:37:4-55:5) in the doctest

Closes #52