### PR TITLE
Fix/38 musl ioctl redo

### DIFF
--- a/crates/bux-guest/src/mounts.rs
+++ b/crates/bux-guest/src/mounts.rs
@@ -62,9 +62,9 @@ const SKIP_FS_TYPES: &[&str] = &[
 //   #define FIFREEZE  _IOWR('X', 119, int)  = 0xC0045877
 //   #define FITHAW    _IOWR('X', 120, int)  = 0xC0045878
 /// `FIFREEZE` ioctl — flush dirty pages and block new writes.
-const FIFREEZE: libc::Ioctl = 0xC004_5877_u64 as libc::Ioctl;
+const FIFREEZE: libc::Ioctl = 0xC004_5877_u32 as libc::Ioctl;
 /// `FITHAW` ioctl — unblock writes on a frozen filesystem.
-const FITHAW: libc::Ioctl = 0xC004_5878_u64 as libc::Ioctl;
+const FITHAW: libc::Ioctl = 0xC004_5878_u32 as libc::Ioctl;
 
 /// Mounts essential tmpfs directories early during boot.
 pub fn mount_essential_tmpfs() {

--- a/crates/bux-guest/src/mounts.rs
+++ b/crates/bux-guest/src/mounts.rs
@@ -62,9 +62,9 @@ const SKIP_FS_TYPES: &[&str] = &[
 //   #define FIFREEZE  _IOWR('X', 119, int)  = 0xC0045877
 //   #define FITHAW    _IOWR('X', 120, int)  = 0xC0045878
 /// `FIFREEZE` ioctl — flush dirty pages and block new writes.
-const FIFREEZE: libc::c_ulong = 0xC004_5877;
+const FIFREEZE: libc::Ioctl = 0xC004_5877_u64 as libc::Ioctl;
 /// `FITHAW` ioctl — unblock writes on a frozen filesystem.
-const FITHAW: libc::c_ulong = 0xC004_5878;
+const FITHAW: libc::Ioctl = 0xC004_5878_u64 as libc::Ioctl;
 
 /// Mounts essential tmpfs directories early during boot.
 pub fn mount_essential_tmpfs() {


### PR DESCRIPTION
# Description

Fixes the `bux-guest` musl build. `FIFREEZE`/`FITHAW` were typed as `libc::c_ulong`, which only matches glibc's `ioctl(int, unsigned long, ...)` — musl follows POSIX with `ioctl(int, int, ...)`, so both call sites failed with E0308 on the only targets `bux-guest` ships for.

This is a regression: the same fix landed in `03a2a0b` (#39) but was dropped when that merge fell out of `main`'s history.

## Changes

- Type both constants as `libc::Ioctl` so the request width follows the target libc
- Use `u32` literals — the width the kernel actually reads; zero-extends on glibc, wraps to `c_int` on musl, same low 32 bits either way

Verified on both musl targets plus gnu: release builds, `clippy -- -D warnings`, and `fmt --check` all pass.

Closes #38