### PR TITLE
fix(jail): allow unix socket network ops in seatbelt profile

### DIFF
--- a/crates/bux-jail/src/seatbelt.rs
+++ b/crates/bux-jail/src/seatbelt.rs
@@ -129,6 +129,12 @@ fn generate_profile(shim: &Path, config_path: &Path, config: &JailConfig) -> Str
     p.push_str("  (global-name \"com.apple.system.notification_center\")\n");
     p.push_str(")\n");
 
+    // Allow unix socket communication with gvproxy.
+    p.push_str("(allow network-bind network-outbound\n");
+    p.push_str("  (local unix)\n");
+    p.push_str("  (remote unix)\n");
+    p.push_str(")\n");
+
     p
 }
 


### PR DESCRIPTION
# Description

The seatbelt profile generated by `bux-jail` used `(deny default)` but contained no network rules at all, so every socket operation was denied with `EPERM`. macOS classifies socket operations under `network-*` regardless of address family, so `AF_UNIX` needs a network rule even though it never touches the network.

This blocked `bux-shim` from binding the unix socket it uses to reach `gvproxy`, causing virtio-net activation to fail and libkrun to panic the vcpu thread — surfaced to the user as `guest agent did not become ready`.

## Changes

- Add a scoped `network-bind` / `network-outbound` rule to the generated seatbelt profile, filtered to `(local unix)` / `(remote unix)` so TCP/UDP remains denied while AF_UNIX communication with gvproxy is permitted.

Fixes #75 