### PR TITLE
build(e2fs): fetch e2fs-v1.47.4

### DIFF
--- a/.github/workflows/e2fs-build.yml
+++ b/.github/workflows/e2fs-build.yml
@@ -85,13 +85,9 @@ jobs:
           # That symbol lives in create_inode_libarchive.c — when built
           # without HAVE_ARCHIVE_H it compiles to a stub returning an error.
           # Both .o files must be in the archive.
-          #
-          # We also stub no_copy_xattrs (normally in mke2fs.c).
           cd misc
           make create_inode.o create_inode_libarchive.o
-          printf 'int no_copy_xattrs = 1;\n' > e2fs_stubs.c
-          ${CC:-cc} $CFLAGS -c -o e2fs_stubs.o e2fs_stubs.c
-          ar rcs libcreate_inode.a create_inode.o create_inode_libarchive.o e2fs_stubs.o
+          ar rcs libcreate_inode.a create_inode.o create_inode_libarchive.o
           cd ..
 
           # Collect static libraries into dist/lib/.

--- a/.github/workflows/e2fs-build.yml
+++ b/.github/workflows/e2fs-build.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Pin e2fsprogs version — keep in sync with crates/bux-e2fs/build.rs.
-  E2FSPROGS_VERSION: "1.47.1"
+  E2FSPROGS_VERSION: "1.47.4"
 
 jobs:
   build:
@@ -165,14 +165,3 @@ jobs:
         with:
           files: bux-e2fs-*.tar.gz
           generate_release_notes: true
-
-  publish-e2fs:
-    needs: release
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/e2fs-v')
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish -p bux-e2fs
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "bux-e2fs"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "bindgen",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bux-bwrap = { version = "0.1", path = "crates/bux-bwrap" }
 bux-jail = { version = "0.1", path = "crates/bux-jail" }
 bux-krun = { version = "0.2", path = "crates/bux-krun" }
 bux-shim = { version = "0.1", path = "crates/bux-shim" }
-bux-e2fs = { version = "0.1.5", path = "crates/bux-e2fs" }
+bux-e2fs = { version = "0.2", path = "crates/bux-e2fs" }
 bux-gvproxy = { version = "0.1", path = "crates/bux-gvproxy" }
 bux-landlock = { version = "0.1", path = "crates/bux-landlock" }
 bux-qcow2 = { version = "0.1", path = "crates/bux-qcow2" }

