### PR TITLE
fix: stage libkrun next to bux and bux-shim (CD + profile dir, fail-closed)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -122,11 +122,11 @@ jobs:
           esac
 
           mkdir "$staging"
-          cp "target/$target/release/$bin" "target/$target/release/bux-shim" \
-             LICENSE-MIT LICENSE-APACHE "$staging/"
+          rel="target/$target/release"
+          cp "$rel/$bin" "$rel/bux-shim" LICENSE-MIT LICENSE-APACHE "$staging/"
           guest_src=""
-          if [ -f "target/$target/release/bux-guest-$guest_target" ]; then
-            guest_src="target/$target/release/bux-guest-$guest_target"
+          if [ -f "$rel/bux-guest-$guest_target" ]; then
+            guest_src="$rel/bux-guest-$guest_target"
           elif [ -f ".guest/bux-guest-$guest_target" ]; then
             guest_src=".guest/bux-guest-$guest_target"
           else
@@ -135,17 +135,6 @@ jobs:
           fi
           cp "$guest_src" "$staging/"
 
-          krun_src=""
-          for d in target/"$target"/release/build/bux-krun-*/out/lib; do
-            if [ -f "$d/libkrun.dylib" ] || [ -f "$d/libkrun.so" ]; then
-              krun_src="$d"
-              break
-            fi
-          done
-          if [ -z "$krun_src" ]; then
-            echo "missing libkrun in bux-krun out/lib"
-            exit 1
-          fi
           if [[ "$target" == *apple-darwin* ]]; then
             krun_files="libkrun.dylib libkrunfw.dylib libkrun.1.dylib libkrunfw.5.dylib"
             krun_required="libkrun.dylib"
@@ -154,11 +143,11 @@ jobs:
             krun_required="libkrun.so"
           fi
           for f in $krun_files; do
-            if [ ! -e "$krun_src/$f" ]; then
-              echo "missing $f in $krun_src"
+            if [ ! -e "$rel/$f" ]; then
+              echo "missing $f next to binaries"
               exit 1
             fi
-            cp -a "$krun_src/$f" "$staging/"
+            cp -a "$rel/$f" "$staging/"
           done
           if [ ! -e "$staging/$krun_required" ]; then
             echo "missing $krun_required next to binaries"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -135,6 +135,36 @@ jobs:
           fi
           cp "$guest_src" "$staging/"
 
+          krun_src=""
+          for d in target/"$target"/release/build/bux-krun-*/out/lib; do
+            if [ -f "$d/libkrun.dylib" ] || [ -f "$d/libkrun.so" ]; then
+              krun_src="$d"
+              break
+            fi
+          done
+          if [ -z "$krun_src" ]; then
+            echo "missing libkrun in bux-krun out/lib"
+            exit 1
+          fi
+          if [[ "$target" == *apple-darwin* ]]; then
+            krun_files="libkrun.dylib libkrunfw.dylib libkrun.1.dylib libkrunfw.5.dylib"
+            krun_required="libkrun.dylib"
+          else
+            krun_files="libkrun.so libkrunfw.so libkrun.so.1 libkrunfw.so.5"
+            krun_required="libkrun.so"
+          fi
+          for f in $krun_files; do
+            if [ ! -e "$krun_src/$f" ]; then
+              echo "missing $f in $krun_src"
+              exit 1
+            fi
+            cp -a "$krun_src/$f" "$staging/"
+          done
+          if [ ! -e "$staging/$krun_required" ]; then
+            echo "missing $krun_required next to binaries"
+            exit 1
+          fi
+
           tar czf "$staging.tar.gz" -C "$staging" .
 
           # SHA-256 checksum

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,11 +20,32 @@ Requires a working C toolchain for libkrun / e2fs / qcow2 native deps, and Go fo
 | `BUX_GUEST_DIR` | Build-time directory of a prebuilt Linux guest ELF (`bux-cli` stages a sibling copy) |
 | `PATH` | Locates `bux-shim`, `bwrap` (Linux), `sandbox-exec` (macOS), `go` |
 
