### PR TITLE
fix: make guest PID 1 executable in ext4 (#108)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,7 @@ jobs:
           export "$env_var=musl-gcc"
           cargo build --release --target "${{ matrix.guest_target }}" -p bux-guest
           cp "target/${{ matrix.guest_target }}/release/bux-guest" "bux-guest-${{ matrix.guest_target }}"
+          chmod 0755 "bux-guest-${{ matrix.guest_target }}"
           file "bux-guest-${{ matrix.guest_target }}"
           arch="${{ matrix.guest_target }}"
           arch="${arch%%-*}"
@@ -171,6 +172,7 @@ jobs:
             exit 1
           fi
           cp "$guest_src" "$staging/"
+          chmod 0755 "$staging/bux-guest-$guest_target"
 
           if [[ "$target" == *apple-darwin* ]]; then
             krun_files="libkrun.dylib libkrunfw.dylib libkrun.1.dylib libkrunfw.5.dylib"
@@ -306,6 +308,7 @@ jobs:
                   sys.exit(1)
           sys.exit(0)
           PY
+          chmod 0755 bux-guest-x86_64-unknown-linux-musl bux-guest-aarch64-unknown-linux-musl
 
       - uses: softprops/action-gh-release@v2
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,8 @@ Release download.
 
 `scripts/e2e/fetch-guest.sh` prefers the `guest-<sha>` Release asset, else
 polls the `guest-<triple>` workflow artifact for this `HEAD`, and copies the
-file next to `target/debug/bux`. Do not `gh run download -n bux-guest-*`.
+file next to `target/debug/bux`. Dest is `chmod 0755` after copy; the script
+exits 1 if not `-x`. Do not `gh run download -n bux-guest-*`.
 
 Pin `$BUX_E2E_IMAGE` if alpine wget/httpd is missing. There is no in-repo
 custom e2e image.

--- a/crates/bux-cli/build.rs
+++ b/crates/bux-cli/build.rs
@@ -108,6 +108,7 @@ fn copy_if_needed(source: &Path, dest: &Path) -> std::io::Result<()> {
         && dest_meta.len() == source_meta.len()
         && dest_meta.modified()? >= source_meta.modified()?
     {
+        chmod_executable(dest)?;
         return Ok(());
     }
 
@@ -115,11 +116,26 @@ fn copy_if_needed(source: &Path, dest: &Path) -> std::io::Result<()> {
         fs::create_dir_all(parent)?;
     }
     fs::copy(source, dest)?;
-    fs::set_permissions(dest, source_meta.permissions())?;
+    chmod_executable(dest)?;
     println!(
         "cargo:warning=staged guest binary {} -> {}",
         source.display(),
         dest.display()
     );
+    Ok(())
+}
+
+fn chmod_executable(dest: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dest, fs::Permissions::from_mode(0o755))?;
+        if fs::metadata(dest)?.permissions().mode() & 0o111 == 0 {
+            return Err(std::io::Error::other(format!(
+                "{} is not executable after staging",
+                dest.display()
+            )));
+        }
+    }
     Ok(())
 }

--- a/crates/bux-e2fs/src/ext4.rs
+++ b/crates/bux-e2fs/src/ext4.rs
@@ -414,6 +414,29 @@ impl Filesystem {
         }
     }
 
+    /// Looks up `path` relative to the filesystem root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if path conversion or the lookup fails.
+    pub fn namei(&self, path: &str) -> Result<u32> {
+        let c_path = str_to_cstring(path)?;
+        unsafe {
+            let mut ino: sys::ext2_ino_t = 0;
+            check(
+                "ext2fs_namei",
+                sys::ext2fs_namei(
+                    self.inner,
+                    sys::EXT2_ROOT_INO,
+                    sys::EXT2_ROOT_INO,
+                    c_path.as_ptr(),
+                    &raw mut ino,
+                ),
+            )?;
+            Ok(ino)
+        }
+    }
+
     /// Reads the on-disk inode structure for the given inode number.
     ///
     /// # Errors

