### PR TITLE
fix(guest): reap SIGCHLD and report exec exit codes

### DIFF
--- a/crates/bux-guest/Cargo.toml
+++ b/crates/bux-guest/Cargo.toml
@@ -17,7 +17,7 @@ nix = { workspace = true }
 rtnetlink = "0.23"
 serde_json = { workspace = true }
 tar = { workspace = true }
-tokio = { workspace = true, features = ["rt", "macros", "io-util", "process", "fs", "time", "sync", "signal"] }
+tokio = { workspace = true, features = ["rt", "macros", "io-util", "fs", "time", "sync", "signal"] }
 tokio-vsock = { workspace = true }
 
 [lints]

--- a/crates/bux-guest/src/exec/mod.rs
+++ b/crates/bux-guest/src/exec/mod.rs
@@ -3,7 +3,7 @@
 mod pty;
 
 use std::io;
-use std::os::unix::process::ExitStatusExt;
+use std::os::fd::OwnedFd;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Instant;
@@ -11,22 +11,34 @@ use std::time::Instant;
 use bux_proto::{ErrorCode, ErrorInfo, ExecIn, ExecOut, ExecStart, HelloAck};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+use crate::reaper::{Exit, Reaper};
+
 /// Monotonic counter for generating unique execution IDs.
 static EXEC_SEQ: AtomicU64 = AtomicU64::new(1);
 
+/// Wrap a stdio fd as `tokio::fs::File` (blocking pool).
+fn file_from_stdio(fd: impl Into<OwnedFd>) -> tokio::fs::File {
+    tokio::fs::File::from_std(std::fs::File::from(fd.into()))
+}
+
 /// Handles an exec connection: spawns a child, multiplexes I/O until exit.
+///
+/// # Errors
+///
+/// Returns an error if spawn, session I/O, or exit reporting fails.
 pub async fn handle(
     r: &mut (impl AsyncRead + Unpin + Send),
     w: &mut (impl AsyncWrite + Unpin + Send),
     req: ExecStart,
+    reaper: Reaper,
 ) -> io::Result<()> {
     let exec_id = format!("exec-{}", EXEC_SEQ.fetch_add(1, Ordering::Relaxed));
     let spawn_t0 = Instant::now();
 
     if req.tty.is_some() {
-        handle_pty(r, w, req, &exec_id, spawn_t0).await
+        handle_pty(r, w, req, &exec_id, spawn_t0, &reaper).await
     } else {
-        handle_pipe(r, w, req, &exec_id, spawn_t0).await
+        handle_pipe(r, w, req, &exec_id, spawn_t0, &reaper).await
     }
 }
 