-Release packaging ships `bux-guest-*` next to the CLI. Runtime resolution
-(`ManagedGuestBinary::resolve`) is: `BUX_GUEST_PATH`, then a sibling of the
-running executable (`bux-guest-<triple>`, `bux-guest-linux`, `bux-guest`),
-then `$PATH`. There is no download protocol and the ELF is not vendored into
-the crate.
+Release packaging ships `bux`, `bux-shim`, `bux-guest-*`, and
+`libkrun*`/`libkrunfw*` (including soname aliases) in the same directory.
+Binaries locate the dylibs via `@executable_path` (Darwin) or `$ORIGIN`
+(Linux). `cargo build` stages those dylibs into the cargo profile directory
+next to `bux` / `bux-shim`.
+
+Runtime guest resolution (`ManagedGuestBinary::resolve`) is: `BUX_GUEST_PATH`,
+then a sibling of the running executable (`bux-guest-<triple>`,
+`bux-guest-linux`, `bux-guest`), then `$PATH`. There is no download protocol
+and the ELF is not vendored into the crate.
+
+Tarball layout (Darwin; Linux uses `libkrun.so` / `libkrun.so.1` and
+`libkrunfw.so` / `libkrunfw.so.5`):
+
+```
+bux-<ver>-aarch64-apple-darwin/
+  bux
+  bux-shim
+  bux-guest-aarch64-unknown-linux-musl
+  libkrun.dylib
+  libkrun.1.dylib
+  libkrunfw.dylib
+  libkrunfw.5.dylib
+  LICENSE-MIT
+  LICENSE-APACHE
+```
 
 Inspect the live host with:
 

--- a/crates/bux-cli/build.rs
+++ b/crates/bux-cli/build.rs
@@ -10,9 +10,6 @@ use std::path::{Path, PathBuf};
 
 fn main() {
     println!("cargo:rerun-if-env-changed=BUX_GUEST_DIR");
-    if let Ok(lib_dir) = env::var("DEP_KRUN_LIB_DIR") {
-        println!("cargo:rustc-link-arg=-Wl,-rpath,{lib_dir}");
-    }
     stage_guest_binary();
 }
 

--- a/crates/bux-krun/build.rs
+++ b/crates/bux-krun/build.rs
@@ -187,12 +187,16 @@ fn profile_bin_dir(out_dir: &Path, profile: &str) -> PathBuf {
         )
 }
 
