### PR TITLE
build(bwrap): fetch bwrap-v0.12.0

### DIFF
--- a/.github/workflows/bwrap-build.yml
+++ b/.github/workflows/bwrap-build.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   # Pin bubblewrap version — keep in sync with crates/bux-bwrap/build.rs.
-  BUBBLEWRAP_VERSION: "0.11.0"
+  BUBBLEWRAP_VERSION: "0.12.0"
 
 jobs:
   build:
@@ -87,14 +87,3 @@ jobs:
         with:
           files: bux-bwrap-*.tar.gz
           generate_release_notes: true
-
-  publish-bwrap:
-    needs: release
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/bwrap-v')
-    steps:
-      - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish -p bux-bwrap
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "bux-bwrap"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "flate2",
  "tar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ bux = { version = "0.7", path = "crates/bux" }
 bux-oci = { version = "0.7", path = "crates/bux-oci" }
 bux-proto = { version = "0.7", path = "crates/bux-proto" }
 
-bux-bwrap = { version = "0.1", path = "crates/bux-bwrap" }
+bux-bwrap = { version = "0.2", path = "crates/bux-bwrap" }
 bux-jail = { version = "0.1", path = "crates/bux-jail" }
 bux-krun = { version = "0.2", path = "crates/bux-krun" }
 bux-shim = { version = "0.1", path = "crates/bux-shim" }

--- a/crates/bux-bwrap/Cargo.toml
+++ b/crates/bux-bwrap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bux-bwrap"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/bux-bwrap/README.md
+++ b/crates/bux-bwrap/README.md
@@ -15,7 +15,7 @@ Bundles the [bubblewrap](https://github.com/containers/bubblewrap) (`bwrap`) san
 ## Environment variables
 
 - **`BUX_BWRAP_DIR`** — Local directory containing a pre-built `bwrap` binary. Skips downloading.
-- **`BUX_BWRAP_VERSION`** — Override the release version to download (default: crate version).
+- **`BUX_BWRAP_VERSION`** — Override the release version to download (default: bubblewrap version).
 
 ## License
 

--- a/crates/bux-bwrap/build.rs
+++ b/crates/bux-bwrap/build.rs
@@ -9,7 +9,7 @@
 //!   binary. When set, skips downloading. Primary flow for local development.
 //!
 //! - `BUX_BWRAP_VERSION` — Override the bubblewrap release version to download.
-//!   Defaults to the crate version from `Cargo.toml`.
+//!   Defaults to `BUBBLEWRAP_VERSION`.
 
 // Build scripts legitimately use stderr for diagnostics, expect/panic for
 // unrecoverable failures, and have internal-only helpers.
@@ -28,6 +28,9 @@ use std::path::{Path, PathBuf};
 
 /// GitHub repository for downloading pre-built bwrap releases.
 const GITHUB_REPO: &str = "qntx/bux";
+
+/// Pinned bubblewrap version — keep in sync with `.github/workflows/bwrap-build.yml`.
+const BUBBLEWRAP_VERSION: &str = "0.12.0";
 
 fn main() {
     println!("cargo:rerun-if-env-changed=BUX_BWRAP_DIR");
@@ -71,23 +74,19 @@ fn obtain_binary(target: &str, out_dir: &Path) -> PathBuf {
         eprintln!("bux-bwrap: BUX_BWRAP_DIR set but bwrap not found, downloading");
     }
 
-    let version = env::var("BUX_BWRAP_VERSION")
-        .unwrap_or_else(|_| env::var("CARGO_PKG_VERSION").expect("CARGO_PKG_VERSION not set"));
+    let version = env::var("BUX_BWRAP_VERSION");
+    let version = version.as_deref().unwrap_or(BUBBLEWRAP_VERSION);
     let bin_dir = out_dir.join("bwrap");
     let bwrap_path = bin_dir.join("bwrap");
 
-    if !bwrap_path.is_file() && !download_binary(&version, target, &bin_dir) {
-        // No pre-built release available yet — emit a sentinel path.
-        // path() will return None at runtime since this file won't exist.
-        return PathBuf::from("/nonexistent");
+    if !bwrap_path.is_file() {
+        download_binary(version, target, &bin_dir);
     }
     bwrap_path
 }
 
 /// Downloads the pre-built bwrap binary from GitHub Releases.
-///
-/// Returns `true` on success, `false` if the release is not available yet.
-fn download_binary(version: &str, target: &str, dest: &Path) -> bool {
+fn download_binary(version: &str, target: &str, dest: &Path) {
     let url = format!(
         "https://github.com/{GITHUB_REPO}/releases/download/bwrap-v{version}/bux-bwrap-{target}.tar.gz"
     );
@@ -95,31 +94,24 @@ fn download_binary(version: &str, target: &str, dest: &Path) -> bool {
 
     fs::create_dir_all(dest).expect("Failed to create bwrap dir");
 
-    let resp = match ureq::get(&url).call() {
-        Ok(r) => r,
-        Err(e) => {
-            println!("cargo:warning=bux-bwrap: download failed ({e}), bwrap will be unavailable");
-            return false;
-        }
-    };
+    let resp = ureq::get(&url)
+        .call()
+        .unwrap_or_else(|e| panic!("Failed to download bwrap: {e}"));
 
     tar::Archive::new(flate2::read::GzDecoder::new(resp.into_body().into_reader()))
         .unpack(dest)
         .expect("Failed to extract bwrap archive");
 
     let bwrap = dest.join("bwrap");
-    if !bwrap.is_file() {
-        println!("cargo:warning=bux-bwrap: binary not found in archive");
-        return false;
-    }
+    assert!(
+        bwrap.is_file(),
+        "bwrap not found after extraction. Check GitHub Release bwrap-v{version}."
+    );
 
-    // Ensure executable permission on Unix.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
         fs::set_permissions(&bwrap, fs::Permissions::from_mode(0o755))
             .expect("Failed to set bwrap permissions");
     }
-
-    true
 }


### PR DESCRIPTION
## Summary
Pin bubblewrap 0.12.0. URL is `bwrap-v{BUBBLEWRAP_VERSION}`. Linux 404 panics. `publish-bwrap` deleted.

**Do not merge until** tag `bwrap-v0.12.0` has the two Linux `bux-bwrap-*.tar.gz` assets and Linux CI is re-run green.

Depends on PR2 in stack 8120de4a.

## Test plan
- [x] clippy -p bux-bwrap on Darwin (no download)
- [ ] tag bwrap-v0.12.0; wait for bwrap-build.yml