### PR TITLE
fix: load allocation bitmaps on open and add test function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,7 @@ dependencies = [
  "bindgen",
  "flate2",
  "tar",
+ "tempfile",
  "thiserror 2.0.18",
  "ureq",
 ]

--- a/crates/bux-e2fs/Cargo.toml
+++ b/crates/bux-e2fs/Cargo.toml
@@ -25,6 +25,9 @@ flate2.workspace = true
 tar.workspace = true
 ureq.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "docsrs"]
 

--- a/crates/bux-e2fs/build.rs
+++ b/crates/bux-e2fs/build.rs
@@ -124,6 +124,10 @@ fn generate_bindings(headers_dir: &Path, out_dir: &Path) {
         .allowlist_function("ext2fs_allocate_tables")
         .allowlist_function("ext2fs_add_journal_inode")
         .allowlist_function("ext2fs_mark_super_dirty")
+        // NOTE: `ext2fs_read_bitmaps` and `ext2fs_default_journal_size` are
+        // intentionally absent from this list — they are hand-declared in
+        // src/sys.rs so they work without the `regenerate` feature. Adding
+        // them here would collide with those declarations (E0428).
         // Inode operations
         .allowlist_function("ext2fs_mkdir")
         .allowlist_function("ext2fs_link")

--- a/crates/bux-e2fs/src/ext4.rs
+++ b/crates/bux-e2fs/src/ext4.rs
@@ -209,9 +209,16 @@ impl Filesystem {
 
     /// Opens an existing ext4 image for read-write operations.
     ///
+    /// The allocation bitmaps are loaded from disk, so the returned handle
+    /// supports allocation ([`mkdir`](Self::mkdir),
+    /// [`write_file`](Self::write_file), [`alloc_inode`](Self::alloc_inode))
+    /// as well as reads, and modifications are written back when the
+    /// filesystem is closed.
+    ///
     /// # Errors
     ///
-    /// Returns an error if the image does not exist or libext2fs fails to open it.
+    /// Returns an error if the image does not exist, libext2fs fails to open
+    /// it, or the allocation bitmaps cannot be read.
     pub fn open(path: &Path) -> Result<Self> {
         let c_path = to_cstring(path)?;
 
@@ -228,7 +235,13 @@ impl Filesystem {
                     std::ptr::from_mut(&mut fs),
                 ),
             )?;
-            Ok(Self { inner: fs })
+
+            // Wrap immediately — Drop guarantees ext2fs_close if the bitmap
+            // read below fails. libext2fs frees and NULLs any partially read
+            // map on error, so no manual bitmap cleanup is needed here.
+            let this = Self { inner: fs };
+            check("ext2fs_read_bitmaps", sys::ext2fs_read_bitmaps(this.inner))?;
+            Ok(this)
         }
     }
 
