### PR TITLE
Schema v5: drop vms.health and HealthState

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ bux system info --format json
 - Engine boundary: product `VmConfig` → `ShimConfig` → `bux-shim` → libkrun.
 - Managed network: gvproxy virtio-net in the `bux-shim` process (`bux-shim-bin`); no TSI `set_port_map`.
 - Guest agent: postcard protocol v9; Phase A process identity only.
-- Schema: SQLite `user_version` 4 — **no migrations**; wipe `BUX_HOME` on mismatch.
+- Schema: SQLite `user_version` 5 — **no migrations**; wipe `BUX_HOME` on mismatch.
 
 Current architecture: `docs/bux-redesign.md`.
 

--- a/crates/bux/src/state/db.rs
+++ b/crates/bux/src/state/db.rs
@@ -143,7 +143,7 @@ impl StateDb {
     /// Panics if the mutex is poisoned, which indicates a prior panic
     /// during a database operation — an unrecoverable state.
     #[allow(clippy::expect_used, reason = "poisoned mutex is unrecoverable")]
-    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
+    fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn.lock().expect("StateDb mutex poisoned")
     }
 
@@ -696,4 +696,39 @@ fn system_time_to_f64(t: SystemTime) -> f64 {
 /// Converts seconds since UNIX epoch (`f64`) back to a [`SystemTime`].
 fn f64_to_system_time(secs: f64) -> SystemTime {
     UNIX_EPOCH + Duration::from_secs_f64(secs)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    reason = "test assertions use unwrap for clarity"
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn product_schema_version() {
+        let db = StateDb::open(":memory:").expect("open in-memory db");
+        assert_eq!(PRODUCT_SCHEMA_VERSION, 5);
+
+        let mut names = Vec::new();
+        {
+            let conn = db.lock();
+            let version: u32 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(version, 5);
+
+            let mut stmt = conn.prepare("PRAGMA table_info(vms)").unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                names.push(row.get::<_, String>(1).unwrap());
+            }
+        }
+        assert!(
+            !names.iter().any(|n| n == "health"),
+            "vms must not have a health column, got {names:?}"
+        );
+    }
 }

--- a/crates/bux/src/state/db.rs
+++ b/crates/bux/src/state/db.rs
@@ -708,6 +708,10 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "MutexGuard must outlive rusqlite Statement"
+    )]
     fn product_schema_version() {
         let db = StateDb::open(":memory:").expect("open in-memory db");
         assert_eq!(PRODUCT_SCHEMA_VERSION, 5);

--- a/crates/bux/src/state/db.rs
+++ b/crates/bux/src/state/db.rs
@@ -8,7 +8,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use rusqlite::{Connection, OptionalExtension, params};
 
-use super::{HealthState, Status, VmState};
+use super::{Status, VmState};
 use crate::error::{Error, Result};
 
 /// Product state-schema version (PRAGMA `user_version`).
@@ -16,8 +16,8 @@ use crate::error::{Error, Result};
 /// Bump only on incompatible schema changes. There is **no** migration
 /// path — callers must wipe the data directory.
 ///
-/// v4: persist `NetworkSpec` in VM config JSON (replaces `network_enabled`).
-pub(crate) const PRODUCT_SCHEMA_VERSION: u32 = 4;
+/// v5: drop `vms.health`.
+pub(crate) const PRODUCT_SCHEMA_VERSION: u32 = 5;
 
 /// DDL for a fresh product database.
 const PRODUCT_SCHEMA_SQL: &str = "
@@ -28,7 +28,6 @@ CREATE TABLE vms (
     image       TEXT,
     socket      TEXT NOT NULL,
     status      TEXT NOT NULL DEFAULT 'running',
-    health      TEXT NOT NULL DEFAULT 'unknown',
     config      TEXT NOT NULL,
     created_at  REAL NOT NULL,
     updated_at  REAL
@@ -144,7 +143,7 @@ impl StateDb {
     /// Panics if the mutex is poisoned, which indicates a prior panic
     /// during a database operation — an unrecoverable state.
     #[allow(clippy::expect_used, reason = "poisoned mutex is unrecoverable")]
-    fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
+    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, Connection> {
         self.conn.lock().expect("StateDb mutex poisoned")
     }
 
@@ -304,19 +303,6 @@ impl StateDb {
     pub(crate) fn delete(&self, id: &str) -> Result<()> {
         self.lock()
             .execute("DELETE FROM vms WHERE id = ?1", params![id])?;
-        Ok(())
-    }
-
-    /// Updates the health state of a VM.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the database update fails.
-    pub(crate) fn update_health(&self, id: &str, health: HealthState) -> Result<()> {
-        self.lock().execute(
-            "UPDATE vms SET health = ?1 WHERE id = ?2",
-            params![health_str(health), id],
-        )?;
         Ok(())
     }
 
@@ -676,15 +662,6 @@ fn row_to_base_disk(row: &rusqlite::Row<'_>) -> rusqlite::Result<BaseDiskRow> {
         ref_count: row.get(3)?,
         created_at: f64_to_system_time(row.get(4)?),
     })
-}
-
-/// Converts a [`HealthState`] to its database string representation.
-const fn health_str(h: HealthState) -> &'static str {
-    match h {
-        HealthState::Unknown => "unknown",
-        HealthState::Healthy => "healthy",
-        HealthState::Unhealthy => "unhealthy",
-    }
 }
 
 /// Converts a [`Status`] to its database string representation.

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -93,18 +93,6 @@ impl Status {
     }
 }
 
