### PR TITLE
RuntimeOptions for shim/guest paths and registry auth

### DIFF
--- a/crates/bux-oci/src/config.rs
+++ b/crates/bux-oci/src/config.rs
@@ -1,8 +1,41 @@
 //! Configuration and result types for OCI image operations.
 
+use std::fmt;
 use std::path::PathBuf;
 
-use oci_client::secrets::RegistryAuth;
+/// Registry credentials for image pull.
+#[derive(Clone, Default)]
+pub enum RegistryAuth {
+    /// No credentials (public registries).
+    #[default]
+    Anonymous,
+    /// HTTP Basic authentication.
+    Basic {
+        /// Registry username.
+        username: String,
+        /// Registry password.
+        password: String,
+    },
+    /// Bearer token authentication.
+    Bearer {
+        /// Registry bearer token.
+        token: String,
+    },
+}
+
+impl fmt::Debug for RegistryAuth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Anonymous => f.write_str("Anonymous"),
+            Self::Basic { username, .. } => f
+                .debug_struct("Basic")
+                .field("username", username)
+                .field("password", &"***")
+                .finish(),
+            Self::Bearer { .. } => f.debug_struct("Bearer").field("token", &"***").finish(),
+        }
+    }
+}
 
 /// Configuration for initializing [`crate::Oci`].
 #[non_exhaustive]
@@ -78,4 +111,46 @@ pub struct PullResult {
     pub rootfs: PathBuf,
     /// Image configuration (Cmd, Env, `WorkingDir`, etc.).
     pub config: Option<ImageConfig>,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::RegistryAuth;
+
+    #[test]
+    fn debug_redacts_basic_password_and_bearer_token() {
+        assert_eq!(format!("{:?}", RegistryAuth::Anonymous), "Anonymous");
+
+        let basic = RegistryAuth::Basic {
+            username: "alice".into(),
+            password: "s3cret".into(),
+        };
+        let basic_dbg = format!("{basic:?}");
+        assert!(
+            basic_dbg.contains("alice"),
+            "username must remain visible: {basic_dbg}"
+        );
+        assert!(
+            basic_dbg.contains("***"),
+            "password must be redacted: {basic_dbg}"
+        );
+        assert!(
+            !basic_dbg.contains("s3cret"),
+            "password must not leak: {basic_dbg}"
+        );
+
+        let bearer = RegistryAuth::Bearer {
+            token: "tokensecret".into(),
+        };
+        let bearer_dbg = format!("{bearer:?}");
+        assert!(
+            bearer_dbg.contains("***"),
+            "token must be redacted: {bearer_dbg}"
+        );
+        assert!(
+            !bearer_dbg.contains("tokensecret"),
+            "token must not leak: {bearer_dbg}"
+        );
+    }
 }

--- a/crates/bux-oci/src/lib.rs
+++ b/crates/bux-oci/src/lib.rs
@@ -28,9 +28,9 @@ use std::path::{Path, PathBuf};
 
 use oci_client::Reference;
 use oci_client::client::ClientConfig;
-use oci_client::secrets::RegistryAuth;
+use oci_client::secrets::RegistryAuth as ClientRegistryAuth;
 
-pub use config::{ImageConfig, OciConfig, PullResult};
+pub use config::{ImageConfig, OciConfig, PullResult, RegistryAuth};
 pub use error::{OciError, Result};
 pub use store::ImageMeta;
 use store::Store;
@@ -45,7 +45,7 @@ pub struct Oci {
     /// OCI registry HTTP client.
     client: oci_client::Client,
     /// Registry authentication credentials.
-    auth: RegistryAuth,
+    auth: ClientRegistryAuth,
 }
 
 impl std::fmt::Debug for Oci {
@@ -63,7 +63,7 @@ impl Oci {
     ///
     /// Returns an error if the store directory cannot be created or the database fails to open.
     pub fn open() -> Result<Self> {
-        Self::open_with(OciConfig::default())
+        Self::open_at(&dirs_default_store(), RegistryAuth::Anonymous)
     }
 
     /// Opens the OCI manager with explicit configuration.
@@ -77,22 +77,29 @@ impl Oci {
             platform_resolver: Some(Box::new(linux_platform_resolver)),
             ..Default::default()
         });
+        let auth = match config.auth {
+            RegistryAuth::Anonymous => ClientRegistryAuth::Anonymous,
+            RegistryAuth::Basic { username, password } => {
+                ClientRegistryAuth::Basic(username, password)
+            }
+            RegistryAuth::Bearer { token } => ClientRegistryAuth::Bearer(token),
+        };
         Ok(Self {
             store,
             client,
-            auth: config.auth,
+            auth,
         })
     }
 
-    /// Opens the OCI manager rooted at a specific directory.
+    /// Opens the OCI manager rooted at `store_dir` with the given registry auth.
     ///
     /// # Errors
     ///
     /// Returns an error if the store directory cannot be created or the database fails to open.