@@ -448,7 +461,8 @@ impl Filesystem {
     /// Allocates a new inode number near `dir` with the given POSIX `mode`.
     ///
     /// Updates the inode bitmap and allocation statistics automatically.
-    /// Requires bitmaps to be loaded (always true after [`create`](Self::create)).
+    /// Requires bitmaps to be loaded — guaranteed by both
+    /// [`create`](Self::create) and [`open`](Self::open).
     ///
     /// # Errors
     ///
@@ -470,7 +484,8 @@ impl Filesystem {
     /// Allocates a new block near `goal`.
     ///
     /// Updates the block bitmap and allocation statistics automatically.
-    /// Requires bitmaps to be loaded (always true after [`create`](Self::create)).
+    /// Requires bitmaps to be loaded — guaranteed by both
+    /// [`create`](Self::create) and [`open`](Self::open).
     ///
     /// # Errors
     ///
@@ -709,6 +724,12 @@ fn walk(dir: &Path, f: &mut impl FnMut(&std::fs::Metadata)) -> Result<()> {
 mod tests {
     use super::*;
 
+    // libext2fs's mount check calls libc `getmntinfo()`, which is not
+    // thread-safe on macOS, so tests that build images must run serially.
+    // If production ever builds base images concurrently, move this into
+    // `Filesystem::add_journal`.
+    static FS_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn block_size_bytes_match_log_levels() {
         assert_eq!(BlockSize::B1024.bytes(), 1024);
@@ -747,5 +768,138 @@ mod tests {
     fn builder_journal_defaults_to_true() {
         let b = Ext4Builder::new();
         assert!(b.journal, "default should produce ext4 (with journal)");
+    }
+
+    // ---- reopening an image must load its allocation bitmaps ----
+
+    /// Builds a 64 MiB image from an empty rootfs plus a payload file. The
+    /// `TempDir` must be kept alive by the caller or the files are deleted.
+    fn image_fixture() -> (tempfile::TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+
+        let rootfs = dir.path().join("rootfs");
+        std::fs::create_dir(&rootfs).unwrap();
+
+        let image = dir.path().join("image.raw");
+        create_from_dir(&rootfs, &image, 64 * 1024 * 1024).unwrap();
+
+        let payload = dir.path().join("payload.bin");
+        std::fs::write(&payload, b"bux-guest").unwrap();
+
+        (dir, image, payload)
+    }
+
+    #[test]
+    fn reopened_image_supports_allocation() {
+        let _guard = FS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::TempDir::new().unwrap();
+        let image = dir.path().join("image.raw");
+
+        // Session 1: create an image with a journal, then close it.
+        {
+            let mut fs =
+                Filesystem::create(&image, 64 * 1024 * 1024, &CreateOptions::default()).unwrap();
+            fs.add_journal().unwrap();
+        }
+
+        // Session 2: reopen and allocate. A missing bitmap load makes every
+        // call here fail with EXT2_ET_NO_INODE_BITMAP.
+        {
+            let mut fs = Filesystem::open(&image).unwrap();
+            fs.mkdir_p("bux/bin").unwrap();
+            let ino = fs.alloc_inode(sys::EXT2_ROOT_INO, 0o100_644).unwrap();
+            assert!(
+                ino >= 11,
+                "allocated inode {ino} should be past the reserved range"
+            );
+        }
+
+        // Session 3: reopen once more. The directory must survive the
+        // round-trip, and a fresh allocation must skip inodes 11-13 that
+        // session 2 took — both hold only if the dirty bitmaps were written
+        // back on close; a stale bitmap would hand out inode 11 again.
+        {
+            let mut fs = Filesystem::open(&image).unwrap();
+            let err = fs.mkdir("bux").unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    Error::Ext2fs {
+                        code: Ext2Code::DirExists,
+                        ..
+                    }
+                ),
+                "second mkdir should report DirExists, got {err:?}"
+            );
+            let ino = fs.alloc_inode(sys::EXT2_ROOT_INO, 0o100_644).unwrap();
+            assert!(
+                ino >= 14,
+                "dirty bitmaps were not written back: reused inode {ino} from session 2"
+            );
+        }
+    }
+
+    #[test]
+    fn inject_file_creates_missing_parent_directories() {
+        let _guard = FS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_dir, image, payload) = image_fixture();
+
+        // None of a/, a/b/ or a/b/c/ exist in a freshly built image.
+        inject_file(&image, &payload, "a/b/c/data.bin").unwrap();
+
+        let mut fs = Filesystem::open(&image).unwrap();
+        for existing in ["a", "a/b", "a/b/c"] {
+            let err = fs.mkdir(existing).unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    Error::Ext2fs {
+                        code: Ext2Code::DirExists,
+                        ..
+                    }
+                ),
+                "directory {existing} should exist, got {err:?}"
+            );
+        }
+
+        let err = fs.write_file(&payload, "a/b/c/data.bin").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                Error::Ext2fs {
+                    code: Ext2Code::FileExists,
+                    ..
+                }
+            ),
+            "injected file should already exist, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn inject_file_is_idempotent_when_parents_exist() {
+        let _guard = FS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_dir, image, payload) = image_fixture();
+
+        inject_file(&image, &payload, "a/b/c/first.bin").unwrap();
+        // a/, a/b/ and a/b/c/ now exist — mkdir_p must swallow DirExists
+        // instead of propagating it.
+        inject_file(&image, &payload, "a/b/c/second.bin").unwrap();
+    }
+
+    #[test]
+    fn inject_file_without_parent_directory_works() {
+        let _guard = FS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (_dir, image, payload) = image_fixture();
+
+        // No '/' in the guest path — the mkdir_p branch must be skipped.
+        inject_file(&image, &payload, "toplevel.bin").unwrap();
     }
 }