-/// VM health state, tracked independently of lifecycle [`Status`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub(crate) enum HealthState {
-    /// Health has not been checked yet.
-    Unknown,
-    /// Guest agent responded successfully.
-    Healthy,
-    /// Guest agent failed to respond within the configured threshold.
-    Unhealthy,
-}
-
 /// A virtio-fs shared directory.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -594,20 +582,29 @@ mod tests {
     }
 
     #[test]
-    fn health_update() {
-        let db = open_test_db();
-        db.insert(&test_vm("vm1", None)).unwrap();
-
-        db.update_health("vm1", HealthState::Healthy).unwrap();
-        let vms = db.list().unwrap();
-        assert_eq!(vms.len(), 1);
-    }
-
-    #[test]
     fn product_schema_version() {
         let db = open_test_db();
-        // Fresh in-memory DB uses product schema.
-        assert_eq!(db::PRODUCT_SCHEMA_VERSION, 4);
+        assert_eq!(db::PRODUCT_SCHEMA_VERSION, 5);
+
+        let mut names = Vec::new();
+        {
+            let conn = db.lock();
+            let version: u32 = conn
+                .query_row("PRAGMA user_version", [], |r| r.get(0))
+                .unwrap();
+            assert_eq!(version, 5);
+
+            let mut stmt = conn.prepare("PRAGMA table_info(vms)").unwrap();
+            let mut rows = stmt.query([]).unwrap();
+            while let Some(row) = rows.next().unwrap() {
+                names.push(row.get::<_, String>(1).unwrap());
+            }
+        }
+        assert!(
+            !names.iter().any(|n| n == "health"),
+            "vms must not have a health column, got {names:?}"
+        );
+
         db.insert(&test_vm("vm1", None)).unwrap();
         assert_eq!(db.list().unwrap().len(), 1);
     }

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -580,32 +580,4 @@ mod tests {
         db.delete_base_disk("bd1").unwrap();
         assert!(db.get_base_disk_by_digest("sha256:abc").unwrap().is_none());
     }
-
-    #[test]
-    fn product_schema_version() {
-        let db = open_test_db();
-        assert_eq!(db::PRODUCT_SCHEMA_VERSION, 5);
-
-        let mut names = Vec::new();
-        {
-            let conn = db.lock();
-            let version: u32 = conn
-                .query_row("PRAGMA user_version", [], |r| r.get(0))
-                .unwrap();
-            assert_eq!(version, 5);
-
-            let mut stmt = conn.prepare("PRAGMA table_info(vms)").unwrap();
-            let mut rows = stmt.query([]).unwrap();
-            while let Some(row) = rows.next().unwrap() {
-                names.push(row.get::<_, String>(1).unwrap());
-            }
-        }
-        assert!(
-            !names.iter().any(|n| n == "health"),
-            "vms must not have a health column, got {names:?}"
-        );
-
-        db.insert(&test_vm("vm1", None)).unwrap();
-        assert_eq!(db.list().unwrap().len(), 1);
-    }
 }

--- a/docs/bux-redesign.md
+++ b/docs/bux-redesign.md
@@ -15,7 +15,7 @@ Spine:
 3. Jail (`bux-jail`) spawns `bux-shim`; shim applies `ShimConfig` and `krun_start_enter`.
 4. Guest agent is PID 1 (Phase A). Workload is `exec`.
 5. Host `Client` uses postcard protocol v9 (one Unix-socket connection per op).
-6. SQLite `user_version` 4; mismatch refuses to open (wipe `data_dir`).
+6. SQLite `user_version` 5; mismatch refuses to open (wipe `data_dir`).
 
 ## Known defects
 


### PR DESCRIPTION
Bump `PRODUCT_SCHEMA_VERSION` to 5. Remove unused `vms.health` and `HealthState`. Wipe-on-mismatch only. Keep live `HealthStatus` / `Vm::health`.

After merge, `user_version=4` databases will not open. Delete `$BUX_HOME` or `bux system reset`.

Stack: 6397f23c PR 2/5.