-    pub fn open_at(store_dir: &Path) -> Result<Self> {
+    pub fn open_at(store_dir: &Path, auth: RegistryAuth) -> Result<Self> {
         Self::open_with(OciConfig {
             store_dir: store_dir.to_path_buf(),
-            ..Default::default()
+            auth,
         })
     }
 

--- a/crates/bux/src/disk/mod.rs
+++ b/crates/bux/src/disk/mod.rs
@@ -131,7 +131,8 @@ impl DiskManager {
 
     /// Creates a managed base ext4 image with guest binary injected.
     ///
-    /// `guest_path` is the unresolved [`crate::RuntimeOptions::guest_path`].
+    /// `guest_path`: `Some` must be a regular file or [`crate::Error::NotFound`];
+    /// `None` searches env / sibling / `PATH`.
     ///
     /// # Errors
     ///

--- a/crates/bux/src/disk/mod.rs
+++ b/crates/bux/src/disk/mod.rs
@@ -131,11 +131,18 @@ impl DiskManager {
 
     /// Creates a managed base ext4 image with guest binary injected.
     ///
+    /// `guest_path` is the unresolved [`crate::RuntimeOptions::guest_path`].
+    ///
     /// # Errors
     ///
     /// Returns an error if image creation, injection, or rename fails.
-    pub(crate) fn create_managed_base(&self, rootfs: &Path, digest: &str) -> Result<PathBuf> {
-        let guest = ManagedGuestBinary::resolve()?;
+    pub(crate) fn create_managed_base(
+        &self,
+        rootfs: &Path,
+        digest: &str,
+        guest_path: Option<&Path>,
+    ) -> Result<PathBuf> {
+        let guest = ManagedGuestBinary::resolve(guest_path)?;
         let versioned = guest.versioned_cache_key(digest);
         let path = self.base_path(&versioned);
         if path.exists() {

--- a/crates/bux/src/guest.rs
+++ b/crates/bux/src/guest.rs
@@ -31,7 +31,17 @@ pub(crate) struct ManagedGuestBinary {
 }
 
 impl ManagedGuestBinary {
-    pub(crate) fn resolve() -> Result<Self> {
+    pub(crate) fn resolve(explicit: Option<&Path>) -> Result<Self> {
+        if let Some(path) = explicit {
+            if !path.is_file() {
+                return Err(Error::NotFound(format!(
+                    "bux-guest not found at {} (RuntimeOptions.guest_path)",
+                    path.display()
+                )));
+            }
+            return Self::from_path(path);
+        }
+
         let mut invalid = Vec::new();
         for path in candidate_paths() {
             if !path.exists() {
@@ -46,12 +56,12 @@ impl ManagedGuestBinary {
         let target = linux_guest_target();
         if invalid.is_empty() {
             return Err(Error::NotFound(format!(
-                "no valid Linux bux-guest binary found; set BUX_GUEST_PATH to a static {target} build"
+                "bux-guest not found (set RuntimeOptions.guest_path, BUX_GUEST_PATH, place a static {target} bux-guest next to the running executable, or on PATH)"
             )));
         }
 
         Err(Error::InvalidConfig(format!(
-            "failed to find a usable Linux bux-guest binary; set BUX_GUEST_PATH to a static {target} build. Candidates: {}",
+            "failed to find a usable Linux bux-guest binary; set RuntimeOptions.guest_path or BUX_GUEST_PATH to a static {target} build. Candidates: {}",
             invalid.join("; ")
         )))
     }
@@ -287,6 +297,131 @@ fn short_hash(data: &[u8]) -> String {
 }
 
 #[cfg(test)]
+impl ManagedGuestBinary {
+    pub(crate) fn host_path(&self) -> &Path {
+        &self.host_path
+    }
+}
+
+/// Static Linux ELF for this host with a unique 16-byte tag at offset 64.
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "test helper")]
+pub(crate) fn test_static_guest_elf(tag: &[u8; 16]) -> Vec<u8> {
+    let machine = expected_machine().unwrap();
+    let mut data = vec![0_u8; 128];
+    data[..4].copy_from_slice(&ELF_MAGIC);
+    data[4] = 2;
+    data[5] = 1;
+    data[6] = 1;
+    data[18..20].copy_from_slice(&machine.to_le_bytes());
+    data[64..80].copy_from_slice(tag);
+    data
+}
+
+#[cfg(test)]
+#[allow(
+    unsafe_code,
+    clippy::unwrap_used,
+    clippy::disallowed_methods,
+    reason = "tests isolate PATH and BUX_*_PATH under a mutex"
+)]
+pub(crate) mod sidecar_env {
+    use std::ffi::{OsStr, OsString};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+    use std::sync::{Mutex, MutexGuard};
+
+    static LOCK: Mutex<()> = Mutex::new(());
+
+    #[must_use]
+    pub(crate) struct Guard {
+        _lock: MutexGuard<'static, ()>,
+        restores: Vec<(&'static str, Option<OsString>)>,
+    }
+
+    pub(crate) fn lock() -> Guard {
+        Guard {
+            _lock: LOCK
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+            restores: Vec::new(),
+        }
+    }
+
+    impl Guard {
+        pub(crate) fn set(&mut self, key: &'static str, val: impl AsRef<OsStr>) {
+            if !self.restores.iter().any(|(k, _)| *k == key) {
+                self.restores.push((key, std::env::var_os(key)));
+            }
+            // SAFETY: `LOCK` serializes env mutation for sidecar tests.
+            unsafe { std::env::set_var(key, val) };
+        }
+
+        pub(crate) fn unset(&mut self, key: &'static str) {
+            if !self.restores.iter().any(|(k, _)| *k == key) {
+                self.restores.push((key, std::env::var_os(key)));
+            }
+            // SAFETY: `LOCK` serializes env mutation for sidecar tests.
+            unsafe { std::env::remove_var(key) };
+        }
+
+        pub(crate) fn prepend_path(&mut self, dir: &Path) {
+            let mut dirs = vec![dir.to_path_buf()];
+            if let Some(p) = std::env::var_os("PATH") {
+                dirs.extend(std::env::split_paths(&p));
+            }
+            self.set("PATH", std::env::join_paths(&dirs).unwrap());
+        }
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            for (key, old) in self.restores.drain(..).rev() {
+                restore_var(key, old);
+            }
+        }
+    }
+
+    fn restore_var(key: &'static str, old: Option<OsString>) {
+        if let Some(v) = old {
+            // SAFETY: caller holds `LOCK` for the Guard lifetime.
+            unsafe { std::env::set_var(key, v) };
+        } else {
+            // SAFETY: caller holds `LOCK` for the Guard lifetime.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    #[must_use]
+    pub(crate) struct Planted {
+        path: PathBuf,
+        backup: Option<Vec<u8>>,
+    }
+
+    impl Planted {
+        pub(crate) fn sibling(name: &str, data: &[u8]) -> Self {
+            let path = std::env::current_exe().unwrap().with_file_name(name);
+            let backup = fs::read(&path).ok();
+            fs::write(&path, data).unwrap();
+            Self { path, backup }
+        }
+
+        pub(crate) fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for Planted {
+        fn drop(&mut self) {
+            match &self.backup {
+                Some(bytes) => drop(fs::write(&self.path, bytes)),
+                None => drop(fs::remove_file(&self.path)),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
 #[allow(
     clippy::unwrap_used,
     clippy::expect_used,
@@ -370,5 +505,41 @@ mod tests {
             guest.versioned_cache_key("rootfs-digest"),
             "rootfs-digest-guest-deadbeefcafebabe"
         );
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive resolve"
+    )]
+    fn resolve_some_missing_does_not_consult_path() {
+        let mut env = sidecar_env::lock();
+        let decoy_dir = tempfile::tempdir().unwrap();
+        let decoy_bytes = test_static_guest_elf(b"DECOY-GUEST-ELF!");
+        fs::write(decoy_dir.path().join("bux-guest"), &decoy_bytes).unwrap();
+        env.prepend_path(decoy_dir.path());
+        env.set("BUX_GUEST_PATH", decoy_dir.path().join("bux-guest"));
+
+        let missing = decoy_dir.path().join("missing-guest");
+        let err = ManagedGuestBinary::resolve(Some(&missing)).unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, Error::NotFound(_)), "{msg}");
+        assert!(msg.contains("RuntimeOptions.guest_path"), "{msg}");
+        assert!(!msg.contains("bux binary"), "{msg}");
+        assert!(!missing.exists(), "must not create the missing path");
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive resolve"
+    )]
+    fn resolve_none_finds_planted_sibling() {
+        let mut env = sidecar_env::lock();
+        env.unset("BUX_GUEST_PATH");
+        let planted_bytes = test_static_guest_elf(b"SIBLING-GUEST-OK");
+        let planted = sidecar_env::Planted::sibling("bux-guest", &planted_bytes);
+        let guest = ManagedGuestBinary::resolve(None).unwrap();
+        assert_eq!(guest.host_path(), planted.path());
     }
 }

--- a/crates/bux/src/guest.rs
+++ b/crates/bux/src/guest.rs
@@ -296,13 +296,6 @@ fn short_hash(data: &[u8]) -> String {
     out
 }
 
-#[cfg(test)]
-impl ManagedGuestBinary {
-    pub(crate) fn host_path(&self) -> &Path {
-        &self.host_path
-    }
-}
-
 /// Static Linux ELF for this host with a unique 16-byte tag at offset 64.
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "test helper")]
@@ -540,6 +533,6 @@ mod tests {
         let planted_bytes = test_static_guest_elf(b"SIBLING-GUEST-OK");
         let planted = sidecar_env::Planted::sibling("bux-guest", &planted_bytes);
         let guest = ManagedGuestBinary::resolve(None).unwrap();
-        assert_eq!(guest.host_path(), planted.path());
+        assert_eq!(guest.host_path, planted.path());
     }
 }

--- a/crates/bux/src/lib.rs
+++ b/crates/bux/src/lib.rs
@@ -54,6 +54,8 @@ mod volumes;
 #[cfg(unix)]
 mod watchdog;
 
+#[cfg(unix)]
+pub use bux_oci::RegistryAuth;
 pub use bux_proto::ExecStart;
 #[cfg(unix)]
 pub use client::{ExecHandle, ExecOutput, PongInfo};
@@ -68,7 +70,7 @@ pub use metrics::{RuntimeMetrics, VmMetrics};
 pub use options::{ImageRef, NetworkSpec, VmOptions};
 pub use ports::{PortSpec, PublishedPort, parse_publish_spec};
 #[cfg(unix)]
-pub use runtime::{HealthStatus, ImageInfo, Runtime, Vm, VmInfo, default_data_dir};
+pub use runtime::{HealthStatus, ImageInfo, Runtime, RuntimeOptions, Vm, VmInfo, default_data_dir};
 #[cfg(unix)]
 pub use secrets::{Secret, StartOptions};
 pub use security::{HostInfo, LayerStatus, SecurityOptions, SecurityStatus};

--- a/crates/bux/src/runtime/boot/guest.rs
+++ b/crates/bux/src/runtime/boot/guest.rs
@@ -9,22 +9,28 @@ use crate::guest::ManagedGuestBinary;
 use crate::state::VmConfig;
 
 /// First boot: inject guest into a host rootfs. Rejects unprepared raw disks.
-pub(super) fn prepare_managed_config(config: &mut VmConfig) -> Result<()> {
+pub(super) fn prepare_managed_config(
+    config: &mut VmConfig,
+    guest_path: Option<&Path>,
+) -> Result<()> {
     if is_overlay_only(config) {
         return Err(crate::Error::InvalidConfig(
             "managed runtime does not support direct root_disk boot without a managed guest-rootfs preparation step".to_owned(),
         ));
     }
-    apply_guest_pid1(config)
+    apply_guest_pid1(config, guest_path)
 }
 
 /// Restart: overlay already has the injected guest. Skip host guest resolve.
-pub(crate) fn prepare_restart_config(config: &mut VmConfig) -> Result<()> {
+pub(crate) fn prepare_restart_config(
+    config: &mut VmConfig,
+    guest_path: Option<&Path>,
+) -> Result<()> {
     if is_overlay_only(config) {
         set_guest_pid1(config);
         return Ok(());
     }
-    apply_guest_pid1(config)
+    apply_guest_pid1(config, guest_path)
 }
 
 /// Persisted overlay: `root_disk` set, no host rootfs / base to inject.
@@ -40,8 +46,8 @@ fn set_guest_pid1(config: &mut VmConfig) {
 }
 
 /// Resolve the host guest ELF and inject into a rootfs directory when present.
-fn apply_guest_pid1(config: &mut VmConfig) -> Result<()> {
-    let guest = ManagedGuestBinary::resolve()?;
+fn apply_guest_pid1(config: &mut VmConfig, guest_path: Option<&Path>) -> Result<()> {
+    let guest = ManagedGuestBinary::resolve(guest_path)?;
     if let Some(rootfs) = config.rootfs.as_deref() {
         guest.inject_into_rootfs(Path::new(rootfs))?;
     }
@@ -171,7 +177,7 @@ mod tests {
             ..VmConfig::default()
         };
         assert!(matches!(
-            prepare_managed_config(&mut cfg),
+            prepare_managed_config(&mut cfg, None),
             Err(crate::Error::InvalidConfig(_))
         ));
     }
@@ -184,12 +190,60 @@ mod tests {
             exec_path: Some("/bux/bin/bux-guest".into()),
             ..VmConfig::default()
         };
-        prepare_restart_config(&mut cfg).unwrap();
+        prepare_restart_config(&mut cfg, None).unwrap();
         assert_eq!(
             cfg.exec_path.as_deref(),
             Some(ManagedGuestBinary::exec_path())
         );
         assert!(cfg.exec_args.is_empty());
         assert!(cfg.env.is_none());
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive inject"
+    )]
+    fn apply_guest_pid1_uses_runtime_guest_path_not_path_decoy() {
+        let mut env = crate::guest::sidecar_env::lock();
+        let planted_bytes = crate::guest::test_static_guest_elf(b"PLANT-GUEST-ELF!");
+        let decoy_bytes = crate::guest::test_static_guest_elf(b"DECOY-GUEST-ELF!");
+
+        let files = tempfile::tempdir().unwrap();
+        let planted = files.path().join("planted-guest");
+        let decoy = files.path().join("decoy-guest");
+        std::fs::write(&planted, &planted_bytes).unwrap();
+        std::fs::write(&decoy, &decoy_bytes).unwrap();
+
+        let decoy_bin = tempfile::tempdir().unwrap();
+        std::fs::write(decoy_bin.path().join("bux-guest"), &decoy_bytes).unwrap();
+        env.prepend_path(decoy_bin.path());
+        env.set("BUX_GUEST_PATH", &decoy);
+
+        let data = tempfile::tempdir().unwrap();
+        let rt = crate::Runtime::open_with(crate::RuntimeOptions {
+            data_dir: data.path().to_path_buf(),
+            shim_path: None,
+            guest_path: Some(planted),
+            registry_auth: crate::RegistryAuth::Anonymous,
+        })
+        .unwrap();
+
+        let rootfs = tempfile::tempdir().unwrap();
+        let mut cfg = VmConfig {
+            rootfs: Some(rootfs.path().to_string_lossy().into_owned()),
+            ..VmConfig::default()
+        };
+        prepare_managed_config(&mut cfg, rt.guest_path.as_deref()).unwrap();
+        let injected =
+            std::fs::read(rootfs.path().join(ManagedGuestBinary::relative_path())).unwrap();
+        assert_eq!(
+            injected, planted_bytes,
+            "rootfs must contain the planted ELF"
+        );
+        assert_ne!(
+            injected, decoy_bytes,
+            "rootfs must not contain the PATH decoy"
+        );
     }
 }

--- a/crates/bux/src/runtime/boot/mod.rs
+++ b/crates/bux/src/runtime/boot/mod.rs
@@ -149,9 +149,10 @@ async fn resolve_image(
                 let rootfs = pull.rootfs.clone();
                 let digest = pull.digest.replace(':', "-");
                 let pull_ref = pull.reference.clone();
+                let guest_path = rt.guest_path.clone();
                 tokio::task::spawn_blocking(move || -> Result<PathBuf> {
                     info!(image = %pull_ref, "creating ext4 base image from rootfs");
-                    disk.create_managed_base(&rootfs, &digest)
+                    disk.create_managed_base(&rootfs, &digest, guest_path.as_deref())
                 })
                 .await
                 .map_err(io::Error::other)??

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -413,8 +413,8 @@ fn map_jail_error(e: bux_jail::Error, shim: &Path) -> crate::Error {
 
 /// Locates the `bux-shim` binary.
 ///
-/// `explicit` is [`crate::RuntimeOptions::shim_path`]: `Some` is fail-closed;
-/// `None` searches env, then a sibling of the running executable, then `$PATH`.
+/// `Some` must be a regular file or [`crate::Error::NotFound`]; `None` searches
+/// env, then a sibling of the running executable, then `$PATH`.
 ///
 /// # Errors
 ///

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -103,7 +103,7 @@ pub(crate) fn spawn_config(
     reject_long_unix_path(&socket)?;
     let socket_str = socket.to_string_lossy().into_owned();
 
-    prepare_managed_config(&mut config)?;
+    prepare_managed_config(&mut config, rt.guest_path.as_deref())?;
     config.auto_remove = auto_remove;
     config.vsock_ports.push(VsockPort {
         port: AGENT_PORT,
@@ -153,7 +153,14 @@ pub(crate) fn spawn_config(
     }
 
     let config_path = rt.socks_dir.join(format!("{id}.json"));
-    let shim = spawn_shim(&config, &config_path, &rt.socks_dir, network, gvproxy)?;
+    let shim = spawn_shim(
+        &config,
+        &config_path,
+        &rt.socks_dir,
+        network,
+        gvproxy,
+        rt.shim_path.as_deref(),
+    )?;
     abort.pid = Some(shim.pid);
 
     config.security_status = shim.security.clone();
@@ -196,6 +203,8 @@ pub(crate) fn spawn_config(
         rt.snapshots.clone(),
         std::sync::Arc::clone(&rt.secrets),
         rt.volumes.clone(),
+        rt.shim_path.clone(),
+        rt.guest_path.clone(),
     ))
 }
 
@@ -275,6 +284,7 @@ pub(crate) fn spawn_shim(
     socks_dir: &Path,
     network: Option<ShimNetwork>,
     gvproxy: Option<ShimGvproxy>,
+    shim_path: Option<&Path>,
 ) -> Result<ShimSpawnResult> {
     if network.is_some() != gvproxy.is_some() {
         return Err(crate::Error::InvalidConfig(
@@ -301,7 +311,7 @@ pub(crate) fn spawn_shim(
     } else {
         (None, None)
     };
-    let shim = find_shim()?;
+    let shim = find_shim(shim_path)?;
 
     let readonly_paths = config
         .root_disk
@@ -402,8 +412,25 @@ fn map_jail_error(e: bux_jail::Error, shim: &Path) -> crate::Error {
 }
 
 /// Locates the `bux-shim` binary.
-fn find_shim() -> io::Result<PathBuf> {
+///
+/// `explicit` is [`crate::RuntimeOptions::shim_path`]: `Some` is fail-closed;
+/// `None` searches env, then a sibling of the running executable, then `$PATH`.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::NotFound`] if the shim cannot be located.
+pub(crate) fn find_shim(explicit: Option<&Path>) -> Result<PathBuf> {
     const NAME: &str = "bux-shim";
+
+    if let Some(path) = explicit {
+        if path.is_file() {
+            return Ok(path.to_path_buf());
+        }
+        return Err(crate::Error::NotFound(format!(
+            "bux-shim not found at {} (RuntimeOptions.shim_path)",
+            path.display()
+        )));
+    }
 
     if let Ok(p) = std::env::var("BUX_SHIM_PATH") {
         let path = PathBuf::from(p);
@@ -428,9 +455,8 @@ fn find_shim() -> io::Result<PathBuf> {
         }
     }
 
-    Err(io::Error::new(
-        io::ErrorKind::NotFound,
-        format!("'{NAME}' not found; install it next to the bux binary or in $PATH"),
+    Err(crate::Error::NotFound(
+        "bux-shim not found (set RuntimeOptions.shim_path, BUX_SHIM_PATH, place bux-shim next to the running executable, or on PATH)".into(),
     ))
 }
 
@@ -488,5 +514,47 @@ mod tests {
         assert!(msg.contains("sun_path"), "{msg}");
         assert!(msg.contains(".sock"), "{msg}");
         assert!(!msg.contains(".net.sock"), "{msg}");
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive find_shim"
+    )]
+    fn find_shim_some_missing_does_not_consult_path() {
+        let mut env = crate::guest::sidecar_env::lock();
+        let decoy_dir = tempfile::tempdir().unwrap();
+        fs::write(decoy_dir.path().join("bux-shim"), b"decoy-shim").unwrap();
+        env.prepend_path(decoy_dir.path());
+        env.set("BUX_SHIM_PATH", decoy_dir.path().join("bux-shim"));
+
+        let missing = decoy_dir.path().join("missing-shim");
+        let err = find_shim(Some(&missing)).unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, crate::Error::NotFound(_)), "{msg}");
+        assert!(msg.contains("RuntimeOptions.shim_path"), "{msg}");
+        assert!(!msg.contains("bux binary"), "{msg}");
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive find_shim"
+    )]
+    fn find_shim_none_finds_planted_sibling() {
+        let mut env = crate::guest::sidecar_env::lock();
+        env.unset("BUX_SHIM_PATH");
+        let planted = crate::guest::sidecar_env::Planted::sibling("bux-shim", b"planted-shim");
+        let found = find_shim(None).unwrap();
+        assert_eq!(found, planted.path());
+    }
+
+    #[test]
+    fn find_shim_some_planted_returns_that_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let planted = dir.path().join("planted-shim");
+        fs::write(&planted, b"shim").unwrap();
+        let found = find_shim(Some(&planted)).unwrap();
+        assert_eq!(found, planted);
     }
 }

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -32,8 +32,23 @@ use crate::snapshot::SnapshotManager;
 use crate::state::{StateDb, Status, VmConfig, VmState};
 use crate::volumes::VolumeManager;
 use boot::{clean_vm_files, is_pid_alive};
+use bux_oci::RegistryAuth;
 
 pub use vm::{Vm, VmInfo};
+
+/// How to open a [`Runtime`]. [`Runtime::open`] is this with defaults.
+#[derive(Debug, Clone)]
+pub struct RuntimeOptions {
+    /// Data dir (`bux.lock`, `bux.db`, disks, volumes, socks). Required.
+    pub data_dir: PathBuf,
+    /// If `Some`, must be a regular file at first use or [`crate::Error::NotFound`] (no search fallthrough).
+    /// If `None` → `BUX_SHIM_PATH` (fall through if not a file) → sibling of the running executable → `$PATH`.
+    pub shim_path: Option<PathBuf>,
+    /// Same contract as `shim_path` for the static Linux `bux-guest` ELF (`BUX_GUEST_PATH`).
+    pub guest_path: Option<PathBuf>,
+    /// Registry credentials for this Runtime's OCI handle (pull and [`crate::ImageRef::Oci`]).
+    pub registry_auth: RegistryAuth,
+}
 
 /// Cached OCI image metadata (product view).
 #[derive(Debug, Clone, serde::Serialize)]
@@ -102,6 +117,10 @@ pub struct Runtime {
     metrics: Arc<RuntimeMetrics>,
     /// Audit event dispatcher.
     events: Arc<EventDispatcher>,
+    /// Unresolved shim binary override from [`RuntimeOptions`].
+    pub(crate) shim_path: Option<PathBuf>,
+    /// Unresolved guest ELF override from [`RuntimeOptions`].
+    pub(crate) guest_path: Option<PathBuf>,
 }
 
 // Runtime is Send + Sync because:
@@ -112,32 +131,51 @@ pub struct Runtime {
 impl Runtime {
     /// Opens (or creates) the runtime data directory and database.
     ///
-    /// Runs crash recovery to reconcile stale state from previous runs.
-    /// Acquires an exclusive file lock to prevent concurrent access.
+    /// Equivalent to [`Self::open_with`] with no sidecar paths and anonymous
+    /// registry auth. Runs crash recovery to reconcile stale state from
+    /// previous runs. Acquires an exclusive file lock to prevent concurrent
+    /// access.
     ///
     /// # Errors
     ///
-    /// Returns an error if the data directory cannot be created, the lock
-    /// is already held, or the database fails to open.
+    /// Returns [`crate::Error::Busy`] if another Runtime holds the lock.
+    /// Returns an error if the data directory cannot be created or the
+    /// database fails to open.
     pub fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
-        let base = data_dir.as_ref();
+        Self::open_with(RuntimeOptions {
+            data_dir: data_dir.as_ref().to_path_buf(),
+            shim_path: None,
+            guest_path: None,
+            registry_auth: RegistryAuth::Anonymous,
+        })
+    }
+
+    /// Opens a runtime with explicit sidecar paths and registry auth.
+    ///
+    /// Sidecar paths are stored unresolved and copied onto each [`Vm`]. They
+    /// are resolved at first shim spawn / guest inject, not at open, and are
+    /// not stored in `SQLite`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::Busy`] if another Runtime holds the lock.
+    /// Returns an error if the data directory cannot be created or the
+    /// database fails to open.
+    pub fn open_with(opts: RuntimeOptions) -> Result<Self> {
+        let base = opts.data_dir.as_path();
         fs::create_dir_all(base)?;
 
         let lock_file = fs::File::create(base.join("bux.lock"))?;
-        let lock =
-            Flock::lock(lock_file, FlockArg::LockExclusiveNonblock).map_err(|(_, errno)| {
-                io::Error::new(
-                    io::ErrorKind::AlreadyExists,
-                    format!("another bux runtime is using {}: {errno}", base.display()),
-                )
-            })?;
+        let lock = Flock::lock(lock_file, FlockArg::LockExclusiveNonblock).map_err(|_| {
+            crate::Error::Busy(format!("another bux runtime is using {}", base.display()))
+        })?;
 
         let socks_dir = base.join("socks");
         fs::create_dir_all(&socks_dir)?;
 
         let db = Arc::new(StateDb::open(base.join("bux.db"))?);
         let disk = DiskManager::open(base)?;
-        let oci = bux_oci::Oci::open_at(base)?;
+        let oci = bux_oci::Oci::open_at(base, opts.registry_auth)?;
         let snapshots = SnapshotManager::new(Arc::clone(&db), base)?;
         let secrets = Arc::new(Mutex::new(HashMap::new()));
         let volumes = VolumeManager::open(base, Arc::clone(&db))?;
@@ -153,6 +191,8 @@ impl Runtime {
             volumes,
             metrics: Arc::new(RuntimeMetrics::new()),
             events: Arc::new(EventDispatcher::new()),
+            shim_path: opts.shim_path,
+            guest_path: opts.guest_path,
         };
 
         rt.recover();
@@ -453,6 +493,8 @@ impl Runtime {
             self.snapshots.clone(),
             Arc::clone(&self.secrets),
             self.volumes.clone(),
+            self.shim_path.clone(),
+            self.guest_path.clone(),
         ))
     }
 
@@ -556,8 +598,9 @@ mod tests {
     use crate::options::NetworkSpec;
     use crate::secrets::LiveSecrets;
     use crate::state::VmConfig;
+    use bux_oci::RegistryAuth;
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::SystemTime;
 
@@ -942,5 +985,146 @@ mod tests {
         drop(rt);
         drop(child.kill());
         drop(child.wait());
+    }
+
+    #[test]
+    fn open_flock_contention_is_busy_not_io() {
+        let dir = tempfile::tempdir().unwrap();
+        let _rt = Runtime::open(dir.path()).unwrap();
+        let open_err = Runtime::open(dir.path()).unwrap_err();
+        assert!(
+            matches!(open_err, crate::Error::Busy(_)),
+            "open contention must be Busy: {open_err}"
+        );
+        let with_err = Runtime::open_with(RuntimeOptions {
+            data_dir: dir.path().to_path_buf(),
+            shim_path: None,
+            guest_path: None,
+            registry_auth: RegistryAuth::Anonymous,
+        })
+        .unwrap_err();
+        assert!(
+            matches!(with_err, crate::Error::Busy(_)),
+            "open_with contention must be Busy: {with_err}"
+        );
+    }
+
+    #[test]
+    fn open_with_anonymous_matches_open_db_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let open_dir = dir.path().join("open");
+        let with_dir = dir.path().join("with");
+        drop(Runtime::open(&open_dir).unwrap());
+        drop(
+            Runtime::open_with(RuntimeOptions {
+                data_dir: with_dir.clone(),
+                shim_path: None,
+                guest_path: None,
+                registry_auth: RegistryAuth::Anonymous,
+            })
+            .unwrap(),
+        );
+
+        let names = |base: &Path| -> Vec<String> {
+            let mut names: Vec<String> = fs::read_dir(base)
+                .unwrap()
+                .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+                .collect();
+            names.sort();
+            names
+        };
+        assert_eq!(names(&open_dir), names(&with_dir));
+        assert!(open_dir.join("bux.db").is_file());
+        assert!(with_dir.join("bux.db").is_file());
+    }
+
+    #[test]
+    fn runtime_options_debug_redacts_registry_auth() {
+        let opts = RuntimeOptions {
+            data_dir: PathBuf::from("/tmp/bux-data"),
+            shim_path: None,
+            guest_path: None,
+            registry_auth: RegistryAuth::Bearer {
+                token: "tokensecret".into(),
+            },
+        };
+        let dbg = format!("{opts:?}");
+        assert!(dbg.contains("***"), "{dbg}");
+        assert!(!dbg.contains("tokensecret"), "{dbg}");
+    }
+
+    #[test]
+    fn get_copies_unresolved_shim_path_from_open_with() {
+        let dir = tempfile::tempdir().unwrap();
+        let planted = dir.path().join("planted-shim");
+        fs::write(&planted, b"shim").unwrap();
+        let rt = Runtime::open_with(RuntimeOptions {
+            data_dir: dir.path().join("rt"),
+            shim_path: Some(planted.clone()),
+            guest_path: None,
+            registry_auth: RegistryAuth::Anonymous,
+        })
+        .unwrap();
+        insert_cfg(
+            &rt,
+            "getshim000001",
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig::default(),
+        );
+        let vm = rt.get("getshim000001").unwrap();
+        assert_eq!(vm.shim_path.as_deref(), Some(planted.as_path()));
+        assert!(vm.guest_path.is_none());
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive create_managed_base"
+    )]
+    fn create_managed_base_uses_runtime_guest_path_not_path_decoy() {
+        let mut env = crate::guest::sidecar_env::lock();
+        let planted_bytes = crate::guest::test_static_guest_elf(b"PLANT-GUEST-ELF!");
+        let decoy_bytes = crate::guest::test_static_guest_elf(b"DECOY-GUEST-ELF!");
+
+        let files = tempfile::tempdir().unwrap();
+        let planted = files.path().join("planted-guest");
+        let decoy = files.path().join("decoy-guest");
+        fs::write(&planted, &planted_bytes).unwrap();
+        fs::write(&decoy, &decoy_bytes).unwrap();
+
+        let decoy_bin = tempfile::tempdir().unwrap();
+        fs::write(decoy_bin.path().join("bux-guest"), &decoy_bytes).unwrap();
+        env.prepend_path(decoy_bin.path());
+        env.set("BUX_GUEST_PATH", &decoy);
+
+        let data = tempfile::tempdir().unwrap();
+        let rt = Runtime::open_with(RuntimeOptions {
+            data_dir: data.path().to_path_buf(),
+            shim_path: None,
+            guest_path: Some(planted),
+            registry_auth: RegistryAuth::Anonymous,
+        })
+        .unwrap();
+
+        let rootfs = tempfile::tempdir().unwrap();
+        fs::write(rootfs.path().join("placeholder"), b"root").unwrap();
+        let image = rt
+            .disk()
+            .create_managed_base(rootfs.path(), "testdigest", rt.guest_path.as_deref())
+            .unwrap();
+        let image_bytes = fs::read(&image).unwrap();
+        assert!(
+            image_bytes
+                .windows(planted_bytes.len())
+                .any(|w| w == planted_bytes.as_slice()),
+            "ext4 image must contain the planted guest ELF"
+        );
+        assert!(
+            image_bytes
+                .windows(decoy_bytes.len())
+                .all(|w| w != decoy_bytes.as_slice()),
+            "ext4 image must not contain the PATH decoy guest ELF"
+        );
     }
 }

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -123,9 +123,9 @@ pub struct Vm {
     volumes: VolumeManager,
     /// When this VM was spawned (for uptime tracking).
     spawned_at: std::time::Instant,
-    /// Unresolved shim path copied from the opening [`super::Runtime`].
+    /// Unresolved shim override (`Some` fail-closed; `None` searches).
     pub(crate) shim_path: Option<PathBuf>,
-    /// Unresolved guest path copied from the opening [`super::Runtime`].
+    /// Unresolved guest override (`Some` fail-closed; `None` searches).
     pub(crate) guest_path: Option<PathBuf>,
 }
 

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -123,6 +123,10 @@ pub struct Vm {
     volumes: VolumeManager,
     /// When this VM was spawned (for uptime tracking).
     spawned_at: std::time::Instant,
+    /// Unresolved shim path copied from the opening [`super::Runtime`].
+    pub(crate) shim_path: Option<PathBuf>,
+    /// Unresolved guest path copied from the opening [`super::Runtime`].
+    pub(crate) guest_path: Option<PathBuf>,
 }
 
 impl Vm {
@@ -141,6 +145,8 @@ impl Vm {
         snapshots: SnapshotManager,
         secrets: Arc<Mutex<HashMap<String, LiveSecrets>>>,
         volumes: VolumeManager,
+        shim_path: Option<PathBuf>,
+        guest_path: Option<PathBuf>,
     ) -> Self {
         let client = Client::new(&state.socket);
         Self {
@@ -156,6 +162,8 @@ impl Vm {
             secrets,
             volumes,
             spawned_at: std::time::Instant::now(),
+            shim_path,
+            guest_path,
         }
     }
 
@@ -445,7 +453,7 @@ impl Vm {
             )));
         }
 
-        prepare_restart_config(&mut self.state.config)?;
+        prepare_restart_config(&mut self.state.config, self.guest_path.as_deref())?;
 
         let live = if opts.secrets.is_empty() {
             let held = {
@@ -501,6 +509,7 @@ impl Vm {
             &socks_dir,
             network,
             gvproxy,
+            self.shim_path.as_deref(),
         )?;
 
         self.state.config.security_status = shim.security.clone();


### PR DESCRIPTION
Add `RuntimeOptions` with fail-closed sidecar paths copied onto `Vm`. Define `RegistryAuth` in `bux-oci` and `Oci::open_at(dir, auth)`. Flock contention is `Error::Busy`.

Stack: bd627533 PR 6. Do not preserve compatibility.