### PR TITLE
fix(macos): sign and package bux-shim with hypervisor entitlement

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -96,9 +96,15 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu libcap-ng-dev:arm64
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
-      - run: cargo build --release --target ${{ matrix.target }} -p bux-cli
+      - run: cargo build --release --target ${{ matrix.target }} -p bux-cli -p bux-shim
         env:
           BUX_GUEST_DIR: ${{ github.workspace }}/.guest
+
+      - name: Sign bux-shim (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          codesign --entitlements crates/bux-shim/bux-shim.entitlements \
+            -s - --force "target/${{ matrix.target }}/release/bux-shim"
 
       - name: Package
         shell: bash
@@ -116,7 +122,8 @@ jobs:
           esac
 
           mkdir "$staging"
-          cp "target/$target/release/$bin" LICENSE-MIT LICENSE-APACHE "$staging/"
+          cp "target/$target/release/$bin" "target/$target/release/bux-shim" \
+             LICENSE-MIT LICENSE-APACHE "$staging/"
           if [ -n "$guest_target" ]; then
             if [ -f "target/$target/release/bux-guest-$guest_target" ]; then
               cp "target/$target/release/bux-guest-$guest_target" "$staging/"

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,20 @@
 # Makefile for Rust project using Cargo
 
-.PHONY: all build check run test bench clippy clippy-fix fmt doc update
+.PHONY: all build check run test bench clippy clippy-fix fmt doc update sign
 
 all: fmt clippy-fix
 
 # Build the project with all features enabled in release mode
 build:
 	cargo build --workspace --release --all-features
+	@$(MAKE) --no-print-directory sign
+
+# macOS: sign bux-shim with the hypervisor entitlement (rebuilds invalidate it); no-op on Linux.
+sign:
+ifeq ($(shell uname -s),Darwin)
+	codesign --entitlements crates/bux-shim/bux-shim.entitlements \
+		-s - --force target/release/bux-shim
+endif
 
 # Check the project for compilation errors without producing binaries
 check:

--- a/crates/bux-shim/bux-shim.entitlements
+++ b/crates/bux-shim/bux-shim.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.hypervisor</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
# Description

macOS requires the `com.apple.security.hypervisor` entitlement to call Hypervisor.framework. `bux-shim` was never signed with it, so `krun_start_enter` returned `-22` (EINVAL) and no VM could be created — surfacing as the misleading `guest agent did not become ready`.

The CI side had nothing to sign either: `cargo build -p bux-cli` does not produce the `bux-shim` binary (`bux` depends on it as a library only), and the release archive never shipped it.

## Changes

- Add `crates/bux-shim/bux-shim.entitlements` declaring `com.apple.security.hypervisor`
- `Makefile`: sign `bux-shim` after `make build` — macOS only, no-op on Linux. Every rebuild invalidates the signature, so this has to be part of the build rather than a manual step.
- `cd.yml`: build `bux-shim`, sign it on macOS, and include it in the release archive

Verified locally: after stripping the signature, `make sign` reapplies it and `codesign -d --entitlements -` reports the entitlement.

The `cd.yml` changes only run on `v*` tags, so they are not exercised by this PR. They can be validated after merge by triggering the CD workflow manually (`workflow_dispatch`) — the `release` job is tag-gated and will be skipped, so nothing gets published.

Note this removes only the *first* blocker on macOS. VM startup still fails further down inside libkrun's virtio-fs setup; that is a separate defect.

Closes #70
