### PR TITLE
fix(jail): grant read on temp dirs in seatbelt profile

### DIFF
--- a/crates/bux-jail/src/seatbelt.rs
+++ b/crates/bux-jail/src/seatbelt.rs
@@ -76,7 +76,8 @@ fn generate_profile(shim: &Path, config_path: &Path, config: &JailConfig) -> Str
     p.push_str("  (literal \"/dev/random\")\n");
     p.push_str(")\n\n");
 
-    p.push_str("(allow file-write*\n");
+    // Allow read+write to temp directories.
+    p.push_str("(allow file-read* file-write*\n");
     p.push_str("  (subpath \"/private/tmp\")\n");
     p.push_str("  (subpath \"/private/var/tmp\")\n");
     p.push_str("  (subpath \"/private/var/folders\")\n");


### PR DESCRIPTION
# Description

The seatbelt profile granted `file-write*` but not `file-read*` on the temp directories, so `bux-shim` could not open anything under them.

libkrun's `krun_set_root_disk_remount` creates a transient root directory under the system temp dir and attaches a virtio-fs device for it. Initialising that device calls `openat()` on the directory; the sandbox denies it with EPERM and libkrun `.unwrap()`s the result, panicking the vcpu thread. The CLI surfaced this as `guest agent did not become ready`.

## Changes

- `crates/bux-jail/src/seatbelt.rs`: grant `file-read*` alongside `file-write*` on the temp subpaths

Verified end-to-end: the virtio-fs panic is gone and startup now proceeds past that device (fs → block → vsock all initialise). It still fails later at virtio-net — a separate gap in the same profile, filed separately.

Closes #72
