### PR TITLE
fix: retry FULL egress wget until TAP DNS/TCP is forwarding

### DIFF
--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -7,6 +7,11 @@
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=wget_probe.sh
+source "${E2E_DIR}/wget_probe.sh"
+bash "${E2E_DIR}/wget_probe_test.sh"
+
 export BUX_HOME="${BUX_HOME:-$(mktemp -d /tmp/bux-e2e.XXXXXX)}"
 cleanup() {
   # Only touch the temp data dir this script created (name contains bux-e2e).
@@ -215,7 +220,10 @@ guest_wget_probe() {
 
 require_wget_ok() {
   local status
-  status="$(guest_wget_probe "$1" "$2")"
+  status="$(retry_until_needle WGET_OK 4 0.5 guest_wget_probe "$1" "$2")" || {
+    echo "$3: expected wget success, got ${status:-empty}"
+    return 1
+  }
   if [[ "${status}" != *WGET_OK* ]]; then
     echo "$3: expected wget success, got ${status:-empty}"
     return 1

--- a/scripts/e2e/wget_probe.sh
+++ b/scripts/e2e/wget_probe.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# WHY: vsock ready is not TAP DNS/TCP ready; one-shot wget races warmup.
+
+retry_until_needle() {
+  local needle="$1"
+  local max_attempts="$2"
+  local sleep_secs="$3"
+  shift 3
+  local i=0 status=""
+  while [ "${i}" -lt "${max_attempts}" ]; do
+    i=$((i + 1))
+    status="$("$@")" || return 1
+    if [[ "${status}" == *WGET_MISSING* ]]; then
+      echo "${status}"
+      return 0
+    fi
+    if [[ "${status}" == *"${needle}"* ]]; then
+      echo "${status}"
+      return 0
+    fi
+    if [ "${i}" -lt "${max_attempts}" ]; then
+      sleep "${sleep_secs}"
+    fi
+  done
+  echo "${status}"
+  return 0
+}

--- a/scripts/e2e/wget_probe_test.sh
+++ b/scripts/e2e/wget_probe_test.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=wget_probe.sh
+source "${HERE}/wget_probe.sh"
+SMOKE="${HERE}/smoke.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+T="$(mktemp -d)"
+trap 'rm -rf "${T}"' EXIT
+
+echo 0 >"${T}/fail_ok"
+echo 0 >"${T}/fail"
+echo 0 >"${T}/missing"
+
+inc() {
+  local f="$1" n
+  n="$(cat "${f}")"
+  n=$((n + 1))
+  echo "${n}" >"${f}"
+  echo "${n}"
+}
+
+mock_fail_then_ok() {
+  local n
+  n="$(inc "${T}/fail_ok")"
+  if [ "${n}" -lt 3 ]; then
+    echo WGET_FAIL
+    return 0
+  fi
+  echo WGET_OK
+}
+
+mock_always_fail() {
+  inc "${T}/fail" >/dev/null
+  echo WGET_FAIL
+}
+
+mock_missing_then_ok() {
+  local n
+  n="$(inc "${T}/missing")"
+  if [ "${n}" -eq 1 ]; then
+    echo WGET_MISSING
+    return 0
+  fi
+  echo WGET_OK
+}
+
+mock_transport() {
+  return 1
+}
+
+out="$(retry_until_needle WGET_OK 4 0 mock_fail_then_ok)"
+[[ "${out}" == *WGET_OK* ]] || fail "fail-then-ok: expected WGET_OK, got ${out:-empty}"
+
+rc=0
+out="$(retry_until_needle WGET_OK 2 0 mock_always_fail)" || rc=$?
+[[ "${out}" == *WGET_FAIL* ]] || fail "exhausted: expected WGET_FAIL, got ${out:-empty}"
+[ "${rc}" -eq 0 ] || fail "exhausted: helper rc=${rc} want 0"
+
+rc=0
+out="$(retry_until_needle WGET_OK 4 0 mock_missing_then_ok)" || rc=$?
+[[ "${out}" == *WGET_MISSING* ]] || fail "missing: expected WGET_MISSING, got ${out:-empty}"
+[ "$(cat "${T}/missing")" -eq 1 ] || fail "missing: retried ($(cat "${T}/missing"))"
+[ "${rc}" -eq 0 ] || fail "missing: helper rc=${rc} want 0"
+
+rc=0
+out="$(retry_until_needle WGET_OK 4 0 mock_transport)" || rc=$?
+[ "${rc}" -eq 1 ] || fail "transport: helper rc=${rc} want 1"
+[ -z "${out}" ] || fail "transport: expected empty stdout, got ${out}"
+
+grep -q 'retry_until_needle WGET_OK' "${SMOKE}" \
+  || fail "smoke.sh still one-shot require_wget_ok (no retry_until_needle WGET_OK)"
+
+echo OK


### PR DESCRIPTION
vsock Hello/Ack does not wait for TAP DNS/TCP. One-shot wget -T 10
races warmup (WGET_FAIL then leftover wget OK). Retry require_wget_ok
only; -T unchanged. Host test gates helper plus smoke wiring.

Closes #115
