### PR TITLE
fix: GitHub CI rustfmt and host e2e smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,3 +11,4 @@ jobs:
     uses: qntx/workflows/.github/workflows/ci-rust.yml@main
     with:
       submodules: true
+      toolchain: "1.97.1"

--- a/.github/workflows/e2e-host.yml
+++ b/.github/workflows/e2e-host.yml
@@ -18,6 +18,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.1
+          components: rustfmt, clippy
+      # Host-only smoke builds bux-cli (links libkrun). Do not install Go here:
+      # FULL=0 does not build bux-shim-bin / libgvproxy.
       # Manual HVF/KVM gate only (CONTRIBUTING.md). Never FULL=1 on GitHub-hosted runners.
       - name: Host-only e2e smoke
         env:

--- a/crates/bux-guest/src/mounts.rs
+++ b/crates/bux-guest/src/mounts.rs
@@ -82,10 +82,10 @@ pub fn mount_essential_tmpfs() {
 
         let _ = fs::create_dir_all(path);
 
-        let Ok(target) = std::ffi::CString::new(m.path) else {
+        let Ok(target) = CString::new(m.path) else {
             continue;
         };
-        let Ok(fstype) = std::ffi::CString::new("tmpfs") else {
+        let Ok(fstype) = CString::new("tmpfs") else {
             continue;
         };
 
@@ -122,6 +122,7 @@ pub fn mount_virtiofs_volumes(volumes: &[GuestVolume]) -> io::Result<()> {
     Ok(())
 }
 
+/// Mount one virtio-fs tag at `vol.guest_path`.
 fn mount_virtiofs_volume(vol: &GuestVolume) -> io::Result<()> {
     vol.validate().map_err(io::Error::other)?;
     fs::create_dir_all(&vol.guest_path).map_err(|e| {
@@ -216,7 +217,7 @@ pub fn freeze_filesystems() -> Vec<PathBuf> {
         if ret == 0 {
             frozen.push(PathBuf::from(mount_point));
         } else {
-            let errno = std::io::Error::last_os_error().raw_os_error().unwrap_or(0);
+            let errno = io::Error::last_os_error().raw_os_error().unwrap_or(0);
             // EBUSY = already frozen → count as success.
             if errno == libc::EBUSY {
                 frozen.push(PathBuf::from(mount_point));

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.97.1"
+components = ["rustfmt", "clippy"]

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -27,25 +27,36 @@ echo "==> BUX_HOME=${BUX_HOME}"
 
 if ! command -v bux >/dev/null 2>&1; then
   echo "building bux-cli..."
-  cargo build -q -p bux-cli -p bux-shim-bin --manifest-path "${ROOT}/Cargo.toml"
+  pkgs=(-p bux-cli)
+  if [[ "${BUX_E2E_FULL:-}" == "1" ]]; then
+    pkgs+=(-p bux-shim-bin)
+  fi
+  cargo build -q "${pkgs[@]}" --manifest-path "${ROOT}/Cargo.toml"
   export PATH="${ROOT}/target/debug:${PATH}"
 fi
 
-# Resolve libkrun / libkrunfw for the CLI (macOS rpath often points at target/debug).
+# libkrun is linked by bux-cli via bux-shim; rpath often points at OUT_DIR.
+krun_name="libkrun.so"
+krun_copies=(libkrun.so libkrunfw.so libkrun.so.1 libkrunfw.so.5)
 if [[ "$(uname -s)" == "Darwin" ]]; then
-  KRUN_LIB="$(find "${ROOT}/target/debug/build" -path '*/out/lib/libkrun.dylib' 2>/dev/null | head -1 || true)"
-  if [[ -n "${KRUN_LIB}" ]]; then
-    KRUN_DIR="$(dirname "${KRUN_LIB}")"
+  krun_name="libkrun.dylib"
+  krun_copies=(libkrun.dylib libkrunfw.dylib libkrun.1.dylib libkrunfw.5.dylib)
+fi
+KRUN_LIB="$(find "${ROOT}/target/debug/build" -path "*/out/lib/${krun_name}" 2>/dev/null | head -1 || true)"
+if [[ -n "${KRUN_LIB}" ]]; then
+  KRUN_DIR="$(dirname "${KRUN_LIB}")"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
     export DYLD_LIBRARY_PATH="${KRUN_DIR}${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-    # Also drop copies next to binary if missing (shim helper does this at runtime).
-    for f in libkrun.dylib libkrunfw.dylib libkrun.1.dylib libkrunfw.5.dylib; do
-      src="${KRUN_DIR}/${f}"
-      dst="${ROOT}/target/debug/${f}"
-      if [[ -f "${src}" && ! -e "${dst}" ]]; then
-        ln -sf "${src}" "${dst}" 2>/dev/null || cp "${src}" "${dst}" 2>/dev/null || true
-      fi
-    done
+  else
+    export LD_LIBRARY_PATH="${KRUN_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   fi
+  for f in "${krun_copies[@]}"; do
+    src="${KRUN_DIR}/${f}"
+    dst="${ROOT}/target/debug/${f}"
+    if [[ -f "${src}" && ! -e "${dst}" ]]; then
+      ln -sf "${src}" "${dst}" 2>/dev/null || cp "${src}" "${dst}" 2>/dev/null || true
+    fi
+  done
 fi
 
 echo "==> system info"


### PR DESCRIPTION
## Summary

#82 landed on main with red CI:

1. **ci / build** — `rust-toolchain.toml` pins `1.97.1` but reusable CI installed rustfmt on `stable` (1.98). `cargo fmt` then used 1.97.1 without rustfmt.
2. **smoke macos** — host-only smoke built `bux-shim-bin` → `bux-gvproxy` → `go` not on the runner.
3. **smoke ubuntu** — `bux` linked libkrun but `LD_LIBRARY_PATH` was never set (only Darwin `DYLD_LIBRARY_PATH`).

Fixes: pass `toolchain: 1.97.1` into the reusable workflow; declare rustfmt/clippy in `rust-toolchain.toml`; FULL=0 builds only `bux-cli`; set `LD_LIBRARY_PATH` on Linux.

## Test plan

- [x] `bash -n scripts/e2e/smoke.sh`
- [ ] GitHub CI + e2e-host green on this PR