--- a/crates/bux-e2fs/src/sys.rs
+++ b/crates/bux-e2fs/src/sys.rs
@@ -65,4 +65,13 @@ unsafe extern "C" {
     /// Idempotent — maps already loaded are left alone — and it installs the
     /// `write_bitmaps` callback so `ext2fs_close` flushes them to disk.
     pub fn ext2fs_read_bitmaps(fs: ext2_filsys) -> errcode_t;
+
+    /// Resolves `name` from `root`/`cwd` into an inode number.
+    pub fn ext2fs_namei(
+        fs: ext2_filsys,
+        root: ext2_ino_t,
+        cwd: ext2_ino_t,
+        name: *const ::core::ffi::c_char,
+        inode: *mut ext2_ino_t,
+    ) -> errcode_t;
 }

--- a/crates/bux/src/guest.rs
+++ b/crates/bux/src/guest.rs
@@ -79,7 +79,7 @@ impl ManagedGuestBinary {
     }
 
     pub(crate) fn versioned_cache_key(&self, base: &str) -> String {
-        format!("{base}-guest-{}", self.cache_key)
+        format!("{base}-guest-{}-x", self.cache_key)
     }
 
     pub(crate) const fn exec_path() -> &'static str {
@@ -97,6 +97,8 @@ impl ManagedGuestBinary {
     pub(crate) fn inject_into_rootfs(&self, rootfs: &Path) -> Result<()> {
         let dest = rootfs.join(Self::relative_path());
         if is_binary_up_to_date(&self.host_path, &dest)? {
+            #[cfg(unix)]
+            fs::set_permissions(&dest, fs::Permissions::from_mode(0o555))?;
             return Ok(());
         }
         if let Some(parent) = dest.parent() {
@@ -112,8 +114,44 @@ impl ManagedGuestBinary {
     }
 
     pub(crate) fn inject_into_disk(&self, image: &Path) -> Result<()> {
-        bux_e2fs::inject_file(image, &self.host_path, Self::relative_path())?;
+        let staged = stage_executable_copy(&self.host_path, image)?;
+        let _guard = UnlinkOnDrop(staged.clone());
+        bux_e2fs::inject_file(image, &staged, Self::relative_path())?;
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct UnlinkOnDrop(PathBuf);
+
+impl Drop for UnlinkOnDrop {
+    fn drop(&mut self) {
+        drop(fs::remove_file(&self.0));
+    }
+}
+
+fn stage_executable_copy(src: &Path, beside: &Path) -> Result<PathBuf> {
+    let dest = beside.with_extension("guest-inject");
+    if let Err(err) = fs::copy(src, &dest) {
+        drop(fs::remove_file(&dest));
+        return Err(err.into());
+    }
+    if let Err(err) = fs::set_permissions(&dest, fs::Permissions::from_mode(0o555)) {
+        drop(fs::remove_file(&dest));
+        return Err(err.into());
+    }
+    match fs::metadata(&dest) {
+        Ok(meta) if meta.permissions().mode() & 0o111 != 0 => Ok(dest),
+        Ok(_) => {
+            drop(fs::remove_file(&dest));
+            Err(Error::InvalidConfig(
+                "guest binary is not executable after staging".to_owned(),
+            ))
+        }
+        Err(err) => {
+            drop(fs::remove_file(&dest));
+            Err(err.into())
+        }
     }
 }
 
@@ -296,6 +334,11 @@ fn short_hash(data: &[u8]) -> String {
     out
 }
 
+// libext2fs getmntinfo is not thread-safe on macOS; tests that build images
+// must run serially.
+#[cfg(all(test, unix))]
+pub(crate) static EXT4_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Static Linux ELF for this host with a unique 16-byte tag at offset 64.
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "test helper")]
@@ -423,6 +466,7 @@ pub(crate) mod sidecar_env {
 )]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
 
     fn make_elf(machine: u16, with_interp: bool) -> Vec<u8> {
         let mut data = vec![0_u8; 128];
@@ -496,7 +540,106 @@ mod tests {
         };
         assert_eq!(
             guest.versioned_cache_key("rootfs-digest"),
-            "rootfs-digest-guest-deadbeefcafebabe"
+            "rootfs-digest-guest-deadbeefcafebabe-x"
+        );
+    }
+
+    #[test]
+    fn stage_executable_copy_sets_0555_from_0644() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("guest");
+        let beside = dir.path().join("image.raw.tmp");
+        fs::write(&src, test_static_guest_elf(b"STAGE-COPY-0555!")).unwrap();
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+        let dest = stage_executable_copy(&src, &beside).unwrap();
+        let mode = fs::metadata(&dest).unwrap().permissions().mode();
+        assert_ne!(mode & 0o111, 0, "staged copy must be executable");
+        assert_eq!(mode & 0o777, 0o555, "staged copy mode must be 0555");
+    }
+
+    #[test]
+    fn inject_into_rootfs_sets_0555_from_0644_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("guest");
+        fs::write(&src, test_static_guest_elf(b"ROOTFS-COPY-0555")).unwrap();
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+        let guest = ManagedGuestBinary::from_path(&src).unwrap();
+        guest.inject_into_rootfs(dir.path()).unwrap();
+        let dest = dir.path().join(ManagedGuestBinary::relative_path());
+        let mode = fs::metadata(&dest).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o555, "rootfs dest must be 0555");
+    }
+
+    #[test]
+    fn inject_into_rootfs_repairs_existing_0644_dest() {
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("guest");
+        let bytes = test_static_guest_elf(b"REPAIR-ROOTFS-OK");
+        fs::write(&src, &bytes).unwrap();
+        fs::set_permissions(&src, fs::Permissions::from_mode(0o644)).unwrap();
+        let dest = dir.path().join(ManagedGuestBinary::relative_path());
+        fs::create_dir_all(dest.parent().unwrap()).unwrap();
+        fs::copy(&src, &dest).unwrap();
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o644)).unwrap();
+        assert!(
+            is_binary_up_to_date(&src, &dest).unwrap(),
+            "precondition: dest is up to date so inject skips copy"
+        );
+        let guest = ManagedGuestBinary::from_path(&src).unwrap();
+        guest.inject_into_rootfs(dir.path()).unwrap();
+        let mode = fs::metadata(&dest).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o555,
+            "stale 0644 dest must be repaired to 0555"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "ext4 lock must outlive create_from_dir and namei"
+    )]
+    fn inject_into_disk_sets_ext4_inode_0555_from_0644_source() {
+        let _lock = EXT4_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let dir = tempfile::tempdir().unwrap();
+        let rootfs = dir.path().join("rootfs");
+        fs::create_dir(&rootfs).unwrap();
+        let image = dir.path().join("image.raw");
+        bux_e2fs::create_from_dir(&rootfs, &image, 64 * 1024 * 1024).unwrap();
+
+        let planted = dir.path().join("planted-guest");
+        fs::write(&planted, test_static_guest_elf(b"INODE-GATE-0555!")).unwrap();
+        fs::set_permissions(&planted, fs::Permissions::from_mode(0o644)).unwrap();
+
+        let guest = ManagedGuestBinary::from_path(&planted).unwrap();
+        guest.inject_into_disk(&image).unwrap();
+
+        let ext4 = bux_e2fs::Filesystem::open(&image).unwrap();
+        let ino = ext4.namei(ManagedGuestBinary::relative_path()).unwrap();
+        let inode = ext4.read_inode(ino).unwrap();
+        assert_eq!(
+            u32::from(inode.i_mode) & 0o777,
+            0o555,
+            "ext4 inode permission bits must be 0555"
+        );
+        assert_eq!(
+            u32::from(inode.i_mode) & 0o170_000,
+            0o100_000,
+            "ext4 inode must be a regular file"
+        );
+
+        let host_mode = fs::metadata(&planted).unwrap().permissions().mode();
+        assert_eq!(
+            host_mode & 0o777,
+            0o644,
+            "inject must not chmod the host planted file"
+        );
+        assert!(
+            !image.with_extension("guest-inject").exists(),
+            "sidecar *.guest-inject must be gone after inject_into_disk"
         );
     }
 

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -603,6 +603,7 @@ mod tests {
     use crate::state::VmConfig;
     use bux_oci::RegistryAuth;
     use std::fs;
+    use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
     use std::time::SystemTime;
@@ -1083,10 +1084,13 @@ mod tests {
     #[test]
     #[allow(
         clippy::significant_drop_tightening,
-        reason = "env lock must outlive create_managed_base"
+        reason = "env lock then ext4 lock must outlive create_managed_base and namei"
     )]
     fn create_managed_base_uses_runtime_guest_path_not_path_decoy() {
         let mut env = crate::guest::sidecar_env::lock();
+        let _ext4 = crate::guest::EXT4_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let planted_bytes = crate::guest::test_static_guest_elf(b"PLANT-GUEST-ELF!");
         let decoy_bytes = crate::guest::test_static_guest_elf(b"DECOY-GUEST-ELF!");
 
@@ -1094,6 +1098,7 @@ mod tests {
         let planted = files.path().join("planted-guest");
         let decoy = files.path().join("decoy-guest");
         fs::write(&planted, &planted_bytes).unwrap();
+        fs::set_permissions(&planted, fs::Permissions::from_mode(0o644)).unwrap();
         fs::write(&decoy, &decoy_bytes).unwrap();
 
         let decoy_bin = tempfile::tempdir().unwrap();
@@ -1128,6 +1133,16 @@ mod tests {
                 .windows(decoy_bytes.len())
                 .all(|w| w != decoy_bytes.as_slice()),
             "ext4 image must not contain the PATH decoy guest ELF"
+        );
+        let ext4 = bux_e2fs::Filesystem::open(&image).unwrap();
+        let ino = ext4
+            .namei(crate::guest::ManagedGuestBinary::relative_path())
+            .unwrap();
+        let inode = ext4.read_inode(ino).unwrap();
+        assert_eq!(
+            u32::from(inode.i_mode) & 0o777,
+            0o555,
+            "managed-base guest inode must be 0555"
         );
     }
 }

