### PR TITLE
Update website URL to .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Embedded micro-VM sandbox for running AI agents, powered by [libkrun](https://gi
 
 <div align="center">
 
-A **[QuantX](https://qntx.fun)** open-source project.
+A **[QuantX](https://qntx.org)** open-source project.
 
-<a href="https://qntx.fun"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
+<a href="https://qntx.org"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
 
 Code is law. We write both.
 
 </div>
+


### PR DESCRIPTION
# Description

Update the website URL from `.fun` to `.org`.

## Changes

- Replaced the old `.fun` URL with the new `.org` URL in `README.md`