@@ -37,10 +49,10 @@ async fn handle_pipe(
     req: ExecStart,
     exec_id: &str,
     spawn_t0: Instant,
+    reaper: &Reaper,
 ) -> io::Result<()> {
-    use std::process::Stdio;
-
-    use tokio::process::Command;
+    use std::os::unix::process::CommandExt as _;
+    use std::process::{Command, Stdio};
 
     let credentials = match resolve_credentials(&req) {
         Ok(c) => c,
@@ -62,8 +74,8 @@ async fn handle_pipe(
 
     apply_exec_options!(&mut cmd, &req, credentials);
 
-    let mut child = match cmd.spawn() {
-        Ok(c) => c,
+    let mut spawned = match reaper.spawn(&mut cmd) {
+        Ok(s) => s,
         Err(e) => {
             let err = ErrorInfo::new(ErrorCode::Internal, e.to_string());
             bux_proto::send(w, &HelloAck::Error(err)).await?;
@@ -72,7 +84,7 @@ async fn handle_pipe(
     };
 
     #[allow(clippy::cast_possible_wrap)]
-    let pid = child.id().unwrap_or(0) as i32;
+    let pid = spawned.child.id() as i32;
     bux_proto::send(
         w,
         &HelloAck::ExecStarted {
@@ -83,26 +95,18 @@ async fn handle_pipe(
     .await?;
     w.flush().await?;
 
-    // Set up timeout watcher.
     let timed_out = Arc::new(AtomicBool::new(false));
-    if req.timeout_ms > 0 {
-        let flag = Arc::clone(&timed_out);
-        let timeout = std::time::Duration::from_millis(req.timeout_ms);
-        tokio::spawn(async move {
-            tokio::time::sleep(timeout).await;
-            flag.store(true, Ordering::SeqCst);
-            unsafe { libc::kill(pid, libc::SIGKILL) };
-        });
-    }
+    spawn_timeout_killer(pid, req.timeout_ms, &timed_out);
 
-    let mut child_stdin = child.stdin.take();
+    let mut child_stdin = spawned.child.stdin.take().map(file_from_stdio);
     // SAFETY: stdout/stderr were set to Stdio::piped() above.
-    let Some(mut stdout) = child.stdout.take() else {
+    let Some(mut stdout) = spawned.child.stdout.take().map(file_from_stdio) else {
         unreachable!()
     };
-    let Some(mut stderr) = child.stderr.take() else {
+    let Some(mut stderr) = spawned.child.stderr.take().map(file_from_stdio) else {
         unreachable!()
     };
+    drop(spawned.child);
     let mut stdout_done = false;
     let mut stderr_done = false;
     let mut stdout_buf = [0u8; 4096];
@@ -156,7 +160,7 @@ async fn handle_pipe(
     }
 
     drop(child_stdin);
-    send_exit(w, &mut child, spawn_t0, &timed_out).await
+    send_exit(w, spawned.exit.await, spawn_t0, &timed_out).await
 }
 
 /// PTY-mode execution: stdout and stderr are merged into a single PTY stream.
@@ -166,8 +170,9 @@ async fn handle_pty(
     req: ExecStart,
     exec_id: &str,
     spawn_t0: Instant,
+    reaper: &Reaper,
 ) -> io::Result<()> {
-    let spawn_result = pty::spawn(&req);
+    let spawn_result = pty::spawn(&req, reaper);
     let mut pty_handle = match spawn_result {
         Ok(h) => h,
         Err(e) => {
@@ -188,17 +193,8 @@ async fn handle_pty(
     .await?;
     w.flush().await?;
 
-    // Set up timeout watcher.
     let timed_out = Arc::new(AtomicBool::new(false));
-    if req.timeout_ms > 0 {
-        let flag = Arc::clone(&timed_out);
-        let timeout = std::time::Duration::from_millis(req.timeout_ms);
-        tokio::spawn(async move {
-            tokio::time::sleep(timeout).await;
-            flag.store(true, Ordering::SeqCst);
-            unsafe { libc::kill(pid, libc::SIGKILL) };
-        });
-    }
+    spawn_timeout_killer(pid, req.timeout_ms, &timed_out);
 
     let mut pty_buf = [0u8; 4096];
 
@@ -233,19 +229,36 @@ async fn handle_pty(
         }
     }
 
-    send_exit_by_pid(w, pid, spawn_t0, &timed_out).await
+    send_exit(w, pty_handle.exit.await, spawn_t0, &timed_out).await
 }
 
-/// Waits for a `tokio::process::Child` and sends `ExecOut::Exit`.
+/// SIGKILL the child after `timeout_ms` if non-zero.
+fn spawn_timeout_killer(pid: i32, timeout_ms: u64, timed_out: &Arc<AtomicBool>) {
+    if timeout_ms == 0 {
+        return;
+    }
+    let flag = Arc::clone(timed_out);
+    tokio::spawn(async move {
+        tokio::time::sleep(std::time::Duration::from_millis(timeout_ms)).await;
+        flag.store(true, Ordering::SeqCst);
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+    });
+}
+
+/// Awaits the reaper waiter and sends `ExecOut::Exit`.
+///
+/// A cancelled oneshot (reaper task died) is an I/O error, not `code: 0`.
+///
+/// # Errors
+///
+/// Returns an error if the waiter was dropped or sending `ExecOut::Exit` fails.
 async fn send_exit(
     w: &mut (impl AsyncWrite + Unpin + Send),
-    child: &mut tokio::process::Child,
+    wait: Result<Exit, tokio::sync::oneshot::error::RecvError>,
     spawn_t0: Instant,
     timed_out: &AtomicBool,
 ) -> io::Result<()> {
-    let status = child.wait().await?;
-    let code = status.code().unwrap_or(-1);
-    let signal = status.signal();
+    let exit = wait.map_err(|_| io::Error::other("reaper waiter dropped"))?;
 
     #[allow(clippy::cast_possible_truncation)]
     let duration_ms = spawn_t0.elapsed().as_millis() as u64;
@@ -253,46 +266,8 @@ async fn send_exit(
     bux_proto::send(
         w,
         &ExecOut::Exit {
-            code,
-            signal,
-            timed_out: timed_out.load(Ordering::SeqCst),
-            duration_ms,
-            error_message: None,
-        },
-    )
-    .await
-}
-
-/// Waits for a process by PID (PTY mode) and sends `ExecOut::Exit`.
-async fn send_exit_by_pid(
-    w: &mut (impl AsyncWrite + Unpin + Send),
-    pid: i32,
-    spawn_t0: Instant,
-    timed_out: &AtomicBool,
-) -> io::Result<()> {
-    use nix::sys::wait::{WaitStatus, waitpid};
-    use nix::unistd::Pid;
-
-    let wait_result = tokio::task::spawn_blocking(move || waitpid(Pid::from_raw(pid), None))
-        .await
-        .map_err(io::Error::other)?;
-
-    let (code, signal) = match wait_result {
-        Ok(WaitStatus::Exited(_, c)) => (c, None),
-        Ok(WaitStatus::Signaled(_, sig, _)) => (0, Some(sig as i32)),
-        // ECHILD: already reaped (SIG_IGN on SIGCHLD).
-        Err(nix::errno::Errno::ECHILD) => (0, None),
-        Ok(_) | Err(_) => (-1, None),
-    };
-
-    #[allow(clippy::cast_possible_truncation)]
-    let duration_ms = spawn_t0.elapsed().as_millis() as u64;
-
-    bux_proto::send(
-        w,
-        &ExecOut::Exit {
-            code,
-            signal,
+            code: exit.code,
+            signal: exit.signal,
             timed_out: timed_out.load(Ordering::SeqCst),
             duration_ms,
             error_message: None,
@@ -321,9 +296,6 @@ pub(crate) fn resolve_credentials(req: &ExecStart) -> io::Result<Credentials> {
 }
 
 /// Applies common exec options (cwd, env, credentials) to a command.
-///
-/// Works with both `std::process::Command` and `tokio::process::Command`
-/// since they share the same method signatures for env/cwd/pre_exec.
 ///
 /// `$credentials` is [`Credentials`] from [`resolve_credentials`].
 macro_rules! apply_exec_options {

--- a/crates/bux-guest/src/exec/pty.rs
+++ b/crates/bux-guest/src/exec/pty.rs
@@ -8,6 +8,9 @@ use std::process::{Command, Stdio};
 use bux_proto::{ExecStart, TtyConfig};
 use nix::pty::{OpenptyResult, Winsize, openpty};
 use nix::unistd::dup;
+use tokio::sync::oneshot;
+
+use crate::reaper::{Exit, Reaper};
 
 /// Handle to a process spawned with a PTY.
 pub struct PtyHandle {
@@ -17,6 +20,8 @@ pub struct PtyHandle {
     pub master_read: tokio::fs::File,
     /// Async writer for the PTY master (child's stdin).
     pub master_write: tokio::fs::File,
+    /// Completes when the reaper observes this child's exit.
+    pub exit: oneshot::Receiver<Exit>,
     /// Raw fd of the PTY master, kept alive for `TIOCSWINSZ`.
     master_fd: OwnedFd,
 }
@@ -45,7 +50,12 @@ impl PtyHandle {
 /// The child gets a new session (`setsid`) and the PTY slave becomes its
 /// controlling terminal (`TIOCSCTTY`). In PTY mode, stdout and stderr are
 /// merged into a single stream through the PTY master.
-pub fn spawn(req: &ExecStart) -> io::Result<PtyHandle> {
+///
+/// # Errors
+///
+/// Returns an error if the PTY cannot be opened, credentials cannot be
+/// resolved, or the child fails to spawn.
+pub fn spawn(req: &ExecStart, reaper: &Reaper) -> io::Result<PtyHandle> {
     let Some(tty) = req.tty.as_ref() else {
         return Err(io::Error::other("tty config required for PTY spawn"));
     };
@@ -107,10 +117,11 @@ pub fn spawn(req: &ExecStart) -> io::Result<PtyHandle> {
         });
     }
 
-    let child = cmd.spawn()?;
+    let spawned = reaper.spawn(&mut cmd)?;
 
     #[allow(clippy::cast_possible_wrap)]
-    let pid = child.id() as i32;
+    let pid = spawned.child.id() as i32;
+    drop(spawned.child);
 
     // Close slave in parent — child has its own copies after fork.
     drop(slave);
@@ -119,15 +130,11 @@ pub fn spawn(req: &ExecStart) -> io::Result<PtyHandle> {
     let read_fd = dup_fd(&master, "master_read")?;
     let write_fd = dup_fd(&master, "master_write")?;
 
-    let master_read =
-        tokio::fs::File::from_std(unsafe { std::fs::File::from_raw_fd(read_fd.into_raw_fd()) });
-    let master_write =
-        tokio::fs::File::from_std(unsafe { std::fs::File::from_raw_fd(write_fd.into_raw_fd()) });
-
     Ok(PtyHandle {
         pid,
-        master_read,
-        master_write,
+        master_read: super::file_from_stdio(read_fd),
+        master_write: super::file_from_stdio(write_fd),
+        exit: spawned.exit,
         master_fd: master,
     })
 }

--- a/crates/bux-guest/src/lib.rs
+++ b/crates/bux-guest/src/lib.rs
@@ -19,22 +19,21 @@
     reason = "guest agent binary runs as PID 1 inside a disposable VM: tight syscall paths, panic→exit semantics, and internal-only modules justify these relaxations"
 )]
 
-#[cfg(not(target_os = "linux"))]
-fn main() {
-    eprintln!("bux-guest only runs inside a Linux micro-VM");
-    std::process::exit(1);
-}
-
 #[cfg(target_os = "linux")]
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
-    std::panic::set_hook(Box::new(|info| {
-        eprintln!("[bux-guest] PANIC: {info}");
-        std::process::exit(1);
-    }));
-
-    if let Err(e) = bux_guest::server::run().await {
-        eprintln!("[bux-guest] fatal: {e}");
-        std::process::exit(1);
-    }
-}
+mod ca_trust;
+#[cfg(target_os = "linux")]
+mod control;
+#[cfg(target_os = "linux")]
+mod exec;
+#[cfg(target_os = "linux")]
+mod files;
+#[cfg(target_os = "linux")]
+mod mounts;
+#[cfg(target_os = "linux")]
+mod network;
+#[cfg(target_os = "linux")]
+pub mod reaper;
+#[cfg(target_os = "linux")]
+pub mod server;
+#[cfg(target_os = "linux")]
+mod user;

--- a/crates/bux-guest/src/reaper.rs
+++ b/crates/bux-guest/src/reaper.rs
@@ -1,0 +1,167 @@
+//! Exclusive `waitpid(-1, WNOHANG)` child reaper for PID 1.
+
+use std::collections::HashMap;
+use std::io;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use nix::sys::wait::{WaitPidFlag, WaitStatus, waitpid};
+use tokio::signal::unix::{Signal, SignalKind, signal};
+use tokio::sync::oneshot;
+
+/// PID 1 child reaper. Clone is cheap (`Arc`).
+#[derive(Clone, Debug)]
+pub struct Reaper {
+    /// Shared waiter table and reap lock.
+    inner: Arc<Mutex<Inner>>,
+}
+
+/// Map of watched pids to oneshot senders.
+#[derive(Debug)]
+struct Inner {
+    /// Registered waiters; unknown pids are orphans.
+    waiters: HashMap<u32, oneshot::Sender<Exit>>,
+}
+
+/// Wait status for one child. `code` is `0..=255` or `128+sig`.
+#[derive(Clone, Copy, Debug)]
+pub struct Exit {
+    /// Child pid as returned by spawn.
+    pub pid: u32,
+    /// Exit code, or `128 + signal` if killed by a signal.
+    pub code: i32,
+    /// Terminating signal number, if any.
+    pub signal: Option<i32>,
+}
+
+/// Result of [`Reaper::spawn`]: pipes still on `child`; status on `exit`.
+#[derive(Debug)]
+pub struct Spawned {
+    /// Child process; drop after taking stdio. Drop does not `waitpid`.
+    pub child: std::process::Child,
+    /// Completes when the reaper observes this child's exit.
+    pub exit: oneshot::Receiver<Exit>,
+}
+
+impl Reaper {
+    /// Install the SIGCHLD handler and spawn the drain task. Once per process.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the SIGCHLD handler cannot be registered.
+    pub fn start() -> io::Result<Self> {
+        let inner = Arc::new(Mutex::new(Inner {
+            waiters: HashMap::new(),
+        }));
+        let sig = signal(SignalKind::child())?;
+        tokio::spawn(drain_sigchld(sig, Arc::clone(&inner)));
+        Ok(Self { inner })
+    }
+
+    /// Fork/exec with the reap lock held so a concurrent SIGCHLD drain cannot
+    /// discard this pid as an orphan before it is in `waiters`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `cmd` fails to spawn.
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "mutex must be held across spawn, insert, and drain"
+    )]
+    pub fn spawn(&self, cmd: &mut std::process::Command) -> io::Result<Spawned> {
+        let mut g = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        reap(&mut g);
+        let child = cmd.spawn()?;
+        let pid = child.id();
+        let (tx, rx) = oneshot::channel();
+        g.waiters.insert(pid, tx);
+        reap(&mut g); // child already a zombie between fork and insert
+        Ok(Spawned { child, exit: rx })
+    }
+
+    /// Spawn a child with no waiter. The reaper treats it as an orphan.
+    ///
+    /// Tests use this; production exec does not. Do not `waitpid` in the caller.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `cmd` fails to spawn.
+    #[allow(
+        clippy::unused_self,
+        reason = "method form matches spawn; unwatched children still belong to this reaper"
+    )]
+    pub fn spawn_unwatched(&self, cmd: &mut std::process::Command) -> io::Result<u32> {
+        let child = cmd.spawn()?;
+        Ok(child.id())
+        // std::process::Child drop does not waitpid.
+    }
+}
+
+/// SIGCHLD task: drain zombies until the signal stream ends.
+async fn drain_sigchld(mut sig: Signal, inner: Arc<Mutex<Inner>>) {
+    loop {
+        let Some(()) = sig.recv().await else {
+            break;
+        };
+        reap_locked(&inner);
+    }
+}
+
+/// Drain `waitpid` while holding `inner`.
+fn reap_locked(inner: &Arc<Mutex<Inner>>) {
+    let mut g = inner.lock().unwrap_or_else(PoisonError::into_inner);
+    reap(&mut g);
+}
+
+/// Non-blocking `waitpid(-1)` until `ECHILD` or `StillAlive`.
+fn reap(inner: &mut Inner) {
+    loop {
+        match waitpid(None, Some(WaitPidFlag::WNOHANG)) {
+            Ok(WaitStatus::StillAlive) | Err(nix::errno::Errno::ECHILD) => break,
+            Err(nix::errno::Errno::EINTR) => {} // do not stop the PID 1 reaper
+            Ok(st) => {
+                let Some((pid, exit)) = decode(st) else {
+                    continue;
+                };
+                let Some(tx) = inner.waiters.remove(&pid) else {
+                    continue;
+                };
+                let _ = tx.send(exit);
+            }
+            Err(e) => {
+                eprintln!("[bux-guest] reaper waitpid: {e}");
+                break;
+            }
+        }
+    }
+}
+
+/// Map an exit/signal wait status to [`Exit`]. Job-control statuses are ignored.
+const fn decode(st: WaitStatus) -> Option<(u32, Exit)> {
+    match st {
+        WaitStatus::Exited(pid, code) => {
+            let pid = pid.as_raw().cast_unsigned();
+            Some((
+                pid,
+                Exit {
+                    pid,
+                    code,
+                    signal: None,
+                },
+            ))
+        }
+        WaitStatus::Signaled(pid, sig, _) => {
+            let pid = pid.as_raw().cast_unsigned();
+            let s = sig as i32;
+            Some((
+                pid,
+                Exit {
+                    pid,
+                    code: 128 + s,
+                    signal: Some(s),
+                },
+            ))
+        }
+        // Stopped / Continued / PtraceEvent / PtraceSyscall: not an exit.
+        _ => None,
+    }
+}

--- a/crates/bux-guest/src/server.rs
+++ b/crates/bux-guest/src/server.rs
@@ -14,6 +14,7 @@ use crate::exec;
 use crate::files;
 use crate::mounts;
 use crate::network;
+use crate::reaper::Reaper;
 
 /// Boot timestamp, set once at agent startup.
 pub static BOOT_T0: OnceLock<Instant> = OnceLock::new();
@@ -24,13 +25,14 @@ pub fn uptime_ms() -> u64 {
     BOOT_T0.get().map_or(0, |t| t.elapsed().as_millis() as u64)
 }
 
-/// Entry point: tmpfs, net, MITM CA, virtio-fs volumes, then vsock listen.
+/// Entry point: tmpfs, boot config, net, MITM CA, virtio-fs, reaper, then vsock listen.
+///
+/// # Errors
+///
+/// Returns an error if boot, network, CA, virtiofs, reaper start, or vsock listen fails.
 pub async fn run() -> io::Result<()> {
     BOOT_T0.set(Instant::now()).ok();
     eprintln!("[bux-guest] T+0ms: starting");
-
-    // PID 1 duty: auto-reap zombie children.
-    unsafe { libc::signal(libc::SIGCHLD, libc::SIG_IGN) };
 
     mounts::mount_essential_tmpfs();
     eprintln!("[bux-guest] T+{}ms: tmpfs mounted", uptime_ms());
@@ -80,6 +82,8 @@ pub async fn run() -> io::Result<()> {
         );
     }
 
+    let reaper = Reaper::start()?;
+
     let addr = tokio_vsock::VsockAddr::new(libc::VMADDR_CID_ANY, AGENT_PORT);
     let listener =
         VsockListener::bind(addr).map_err(|e| io::Error::new(io::ErrorKind::AddrInUse, e))?;
@@ -90,8 +94,9 @@ pub async fn run() -> io::Result<()> {
 
     loop {
         let (stream, _addr) = listener.accept().await?;
+        let reaper = reaper.clone();
         tokio::spawn(async move {
-            if let Err(e) = session(stream).await {
+            if let Err(e) = session(stream, reaper).await {
                 eprintln!("[bux-guest] session error: {e}");
             }
         });
@@ -99,7 +104,7 @@ pub async fn run() -> io::Result<()> {
 }
 
 /// Dispatches a single connection based on its [`Hello`] message.
-async fn session(stream: tokio_vsock::VsockStream) -> io::Result<()> {
+async fn session(stream: tokio_vsock::VsockStream, reaper: Reaper) -> io::Result<()> {
     let (reader, writer) = tokio::io::split(stream);
     let mut r = BufReader::new(reader);
     let mut w = BufWriter::new(writer);
@@ -129,7 +134,7 @@ async fn session(stream: tokio_vsock::VsockStream) -> io::Result<()> {
             w.flush().await?;
             control::handle(&mut r, &mut w).await
         }
-        Hello::Exec(req) => exec::handle(&mut r, &mut w, req).await,
+        Hello::Exec(req) => exec::handle(&mut r, &mut w, req, reaper).await,
         Hello::FileRead { path } => {
             bux_proto::send(&mut w, &HelloAck::Ready).await?;
             w.flush().await?;

--- a/crates/bux-guest/tests/reaper.rs
+++ b/crates/bux-guest/tests/reaper.rs
@@ -1,0 +1,117 @@
+//! Reaper integration: exclusive waitpid demux, signaled encoding, orphan reap.
+
+#![allow(
+    unused_crate_dependencies,
+    clippy::tests_outside_test_module,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "linux-only integration test binary"
+)]
+#![cfg(target_os = "linux")]
+
+use std::io;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use bux_guest::reaper::{Exit, Reaper, Spawned};
+use tokio::sync::oneshot;
+
+/// `sh -c` with stdio discarded.
+fn sh(script: &str) -> Command {
+    let mut cmd = Command::new("sh");
+    cmd.arg("-c")
+        .arg(script)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    cmd
+}
+
+/// Await a reaper oneshot with a 2s timeout.
+async fn wait_exit(rx: oneshot::Receiver<Exit>) -> Exit {
+    tokio::time::timeout(Duration::from_secs(2), rx)
+        .await
+        .expect("timeout waiting for child exit")
+        .expect("reaper dropped waiter")
+}
+
+/// Drop the child and return its waiter.
+fn take_exit(spawned: Spawned) -> oneshot::Receiver<Exit> {
+    spawned.exit
+}
+
+/// True when the unwatched child is gone (`/proc` or `kill(pid, 0)`).
+fn orphan_gone(pid: u32) -> bool {
+    if std::path::Path::new("/proc").is_dir() {
+        return !std::path::Path::new(&format!("/proc/{pid}")).exists();
+    }
+    let raw = nix::unistd::Pid::from_raw(pid.cast_signed());
+    nix::sys::signal::kill(raw, None) == Err(nix::errno::Errno::ESRCH)
+}
+
+/// Poll until `pid` is reaped. Must `.await` so the current-thread reaper runs.
+async fn wait_orphan_gone(pid: u32) {
+    loop {
+        if orphan_gone(pid) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Sequential cases: exit codes, demux, signaled encoding, orphan reap.
+#[tokio::test(flavor = "current_thread")]
+async fn reaper_reports_exit_codes_and_reaps_orphans() {
+    let reaper = Reaper::start().expect("Reaper::start");
+
+    // 1. exit 42
+    let mut cmd_42 = sh("exit 42");
+    let spawned_42 = match reaper.spawn(&mut cmd_42) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            eprintln!("skipping: sh not found");
+            return;
+        }
+        Err(e) => panic!("spawn sh: {e}"),
+    };
+    let exit_42 = wait_exit(take_exit(spawned_42)).await;
+    assert_eq!(exit_42.code, 42);
+    assert_eq!(exit_42.signal, None);
+
+    // 2. true / exit 0
+    let mut cmd_true = sh("exit 0");
+    let spawned_true = reaper.spawn(&mut cmd_true).expect("spawn exit 0");
+    let exit_true = wait_exit(take_exit(spawned_true)).await;
+    assert_eq!(exit_true.code, 0);
+    assert_eq!(exit_true.signal, None);
+
+    // 3. concurrent demux
+    let mut cmd3 = sh("exit 3");
+    let spawned_3 = reaper.spawn(&mut cmd3).expect("spawn exit 3");
+    let mut cmd5 = sh("exit 5");
+    let spawned_5 = reaper.spawn(&mut cmd5).expect("spawn exit 5");
+    let pid3 = spawned_3.child.id();
+    let pid5 = spawned_5.child.id();
+    let exit_3 = wait_exit(take_exit(spawned_3)).await;
+    let exit_5 = wait_exit(take_exit(spawned_5)).await;
+    assert_eq!(exit_3.pid, pid3);
+    assert_eq!(exit_3.code, 3);
+    assert_eq!(exit_5.pid, pid5);
+    assert_eq!(exit_5.code, 5);
+
+    // 4. SIGKILL → 128+9
+    let mut cmd_kill = sh("kill -s KILL $$");
+    let spawned_kill = reaper.spawn(&mut cmd_kill).expect("spawn kill");
+    let exit_kill = wait_exit(take_exit(spawned_kill)).await;
+    assert_eq!(exit_kill.signal, Some(9));
+    assert_eq!(exit_kill.code, 137);
+
+    // 5. unwatched orphan is reaped (poll must .await so the reaper task runs)
+    let mut cmd_orphan = sh("exit 0");
+    let orphan_pid = reaper
+        .spawn_unwatched(&mut cmd_orphan)
+        .expect("spawn_unwatched");
+    tokio::time::timeout(Duration::from_secs(2), wait_orphan_gone(orphan_pid))
+        .await
+        .expect("orphan still present; reaper not polled or not reaping");
+}

--- a/crates/bux-guest/tests/sig_ign_waitpid.rs
+++ b/crates/bux-guest/tests/sig_ign_waitpid.rs
@@ -1,0 +1,50 @@
+//! Kernel contract: `SIG_IGN` on `SIGCHLD` makes `waitpid` return `ECHILD`.
+//!
+//! Isolated process so it cannot poison tokio's SIGCHLD handler or steal
+//! `waitpid(-1)` from the reaper test binary.
+
+#![allow(
+    unused_crate_dependencies,
+    unsafe_code,
+    clippy::tests_outside_test_module,
+    clippy::panic,
+    reason = "linux-only kernel-contract test; SIG_IGN via libc::signal"
+)]
+#![cfg(target_os = "linux")]
+
+use std::io;
+use std::process::{Command, Stdio};
+
+use nix::sys::wait::waitpid;
+use nix::unistd::Pid;
+
+/// `waitpid(pid)` returns `ECHILD` after `SIG_IGN` on `SIGCHLD`.
+#[test]
+fn sig_ign_waitpid_returns_echild() {
+    // SAFETY: dedicated test process; POSIX `signal(SIGCHLD, SIG_IGN)`.
+    unsafe {
+        libc::signal(libc::SIGCHLD, libc::SIG_IGN);
+    }
+
+    let child = match Command::new("sh")
+        .args(["-c", "exit 42"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            eprintln!("skipping: sh not found");
+            return;
+        }
+        Err(e) => panic!("spawn sh: {e}"),
+    };
+
+    let pid = Pid::from_raw(child.id().cast_signed());
+    let result = waitpid(pid, None);
+    assert!(
+        matches!(result, Err(nix::errno::Errno::ECHILD)),
+        "expected ECHILD under SIG_IGN, got {result:?}"
+    );
+}


### PR DESCRIPTION
## Summary
Replace SIG_IGN with an exclusive waitpid(-1, WNOHANG) reaper started after MITM CA. Pipe and PTY send real ExecOut::Exit. Fixes #87.

Linux tests: tests/sig_ign_waitpid.rs and tests/reaper.rs. Darwin: 0 tests, compiles.

Depends on PR3 in stack 8120de4a. Independent of native Release assets.

## Test plan
- [x] cargo test -p bux-guest (Darwin 0 tests)
- [x] clippy -p bux-guest including --target aarch64-unknown-linux-gnu
- [ ] Linux CI cargo test --workspace includes guest binaries