--- a/crates/bux-e2fs/src/sys.rs
+++ b/crates/bux-e2fs/src/sys.rs
@@ -48,6 +48,21 @@ include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 #[cfg(not(feature = "regenerate"))]
 include!("bindings.rs");
 
+// Hand-written declarations for symbols that exist in libext2fs.a but are
+// deliberately kept out of the bindgen allowlist in build.rs. Adding them to
+// that list would produce duplicate definitions (E0428) in this module when
+// the `regenerate` feature is enabled.
 unsafe extern "C" {
+    /// Recommended journal size in blocks for a filesystem of `num_blocks`;
+    /// returns a negative value on failure.
     pub fn ext2fs_default_journal_size(num_blocks: __u64) -> ::core::ffi::c_int;
+
+    /// Loads the on-disk inode and block bitmaps into `fs->inode_map` and
+    /// `fs->block_map`.
+    ///
+    /// `ext2fs_open` leaves both maps NULL, so allocations
+    /// (`ext2fs_new_inode`, `ext2fs_new_block2`) fail until this runs.
+    /// Idempotent — maps already loaded are left alone — and it installs the
+    /// `write_bitmaps` callback so `ext2fs_close` flushes them to disk.
+    pub fn ext2fs_read_bitmaps(fs: ext2_filsys) -> errcode_t;
 }


### PR DESCRIPTION
Description
Filesystem::open only called ext2fs_open, which reads the superblock and group descriptors but leaves fs->inode_map and fs->block_map NULL. Any allocation on a reopened handle (mkdir, mkdir_p, write_file, symlink, alloc_inode, alloc_block) therefore failed with EXT2_ET_NO_INODE_BITMAP, breaking guest-binary injection into existing images during base-image creation.

Filesystem::open now calls ext2fs_read_bitmaps immediately after opening. The call is idempotent and installs the write_bitmaps callback, so dirty bitmaps are flushed back to disk on close. Handles returned by open now support the same operations as handles returned by create.

This also adds regression coverage for the bitmap round-trip and for the nested-inject paths, and serializes the image-building tests to eliminate an intermittent parallel-test failure caused by libext2fs's macOS mount check (libc getmntinfo() is not thread-safe).

Verified: cargo test -p bux-e2fs passes 9 tests + 5 doctests across repeated parallel runs; cargo clippy --workspace --all-targets --all-features -- -D warnings and cargo fmt --check are clean on the pinned stable toolchain.

Changes
crates/bux-e2fs/src/ext4.rs
Filesystem::open loads the allocation bitmaps after ext2fs_open. The RAII wrapper is constructed first, so a failed bitmap read still runs ext2fs_close; libext2fs frees any partially read map itself.
Updated alloc_inode/alloc_block docs: bitmaps are now guaranteed after both create and open.
crates/bux-e2fs/src/sys.rs
Hand-written ext2fs_read_bitmaps extern, kept out of the bindgen allowlist so it works without the regenerate feature (adding it there would collide with the declaration, E0428).
crates/bux-e2fs/build.rs
Comment documenting why ext2fs_read_bitmaps and ext2fs_default_journal_size are intentionally absent from the allowlist.
crates/bux-e2fs/Cargo.toml
Added tempfile as a dev-dependency for the image tests.
Tests (mod tests in ext4.rs)
reopened_image_supports_allocation: create → close → reopen → allocate → reopen again; asserts the directory survives the round-trip and that a fresh inode skips the ones allocated earlier, proving the dirty bitmaps were written back on close rather than only held in memory.
inject_file_creates_missing_parent_directories, inject_file_is_idempotent_when_parents_exist, inject_file_without_parent_directory_works: nested-inject coverage requested in #54.
FS_TEST_LOCK serializes the image-building tests: the journal's mount check goes through libc getmntinfo() on macOS, whose process-global buffer is not thread-safe, so parallel builds failed intermittently with Errno(EFAULT/EPERM). If production ever builds base images concurrently, this serialization should move into Filesystem::add_journal.
Fixes #57