### PR TITLE
fix: unlink vsock sock on stop so restart add_vsock_port2 cannot EEXIST (#109)

### DIFF
--- a/crates/bux/src/runtime/boot/mod.rs
+++ b/crates/bux/src/runtime/boot/mod.rs
@@ -13,8 +13,8 @@ pub(super) use spawn::ShimSpawnResult;
 pub(crate) use spawn::spawn_config;
 pub(super) use spawn::spawn_shim;
 pub(super) use unix::{
-    clean_net_sock, clean_vm_files, is_pid_alive, prepare_virtio_net, shim_death_message,
-    wait_for_exit,
+    clean_net_sock, clean_vm_files, clean_vsock_sock, is_pid_alive, prepare_virtio_net,
+    shim_death_message, wait_for_exit,
 };
 
 use std::io;

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -15,7 +15,7 @@ use tracing::info;
 
 use super::super::{Runtime, Vm};
 use super::guest::{inject_guest_boot_env, prepare_managed_config};
-use super::unix::{clean_vm_files, prepare_virtio_net, reject_long_unix_path};
+use super::unix::{clean_vm_files, prepare_virtio_net, reject_long_unix_path, unlink_unix_socket};
 use crate::Result;
 use crate::disk::DiskFormat;
 use crate::secrets::{LiveSecrets, Secret};
@@ -325,6 +325,13 @@ pub(crate) fn spawn_shim(
     } else {
         Some(Box::new(bux_jail::NoopSandbox::default()))
     };
+
+    // leftover listen inode makes krun add_vsock_port2 EEXIST
+    for vs in &config.vsock_ports {
+        if vs.listen {
+            unlink_unix_socket(Path::new(&vs.path))?;
+        }
+    }
 
     let jail_config = JailConfig {
         rootfs: config.rootfs.as_deref().map(PathBuf::from),

--- a/crates/bux/src/runtime/boot/unix.rs
+++ b/crates/bux/src/runtime/boot/unix.rs
@@ -1,6 +1,7 @@
 //! Unix sockets, shim PID, and virtio-net JSON.
 
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::time::Duration;
 
@@ -49,9 +50,25 @@ pub(crate) fn shim_death_message(pid: i32, exit_file: &Path) -> String {
     format!("VM process (pid {pid}) died before ready: {detail}{stderr_hint}")
 }
 
+/// Unlink a Unix socket path. `NotFound` is success (already gone).
+pub(crate) fn unlink_unix_socket(path: &Path) -> io::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Best-effort unlink of the vsock listen path (`{id}.sock`).
+///
+/// Leftover inode makes the next `krun_add_vsock_port2` bind EEXIST (-17).
+pub(crate) fn clean_vsock_sock(socket: &Path) {
+    drop(unlink_unix_socket(socket));
+}
+
 /// Removes transient files associated with a VM socket path.
 pub(crate) fn clean_vm_files(socket: &Path) {
-    drop(fs::remove_file(socket));
+    clean_vsock_sock(socket);
     for ext in ["exit", "json", "stderr"] {
         drop(fs::remove_file(socket.with_extension(ext)));
     }
@@ -105,9 +122,7 @@ pub(crate) fn prepare_virtio_net(
 
     let socket_path = socks_dir.join(format!("{id}.net.sock"));
     reject_long_unix_path(&socket_path)?;
-    if socket_path.exists() {
-        fs::remove_file(&socket_path)?;
-    }
+    unlink_unix_socket(&socket_path)?;
 
     let network = ShimNetwork {
         socket_path,
@@ -196,5 +211,43 @@ mod tests {
         assert_eq!(net.connection, ShimNetConn::UnixDgram);
         #[cfg(not(target_os = "macos"))]
         assert_eq!(net.connection, ShimNetConn::UnixStream);
+    }
+
+    #[test]
+    fn clean_vsock_sock_unlinks_unix_socket_and_keeps_stderr() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("id.sock");
+        let stderr = sock.with_extension("stderr");
+        let json = sock.with_extension("json");
+        let exit = sock.with_extension("exit");
+        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        fs::write(&stderr, b"keep-me").unwrap();
+        fs::write(&json, b"{}").unwrap();
+        fs::write(&exit, b"{}").unwrap();
+
+        clean_vsock_sock(&sock);
+
+        assert!(
+            !sock.exists(),
+            "non-auto_remove stop must unlink vsock listen path"
+        );
+        assert!(stderr.exists(), "bux logs needs id.stderr after stop");
+        assert!(json.exists());
+        assert!(exit.exists());
+    }
+
+    #[test]
+    fn unlink_unix_socket_not_found_is_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        unlink_unix_socket(&dir.path().join("missing.sock")).unwrap();
+    }
+
+    #[test]
+    fn unlink_unix_socket_unlinks_listen_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("listen.sock");
+        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        unlink_unix_socket(&sock).unwrap();
+        assert!(!sock.exists());
     }
 }

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -911,6 +911,37 @@ mod tests {
     }
 
     #[test]
+    fn mark_stopped_non_auto_remove_unlinks_vsock_sock_keeps_stderr() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let id = "stopvsock000001";
+        insert_cfg(
+            &rt,
+            id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                auto_remove: false,
+                ..VmConfig::default()
+            },
+        );
+        let sock = rt.socks_dir.join(format!("{id}.sock"));
+        let stderr = sock.with_extension("stderr");
+        let _listener = std::os::unix::net::UnixListener::bind(&sock).unwrap();
+        fs::write(&stderr, b"shim-log").unwrap();
+
+        rt.get(id).unwrap().kill().unwrap();
+
+        assert!(
+            !sock.exists(),
+            "#109: non-auto_remove stop must unlink {id}.sock"
+        );
+        assert!(stderr.exists(), "bux logs after stop");
+        let row = rt.db.get_by_id_prefix(id).unwrap();
+        assert_eq!(row.status, Status::Stopped);
+    }
+
+    #[test]
     fn list_auto_remove_does_not_delete_name_colliding_with_id() {
         let dir = tempfile::tempdir().unwrap();
         let rt = Runtime::open(dir.path()).unwrap();

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -14,8 +14,8 @@ use tracing::info;
 
 use super::HealthStatus;
 use super::boot::{
-    clean_net_sock, clean_vm_files, inject_guest_boot_env, is_pid_alive, prepare_restart_config,
-    prepare_virtio_net, shim_death_message, spawn_shim, wait_for_exit,
+    clean_net_sock, clean_vm_files, clean_vsock_sock, inject_guest_boot_env, is_pid_alive,
+    prepare_restart_config, prepare_virtio_net, shim_death_message, spawn_shim, wait_for_exit,
 };
 use crate::Result;
 use crate::client::{Client, ExecHandle, ExecOutput, PongInfo};
@@ -783,6 +783,7 @@ impl Vm {
     /// `update_status(Stopped)` covers a pid row that already landed.
     fn revert_failed_start(&mut self, pid: i32) {
         signal::kill(Pid::from_raw(pid), Signal::SIGKILL).ok();
+        clean_vsock_sock(&self.state.socket);
         clean_net_sock(&self.state.socket);
         self.state.status = Status::Stopped;
         drop(self.db.update_status(&self.state.id, Status::Stopped));
@@ -792,6 +793,7 @@ impl Vm {
     /// deletes the VM record, socket, and disk image.
     fn mark_stopped(&mut self) -> Result<()> {
         self.state.status = Status::Stopped;
+        clean_vsock_sock(&self.state.socket);
         clean_net_sock(&self.state.socket);
 
         let uptime_ms = u64::try_from(self.spawned_at.elapsed().as_millis()).unwrap_or(u64::MAX);


### PR DESCRIPTION
Non-auto_remove mark_stopped left {id}.sock; libkrun bind then EEXIST.
Always clean_vsock_sock on stop; spawn bind-prep unlinks listen==true
vsock paths. Keep stderr for bux logs.

Closes #109
