### PR TITLE
fix: codesign bux-shim with disable-library-validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,8 @@ not use zig cc. Linux FULL may `cargo build -p bux-guest --target
 $ARCH-unknown-linux-musl` only when `musl-gcc` and that rustc target are already
 present; the ELF must still pass validation (64-bit LE, host guest arch
 x86_64/aarch64, no `PT_INTERP`). Missing or dynamic ELF exits before `bux
-create`.
+create`. FULL needs python3 for the guest ELF validator and Go for
+`bux-shim-bin`; Darwin FULL still needs `BUX_GUEST_PATH`.
 
 Pin `$BUX_E2E_IMAGE` if alpine wget/httpd is missing. There is no in-repo
 custom e2e image.

--- a/crates/bux-shim/bux-shim.entitlements
+++ b/crates/bux-shim/bux-shim.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.hypervisor</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Codesigned Darwin `bux-shim` must load the ad-hoc `libkrun`/`libkrunfw` dylibs FULL already stages next to the binary (`@rpath` = `@executable_path`). The dylibs are ad-hoc-signed under a different CS identifier; without `com.apple.security.cs.disable-library-validation` the first FULL run can fail as a dyld red herring.

- `crates/bux-shim/bux-shim.entitlements`: keep `com.apple.security.hypervisor`; add `com.apple.security.cs.disable-library-validation`. No `allow-jit`. No `-o runtime`.
- Same plist is already passed by `scripts/e2e/smoke.sh`, `cd.yml`, and `Makefile` (`codesign -s - --force`). Those call sites are unchanged.
- `CONTRIBUTING.md`: one sentence — FULL needs python3 (guest ELF validator) and Go (`bux-shim-bin`); Darwin FULL still needs `BUX_GUEST_PATH`.

No invented `BUX_E2E_FULL` gate record. D4 stays Open. Host CI does not codesign.

## Verification

- `plutil -lint` OK; two keys present; `allow-jit` absent
- Diff is two files only (`entitlements` + CONTRIBUTING)
- Seatbelt / smoke codesign flags / workflows untouched
- Prior execute-plan review: 0 issues

## Audit

Landing audit vs `origin/main` (`1623aea`): no correctness bugs. Comment duplication of Darwin `BUX_GUEST_PATH` in CONTRIBUTING is a nit, not a merge blocker.