--- a/scripts/e2e/fetch-guest.sh
+++ b/scripts/e2e/fetch-guest.sh
@@ -82,6 +82,11 @@ install_from() {
   fi
   mkdir -p "${ROOT}/target/debug"
   cp "${src}" "${dest}"
+  chmod 0755 "${dest}"
+  if [[ ! -x "${dest}" ]]; then
+    echo "failed to make ${dest} executable" >&2
+    exit 1
+  fi
   echo "export BUX_GUEST_PATH=${dest}"
   exit 0
 }

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -122,6 +122,8 @@ pin_full_guest() {
       cp "${ROOT}/target/${musl_triple}/debug/bux-guest" \
         "${ROOT}/target/debug/bux-guest-${musl_triple}"
       guest="${ROOT}/target/debug/bux-guest-${musl_triple}"
+      chmod 0755 "${guest}"
+      [[ -x "${guest}" ]] || full_guest_fail
       validate_guest_elf "${guest}" "${arch}" || full_guest_fail
     fi
   fi


### PR DESCRIPTION
Stage a 0555 copy beside the image before inject_file so a 0644
BUX_GUEST_PATH still yields inode 0100555. chmod 0755 on every
host staging dest (fetch-guest, CLI copy_if_needed skip, CD, smoke
local musl). Cache key suffix -x so 0644-injected bases miss.

Closes #108