-fn copy_over(src: &Path, dest: &Path) {
-    if dest.symlink_metadata().is_ok() {
-        fs::remove_file(dest).unwrap_or_else(|e| {
-            panic!("bux-krun: failed to replace {}: {e}", dest.display());
+fn remove_existing(path: &Path) {
+    if path.symlink_metadata().is_ok() {
+        fs::remove_file(path).unwrap_or_else(|e| {
+            panic!("bux-krun: failed to replace {}: {e}", path.display());
         });
     }
+}
+
+fn copy_over(src: &Path, dest: &Path) {
+    remove_existing(dest);
     fs::copy(src, dest).unwrap_or_else(|e| {
         panic!(
             "bux-krun: failed to copy {} -> {}: {e}",
@@ -224,6 +228,9 @@ fn stage_libraries_beside_binaries(lib_dir: &Path, target: &str, out_dir: &Path)
         copy_over(&src, &dest.join(unversioned));
     }
 
+    for (_, alias) in &aliases {
+        remove_existing(&dest.join(alias));
+    }
     create_versioned_symlinks(&dest, target);
 
     let required = lib_filename(target);

--- a/crates/bux-krun/build.rs
+++ b/crates/bux-krun/build.rs
@@ -72,6 +72,7 @@ fn main() {
     }
 
     let lib_dir = obtain_libraries(&target, &out_dir);
+    stage_libraries_beside_binaries(&lib_dir, &target, &out_dir);
     println!("cargo:rustc-link-search=native={}", lib_dir.display());
     println!("cargo:rustc-link-lib=dylib=krun");
     println!("cargo:LIB_DIR={}", lib_dir.display());
@@ -170,6 +171,76 @@ fn lib_filename(target: &str) -> &'static str {
     }
 }
 
+/// `OUT_DIR` ancestor named `$PROFILE` is the cargo bin dir (native or `--target`).
+fn profile_bin_dir(out_dir: &Path, profile: &str) -> PathBuf {
+    out_dir
+        .ancestors()
+        .find(|path| path.file_name().is_some_and(|name| name == profile))
+        .map_or_else(
+            || {
+                panic!(
+                    "bux-krun: cannot resolve profile bin dir from OUT_DIR={} PROFILE={profile}",
+                    out_dir.display()
+                )
+            },
+            Path::to_path_buf,
+        )
+}
+
+fn copy_over(src: &Path, dest: &Path) {
+    if dest.symlink_metadata().is_ok() {
+        fs::remove_file(dest).unwrap_or_else(|e| {
+            panic!("bux-krun: failed to replace {}: {e}", dest.display());
+        });
+    }
+    fs::copy(src, dest).unwrap_or_else(|e| {
+        panic!(
+            "bux-krun: failed to copy {} -> {}: {e}",
+            src.display(),
+            dest.display()
+        );
+    });
+}
+
+/// Rpath is `@executable_path` / `$ORIGIN`; binaries load these siblings.
+fn stage_libraries_beside_binaries(lib_dir: &Path, target: &str, out_dir: &Path) {
+    let profile = env::var("PROFILE").expect("PROFILE not set");
+    let dest = profile_bin_dir(out_dir, &profile);
+    fs::create_dir_all(&dest).unwrap_or_else(|e| {
+        panic!(
+            "bux-krun: failed to create profile dir {}: {e}",
+            dest.display()
+        )
+    });
+
+    let aliases = soname_aliases(target);
+    for (unversioned, _) in &aliases {
+        let src = lib_dir.join(unversioned);
+        assert!(
+            src.exists(),
+            "bux-krun: {unversioned} not found in {}",
+            lib_dir.display()
+        );
+        copy_over(&src, &dest.join(unversioned));
+    }
+
+    create_versioned_symlinks(&dest, target);
+
+    let required = lib_filename(target);
+    assert!(
+        dest.join(required).exists(),
+        "bux-krun: {required} missing next to binaries at {}",
+        dest.display()
+    );
+    for (_, alias) in &aliases {
+        assert!(
+            dest.join(alias).exists(),
+            "bux-krun: {alias} missing next to binaries at {}",
+            dest.display()
+        );
+    }
+}
+
 fn download_libs(version: &str, target: &str, dest: &Path) {
     let url = format!(
         "https://github.com/{GITHUB_REPO}/releases/download/krun-v{version}/bux-deps-{target}.tar.gz"
@@ -200,14 +271,10 @@ fn major_version(version: &str) -> &str {
     version.split('.').next().expect("empty version string")
 }
 
-/// Create versioned symlinks (e.g. `libkrunfw.so.5 -> libkrunfw.so`) so that
-/// `dlopen("libkrunfw.so.5")` succeeds at runtime.
-fn create_versioned_symlinks(dir: &Path, target: &str) {
-    // Derive major version from pinned version strings for soname symlinks.
+fn soname_aliases(target: &str) -> [(&'static str, String); 2] {
     let krun_major = major_version(LIBKRUN_VERSION);
     let krunfw_major = major_version(LIBKRUNFW_VERSION);
-
-    let pairs = if target.contains("apple") {
+    if target.contains("apple") {
         [
             ("libkrun.dylib", format!("libkrun.{krun_major}.dylib")),
             ("libkrunfw.dylib", format!("libkrunfw.{krunfw_major}.dylib")),
@@ -217,9 +284,13 @@ fn create_versioned_symlinks(dir: &Path, target: &str) {
             ("libkrun.so", format!("libkrun.so.{krun_major}")),
             ("libkrunfw.so", format!("libkrunfw.so.{krunfw_major}")),
         ]
-    };
+    }
+}
 
-    for (src, link) in &pairs {
+/// Create versioned symlinks (e.g. `libkrunfw.so.5 -> libkrunfw.so`) so that
+/// `dlopen("libkrunfw.so.5")` succeeds at runtime.
+fn create_versioned_symlinks(dir: &Path, target: &str) {
+    for (src, link) in &soname_aliases(target) {
         let src_path = dir.join(src);
         let link_path = dir.join(link);
         if !src_path.exists() || link_path.exists() {

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -155,30 +155,6 @@ elif ! command -v bux >/dev/null 2>&1; then
   export PATH="${ROOT}/target/debug:${PATH}"
 fi
 
-# libkrun is linked by bux-cli via bux-shim; rpath often points at OUT_DIR.
-krun_name="libkrun.so"
-krun_copies=(libkrun.so libkrunfw.so libkrun.so.1 libkrunfw.so.5)
-if [[ "$(uname -s)" == "Darwin" ]]; then
-  krun_name="libkrun.dylib"
-  krun_copies=(libkrun.dylib libkrunfw.dylib libkrun.1.dylib libkrunfw.5.dylib)
-fi
-KRUN_LIB="$(find "${ROOT}/target/debug/build" -path "*/out/lib/${krun_name}" 2>/dev/null | head -1 || true)"
-if [[ -n "${KRUN_LIB}" ]]; then
-  KRUN_DIR="$(dirname "${KRUN_LIB}")"
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    export DYLD_LIBRARY_PATH="${KRUN_DIR}${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
-  else
-    export LD_LIBRARY_PATH="${KRUN_DIR}${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-  fi
-  for f in "${krun_copies[@]}"; do
-    src="${KRUN_DIR}/${f}"
-    dst="${ROOT}/target/debug/${f}"
-    if [[ -f "${src}" && ! -e "${dst}" ]]; then
-      ln -sf "${src}" "${dst}" 2>/dev/null || cp "${src}" "${dst}" 2>/dev/null || true
-    fi
-  done
-fi
-
 echo "==> system info"
 bux system info
 info_json="$(bux system info --format json)"


### PR DESCRIPTION
## Summary

Rpath is already `@executable_path` / `$ORIGIN` (`.cargo/config.toml`). Release tarballs and a clean `target/debug` could not load libkrun because native libs were not next to the binaries. This PR copies `libkrun*`/`libkrunfw*` (plus soname aliases) beside `bux` and `bux-shim`, fail-closed.

- `crates/bux-krun/build.rs`: after `obtain_libraries`, copy unversioned libs into the cargo profile bin dir (`target/{debug,release}` or `target/${TARGET}/{debug,release}`). Replace leftover aliases then write sibling-relative symlinks. Panic if missing.
- `crates/bux-cli/build.rs`: delete dead `DEP_KRUN_LIB_DIR` rpath `link-arg`. Guest staging kept.
- `.github/workflows/cd.yml`: copy the four names from `target/$target/release/` (the directory this build staged), not a `bux-krun-*/out/lib` glob. `exit 1` if missing. No `RUSTFLAGS`. Darwin codesign unchanged.
- `scripts/e2e/smoke.sh`: remove `DYLD_LIBRARY_PATH` / `LD_LIBRARY_PATH` / `find OUT_DIR` after staging exists.
- `CONTRIBUTING.md`: tarball layout. No FULL record. No production-ready claim.

No `bux-shim-bin` `build.rs`. No second rpath. No invented `BUX_E2E_FULL` gate record.

## Verification

- `cargo build -p bux-cli` → `target/debug/libkrun.dylib` + aliases
- `otool -L` `@rpath/libkrun.dylib`; `LC_RPATH` `@executable_path`
- `cargo clippy -p bux-krun -p bux-cli --all-targets -- -D warnings`
- `BUX_E2E_FULL=0 ./scripts/e2e/smoke.sh` → `OK (host-only smoke)` without DYLD
- Review: 1 bug (CD glob vs this compile's profile dir) + 1 suggestion (replace leftover aliases) — both fixed; 0 open