--- a/crates/bux-e2fs/Cargo.toml
+++ b/crates/bux-e2fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bux-e2fs"
-version = "0.1.5"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/bux-e2fs/README.md
+++ b/crates/bux-e2fs/README.md
@@ -66,7 +66,7 @@ create_from_dir(
 | Variable | Description |
 | --- | --- |
 | `BUX_E2FS_DIR` | Path to a local directory containing pre-built static libraries. Skips downloading. |
-| `BUX_E2FS_VERSION` | Override the e2fsprogs release version (default: crate version). |
+| `BUX_E2FS_VERSION` | Override the e2fsprogs release version (default: 1.47.4). |
 | `BUX_UPDATE_BINDINGS` | Copy generated bindings back to `src/bindings.rs` (with `regenerate` feature). |
 
 ## Supported platforms

--- a/crates/bux-e2fs/build.rs
+++ b/crates/bux-e2fs/build.rs
@@ -11,7 +11,7 @@
 //!   local development.
 //!
 //! - `BUX_E2FS_VERSION` — Override the e2fsprogs release version to download.
-//!   Defaults to the crate version from `Cargo.toml`.
+//!   Defaults to `E2FSPROGS_VERSION`.
 //!
 //! - `BUX_UPDATE_BINDINGS` — When set alongside the `regenerate` feature, the
 //!   freshly generated `bindings.rs` is copied back to `src/bindings.rs` so it
@@ -31,6 +31,9 @@
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
+
+/// Pinned e2fsprogs version — keep in sync with `.github/workflows/e2fs-build.yml`.
+const E2FSPROGS_VERSION: &str = "1.47.4";
 
 /// GitHub repository for downloading pre-built library releases.
 const GITHUB_REPO: &str = "qntx/bux";
@@ -212,8 +215,7 @@ fn obtain_libraries(target: &str, out_dir: &Path) -> PathBuf {
         eprintln!("bux-e2fs: BUX_E2FS_DIR set but libs not found, downloading");
     }
 
-    let version = env::var("BUX_E2FS_VERSION")
-        .unwrap_or_else(|_| env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set"));
+    let version = env::var("BUX_E2FS_VERSION").unwrap_or_else(|_| E2FSPROGS_VERSION.to_owned());
     let lib_dir = out_dir.join("e2fs").join("lib");
 
     if !lib_dir.join("libext2fs.a").exists() {

--- a/crates/bux-e2fs/src/bindings.rs
+++ b/crates/bux-e2fs/src/bindings.rs
@@ -51,6 +51,8 @@ pub const LINUX_S_IFDIR: u32 = 16384;
 pub const LINUX_S_IFCHR: u32 = 8192;
 pub const LINUX_S_IFIFO: u32 = 4096;
 pub const EXT2_FLAG_FLUSH_NO_SYNC: u32 = 1;
+pub const POPULATE_FS_NO_COPY_XATTRS: u32 = 1;
+pub const POPULATE_FS_LINK_APPEND: u32 = 2;
 pub type __dev_t = ::core::ffi::c_ulong;
 pub type __uid_t = ::core::ffi::c_uint;
 pub type __gid_t = ::core::ffi::c_uint;
@@ -969,10 +971,12 @@ pub struct struct_io_stats {
     pub reserved: ::core::ffi::c_int,
     pub bytes_read: ::core::ffi::c_ulonglong,
     pub bytes_written: ::core::ffi::c_ulonglong,
+    pub cache_hits: ::core::ffi::c_ulonglong,
+    pub cache_misses: ::core::ffi::c_ulonglong,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of struct_io_stats"][::core::mem::size_of::<struct_io_stats>() - 24usize];
+    ["Size of struct_io_stats"][::core::mem::size_of::<struct_io_stats>() - 40usize];
     ["Alignment of struct_io_stats"][::core::mem::align_of::<struct_io_stats>() - 8usize];
     ["Offset of field: struct_io_stats::num_fields"]
         [::core::mem::offset_of!(struct_io_stats, num_fields) - 0usize];
@@ -982,6 +986,10 @@ const _: () = {
         [::core::mem::offset_of!(struct_io_stats, bytes_read) - 8usize];
     ["Offset of field: struct_io_stats::bytes_written"]
         [::core::mem::offset_of!(struct_io_stats, bytes_written) - 16usize];
+    ["Offset of field: struct_io_stats::cache_hits"]
+        [::core::mem::offset_of!(struct_io_stats, cache_hits) - 24usize];
+    ["Offset of field: struct_io_stats::cache_misses"]
+        [::core::mem::offset_of!(struct_io_stats, cache_misses) - 32usize];
 };
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -1639,6 +1647,16 @@ unsafe extern "C" {
     ) -> errcode_t;
 }
 unsafe extern "C" {
+    pub fn populate_fs3(
+        fs: ext2_filsys,
+        parent_ino: ext2_ino_t,
+        source_dir: *const ::core::ffi::c_char,
+        root: ext2_ino_t,
+        flags: ::core::ffi::c_int,
+        fs_callbacks: *mut fs_ops_callbacks,
+    ) -> errcode_t;
+}
+unsafe extern "C" {
     pub fn do_symlink_internal(
         fs: ext2_filsys,
         cwd: ext2_ino_t,
@@ -1652,6 +1670,7 @@ unsafe extern "C" {
         fs: ext2_filsys,
         cwd: ext2_ino_t,
         name: *const ::core::ffi::c_char,
+        flags: ::core::ffi::c_ulong,
         root: ext2_ino_t,
     ) -> errcode_t;
 }
@@ -1661,6 +1680,7 @@ unsafe extern "C" {
         cwd: ext2_ino_t,
         src: *const ::core::ffi::c_char,
         dest: *const ::core::ffi::c_char,
+        flags: ::core::ffi::c_ulong,
         root: ext2_ino_t,
     ) -> errcode_t;
 }

--- a/crates/bux-e2fs/src/ext4.rs
+++ b/crates/bux-e2fs/src/ext4.rs
@@ -295,6 +295,7 @@ impl Filesystem {
                     sys::EXT2_ROOT_INO,
                     c_host.as_ptr(),
                     c_guest.as_ptr(),
+                    0,
                     sys::EXT2_ROOT_INO,
                 ),
             )
@@ -315,6 +316,7 @@ impl Filesystem {
                     self.inner,
                     sys::EXT2_ROOT_INO,
                     c_name.as_ptr(),
+                    0,
                     sys::EXT2_ROOT_INO,
                 ),
             )


### PR DESCRIPTION
## Summary
Pin e2fsprogs 1.47.4. URL is `e2fs-v{E2FSPROGS_VERSION}`. Drop `e2fs_stubs.c` / `no_copy_xattrs`. `publish-e2fs` deleted.

**Do not merge until** tag `e2fs-v1.47.4` on this PR SHA has the three `bux-e2fs-*.tar.gz` assets and CI is re-run green.

Depends on PR1 in stack 8120de4a.

## Test plan
- [x] clippy -p bux-e2fs with BUX_E2FS_DIR
- [ ] tag e2fs-v1.47.4; wait for e2fs-build.yml
- [ ] cargo build -p bux-e2fs logs e2fs-v1.47.4