### PR TITLE
Delete public pause/resume and dead Status variants

### DIFF
--- a/crates/bux-cli/src/vm.rs
+++ b/crates/bux-cli/src/vm.rs
@@ -240,12 +240,7 @@ pub fn ps(args: &PsArgs) -> Result<()> {
         vms
     } else {
         vms.into_iter()
-            .filter(|v| {
-                matches!(
-                    v.status,
-                    bux::Status::Running | bux::Status::Creating | bux::Status::Paused
-                )
-            })
+            .filter(|v| v.status == bux::Status::Running)
             .collect()
     };
 
@@ -255,9 +250,8 @@ pub fn ps(args: &PsArgs) -> Result<()> {
         filtered.retain(|vm| match key {
             "status" => {
                 let s = match vm.status {
-                    bux::Status::Creating => "creating",
                     bux::Status::Running => "running",
-                    bux::Status::Paused => "paused",
+                    bux::Status::Stopping => "stopping",
                     bux::Status::Stopped => "stopped",
                     _ => "unknown",
                 };
@@ -294,9 +288,8 @@ pub fn ps(args: &PsArgs) -> Result<()> {
         let name = vm.name.as_deref().unwrap_or("-");
         let image = vm.image.as_deref().unwrap_or("-");
         let status = match vm.status {
-            bux::Status::Creating => "creating",
             bux::Status::Running => "running",
-            bux::Status::Paused => "paused",
+            bux::Status::Stopping => "stopping",
             bux::Status::Stopped => "stopped",
             _ => "unknown",
         };

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -600,44 +600,6 @@ impl Vm {
         is_pid_alive(self.state.pid)
     }
 
-    /// Pauses the VM by quiescing its filesystems and sending `SIGSTOP`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the VM cannot be paused or the signal fails.
-    pub async fn pause(&mut self) -> Result<()> {
-        if !self.state.status.can_pause() {
-            return Err(crate::Error::InvalidState(format!(
-                "VM {} cannot be paused (status: {:?})",
-                self.state.id, self.state.status
-            )));
-        }
-        drop(self.client.quiesce().await);
-        signal::kill(Pid::from_raw(self.state.pid), Signal::SIGSTOP)?;
-        self.state.status = Status::Paused;
-        self.db.update_status(&self.state.id, Status::Paused)?;
-        Ok(())
-    }
-
-    /// Resumes a paused VM by sending `SIGCONT` and thawing its filesystems.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the VM cannot be resumed or the signal fails.
-    pub async fn resume(&mut self) -> Result<()> {
-        if !self.state.status.can_resume() {
-            return Err(crate::Error::InvalidState(format!(
-                "VM {} cannot be resumed (status: {:?})",
-                self.state.id, self.state.status
-            )));
-        }
-        signal::kill(Pid::from_raw(self.state.pid), Signal::SIGCONT)?;
-        drop(self.client.thaw().await);
-        self.state.status = Status::Running;
-        self.db.update_status(&self.state.id, Status::Running)?;
-        Ok(())
-    }
-
     /// Sends a POSIX signal to the VM process.
     ///
     /// # Errors

--- a/crates/bux/src/state/db.rs
+++ b/crates/bux/src/state/db.rs
@@ -667,9 +667,7 @@ fn row_to_base_disk(row: &rusqlite::Row<'_>) -> rusqlite::Result<BaseDiskRow> {
 /// Converts a [`Status`] to its database string representation.
 const fn status_str(s: Status) -> &'static str {
     match s {
-        Status::Creating => "creating",
         Status::Running => "running",
-        Status::Paused => "paused",
         Status::Stopping => "stopping",
         Status::Stopped => "stopped",
     }
@@ -678,9 +676,7 @@ const fn status_str(s: Status) -> &'static str {
 /// Parses a database string into a [`Status`].
 fn parse_status(s: &str) -> Status {
     match s {
-        "creating" => Status::Creating,
         "running" => Status::Running,
-        "paused" => Status::Paused,
         "stopping" => Status::Stopping,
         _ => Status::Stopped,
     }

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -10,23 +10,15 @@ use crate::disk::DiskFormat;
 /// VM lifecycle status.
 ///
 /// ```text
-/// Creating ──► Running ──► Stopping ──► Stopped
-///                │  ▲                      ▲
-///                ▼  │                      │
-///              Paused ────────────────────►┘
+/// Stopped ──► Running ──► Stopping ──► Stopped
+///                │                        ▲
+///                └────────────────────────┘
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Status {
-    /// VM is being prepared (disk creation, etc.).
-    Creating,
     /// VM process is running.
     Running,
-    /// VM is frozen via SIGSTOP (vCPUs and virtio backends paused).
-    ///
-    /// Filesystem may also be quiesced (FIFREEZE) for point-in-time consistency.
-    /// Resume with [`Vm::resume()`](crate::runtime::Vm::resume).
-    Paused,
     /// A graceful shutdown has been requested; waiting for the process to exit.
     Stopping,
     /// VM has been stopped or exited.
@@ -37,7 +29,7 @@ impl Status {
     /// Returns `true` if the VM process may still be alive.
     #[must_use]
     pub const fn is_active(self) -> bool {
-        matches!(self, Self::Running | Self::Paused | Self::Stopping)
+        matches!(self, Self::Running | Self::Stopping)
     }
 
     /// Returns `true` if `exec()` can be called.
@@ -49,19 +41,7 @@ impl Status {
     /// Returns `true` if `stop()` can be called.
     #[must_use]
     pub const fn can_stop(self) -> bool {
-        matches!(self, Self::Running | Self::Paused)
-    }
-
-    /// Returns `true` if `pause()` can be called.
-    #[must_use]
-    pub const fn can_pause(self) -> bool {
         matches!(self, Self::Running)
-    }
-
-    /// Returns `true` if `resume()` can be called.
-    #[must_use]
-    pub const fn can_resume(self) -> bool {
-        matches!(self, Self::Paused)
     }
 
     /// Returns `true` if `remove()` can be called.
@@ -73,22 +53,17 @@ impl Status {
     /// Returns `true` if transitioning from `self` to `target` is valid.
     ///
     /// ```text
-    /// Creating ──► Running ──► Stopping ──► Stopped
-    ///                │  ▲                      ▲
-    ///                ▼  │                      │
-    ///              Paused ────────────────────►┘
+    /// Stopped ──► Running ──► Stopping ──► Stopped
+    ///                │                        ▲
+    ///                └────────────────────────┘
     /// ```
     #[must_use]
     pub const fn can_transition_to(self, target: Self) -> bool {
         matches!(
             (self, target),
-            (Self::Creating | Self::Paused | Self::Stopped, Self::Running)
-                | (
-                    Self::Creating | Self::Running | Self::Paused | Self::Stopping,
-                    Self::Stopped
-                )
-                | (Self::Running, Self::Paused | Self::Stopping)
-                | (Self::Paused, Self::Stopping)
+            (Self::Stopped, Self::Running)
+                | (Self::Running | Self::Stopping, Self::Stopped)
+                | (Self::Running, Self::Stopping)
         )
     }
 }
@@ -514,17 +489,22 @@ mod tests {
 
     #[test]
     fn status_transitions() {
-        assert!(Status::Creating.can_transition_to(Status::Running));
-        assert!(Status::Running.can_transition_to(Status::Paused));
-        assert!(Status::Running.can_transition_to(Status::Stopping));
-        assert!(Status::Paused.can_transition_to(Status::Running));
-        assert!(Status::Stopping.can_transition_to(Status::Stopped));
         assert!(Status::Stopped.can_transition_to(Status::Running));
+        assert!(Status::Running.can_transition_to(Status::Stopping));
+        assert!(Status::Running.can_transition_to(Status::Stopped));
+        assert!(Status::Stopping.can_transition_to(Status::Stopped));
 
-        // Invalid transitions.
-        assert!(!Status::Stopped.can_transition_to(Status::Paused));
-        assert!(!Status::Creating.can_transition_to(Status::Paused));
-        assert!(!Status::Running.can_transition_to(Status::Creating));
+        assert!(!Status::Stopped.can_transition_to(Status::Stopping));
+        assert!(!Status::Stopping.can_transition_to(Status::Running));
+        assert!(!Status::Stopping.can_transition_to(Status::Stopping));
+
+        assert!(Status::Running.can_stop());
+        assert!(!Status::Stopping.can_stop());
+        assert!(!Status::Stopped.can_stop());
+
+        assert!(Status::Running.is_active());
+        assert!(Status::Stopping.is_active());
+        assert!(!Status::Stopped.is_active());
     }
 
     #[test]


### PR DESCRIPTION
Remove `Vm::pause`/`resume` and `Status::{Paused,Creating}`. Status is `Running | Stopping | Stopped`. CLI `ps` prints `stopping`. Snapshot quiesce/thaw unchanged.

Stack: 6397f23c PR 3/5.