### PR TITLE
fix: wait for TAP DNS/TCP on FULL egress wget fast-fail

### DIFF
--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -220,7 +220,7 @@ guest_wget_probe() {
 
 require_wget_ok() {
   local status
-  status="$(retry_until_needle WGET_OK 4 0.5 guest_wget_probe "$1" "$2")" || {
+  status="$(retry_until_needle WGET_OK "${WGET_OK_DEADLINE_SECS}" "${WGET_OK_SLEEP_SECS}" guest_wget_probe "$1" "$2")" || {
     echo "$3: expected wget success, got ${status:-empty}"
     return 1
   }

--- a/scripts/e2e/wget_probe.sh
+++ b/scripts/e2e/wget_probe.sh
@@ -1,14 +1,19 @@
 #!/usr/bin/env bash
-# WHY: vsock ready is not TAP DNS/TCP ready; one-shot wget races warmup.
+# WHY: wait_ready is vsock Hello/Ack. TAP DNS/TCP can still be cold.
+# Fast wget fail does not burn -T 10, so attempt count × 0.5s collapses.
+# Deadline is TAP wait even when each probe returns immediately.
+
+WGET_OK_DEADLINE_SECS=8
+WGET_OK_SLEEP_SECS=0.5
 
 retry_until_needle() {
   local needle="$1"
-  local max_attempts="$2"
+  local deadline_secs="$2"
   local sleep_secs="$3"
   shift 3
-  local i=0 status=""
-  while [ "${i}" -lt "${max_attempts}" ]; do
-    i=$((i + 1))
+  local status="" start now
+  start="$(date +%s)"
+  while :; do
     status="$("$@")" || return 1
     if [[ "${status}" == *WGET_MISSING* ]]; then
       echo "${status}"
@@ -18,10 +23,11 @@ retry_until_needle() {
       echo "${status}"
       return 0
     fi
-    if [ "${i}" -lt "${max_attempts}" ]; then
-      sleep "${sleep_secs}"
+    now="$(date +%s)"
+    if [ $((now - start)) -ge "${deadline_secs}" ]; then
+      echo "${status}"
+      return 0
     fi
+    sleep "${sleep_secs}"
   done
-  echo "${status}"
-  return 0
 }

--- a/scripts/e2e/wget_probe_test.sh
+++ b/scripts/e2e/wget_probe_test.sh
@@ -2,9 +2,10 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
-# shellcheck source=wget_probe.sh
-source "${HERE}/wget_probe.sh"
+HELPER="${HERE}/wget_probe.sh"
 SMOKE="${HERE}/smoke.sh"
+# shellcheck source=wget_probe.sh
+source "${HELPER}"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -15,8 +16,10 @@ T="$(mktemp -d)"
 trap 'rm -rf "${T}"' EXIT
 
 echo 0 >"${T}/fail_ok"
-echo 0 >"${T}/fail"
+echo 0 >"${T}/five"
+echo 0 >"${T}/fail_d0"
 echo 0 >"${T}/missing"
+echo 0 >"${T}/fail_wall"
 
 inc() {
   local f="$1" n
@@ -25,6 +28,8 @@ inc() {
   echo "${n}" >"${f}"
   echo "${n}"
 }
+
+FAIL_COUNTER=""
 
 mock_fail_then_ok() {
   local n
@@ -36,8 +41,18 @@ mock_fail_then_ok() {
   echo WGET_OK
 }
 
+mock_five_fail_then_ok() {
+  local n
+  n="$(inc "${T}/five")"
+  if [ "${n}" -le 5 ]; then
+    echo WGET_FAIL
+    return 0
+  fi
+  echo WGET_OK
+}
+
 mock_always_fail() {
-  inc "${T}/fail" >/dev/null
+  inc "${FAIL_COUNTER}" >/dev/null
   echo WGET_FAIL
 }
 
@@ -55,26 +70,62 @@ mock_transport() {
   return 1
 }
 
-out="$(retry_until_needle WGET_OK 4 0 mock_fail_then_ok)"
+rc=0
+out="$(retry_until_needle WGET_OK 8 0 mock_fail_then_ok)" || rc=$?
 [[ "${out}" == *WGET_OK* ]] || fail "fail-then-ok: expected WGET_OK, got ${out:-empty}"
+[ "${rc}" -eq 0 ] || fail "fail-then-ok: helper rc=${rc} want 0"
 
 rc=0
-out="$(retry_until_needle WGET_OK 2 0 mock_always_fail)" || rc=$?
-[[ "${out}" == *WGET_FAIL* ]] || fail "exhausted: expected WGET_FAIL, got ${out:-empty}"
-[ "${rc}" -eq 0 ] || fail "exhausted: helper rc=${rc} want 0"
+out="$(retry_until_needle WGET_OK 8 0 mock_five_fail_then_ok)" || rc=$?
+[[ "${out}" == *WGET_OK* ]] || fail "beyond-four: expected WGET_OK, got ${out:-empty}"
+[ "${rc}" -eq 0 ] || fail "beyond-four: helper rc=${rc} want 0"
+
+FAIL_COUNTER="${T}/fail_d0"
+rc=0
+out="$(retry_until_needle WGET_OK 0 0 mock_always_fail)" || rc=$?
+[[ "${out}" == *WGET_FAIL* ]] || fail "deadline=0: expected WGET_FAIL, got ${out:-empty}"
+[ "$(cat "${T}/fail_d0")" -eq 1 ] || fail "deadline=0: calls=$(cat "${T}/fail_d0") want 1"
+[ "${rc}" -eq 0 ] || fail "deadline=0: helper rc=${rc} want 0"
 
 rc=0
-out="$(retry_until_needle WGET_OK 4 0 mock_missing_then_ok)" || rc=$?
+out="$(retry_until_needle WGET_OK 8 0 mock_missing_then_ok)" || rc=$?
 [[ "${out}" == *WGET_MISSING* ]] || fail "missing: expected WGET_MISSING, got ${out:-empty}"
 [ "$(cat "${T}/missing")" -eq 1 ] || fail "missing: retried ($(cat "${T}/missing"))"
 [ "${rc}" -eq 0 ] || fail "missing: helper rc=${rc} want 0"
 
 rc=0
-out="$(retry_until_needle WGET_OK 4 0 mock_transport)" || rc=$?
+out="$(retry_until_needle WGET_OK 8 0 mock_transport)" || rc=$?
 [ "${rc}" -eq 1 ] || fail "transport: helper rc=${rc} want 1"
 [ -z "${out}" ] || fail "transport: expected empty stdout, got ${out}"
 
-grep -q 'retry_until_needle WGET_OK' "${SMOKE}" \
-  || fail "smoke.sh still one-shot require_wget_ok (no retry_until_needle WGET_OK)"
+[ "${WGET_OK_DEADLINE_SECS}" -eq 8 ] || fail "constants: WGET_OK_DEADLINE_SECS=${WGET_OK_DEADLINE_SECS} want 8"
+[ "${WGET_OK_DEADLINE_SECS}" -lt 10 ] || fail "constants: WGET_OK_DEADLINE_SECS=${WGET_OK_DEADLINE_SECS} want < 10"
+[ "${WGET_OK_DEADLINE_SECS}" -lt 30 ] || fail "constants: WGET_OK_DEADLINE_SECS=${WGET_OK_DEADLINE_SECS} want < 30"
+[ "${WGET_OK_SLEEP_SECS}" = "0.5" ] || fail "constants: WGET_OK_SLEEP_SECS=${WGET_OK_SLEEP_SECS} want 0.5"
+grep -q 'require_wget_ok "${NAME}" 10 "egress"' "${SMOKE}" \
+  || fail "constants: smoke.sh item 4 landmark missing"
+
+grep -q 'retry_until_needle WGET_OK "${WGET_OK_DEADLINE_SECS}"' "${SMOKE}" \
+  || fail "wiring: smoke.sh missing retry_until_needle WGET_OK with WGET_OK_DEADLINE_SECS"
+c="$(grep -c 'retry_until_needle WGET_OK' "${SMOKE}" || true)"
+[ "${c}" -eq 1 ] || fail "wiring: retry_until_needle WGET_OK count=${c} want 1"
+if grep -Eq 'retry_until_needle WGET_OK[[:space:]]+4[[:space:]]+0\.5' "${SMOKE}"; then
+  fail "wiring: smoke.sh still uses 4-attempt 0.5s retry"
+fi
+
+FAIL_COUNTER="${T}/fail_wall"
+t0="$(date +%s)"
+while [ "$(date +%s)" -eq "${t0}" ]; do
+  :
+done
+rc=0
+out="$(retry_until_needle WGET_OK 1 0 mock_always_fail)" || rc=$?
+[ "${rc}" -eq 0 ] || fail "wall-clock: helper rc=${rc} want 0"
+[ "$(cat "${T}/fail_wall")" -ge 3 ] || fail "wall-clock: calls=$(cat "${T}/fail_wall") want >= 3"
+
+grep -q 'date +%s' "${HELPER}" || fail "source: helper missing date +%s"
+if grep -Eq 'max_attempts|i -lt' "${HELPER}"; then
+  fail "source: helper still uses attempt-count loop"
+fi
 
 echo OK


### PR DESCRIPTION
## Summary

FULL item 4 on the #117+#118 tree (`c7971b8`) died with `WGET_FAIL` while leftover wget on the same VM later returned 200. `#117` retry (`4×0.5s`) is on that tree. wget failed **fast**, so four attempts collapse to ~2s of TAP wait.

`require_wget_ok` now uses an **8s deadline** (`WGET_OK_DEADLINE_SECS`) and 0.5s sleep. wget `-T` stays 10. `require_wget_fail` stays wget `-T` 3, one-shot. `wait_ready` stays vsock. Fast-fail TAP wait ≈8–8.5s. Worst wall ≈ deadline + one in-flight `-T` (≤ ~18s).

Host gate (`bash scripts/e2e/wget_probe_test.sh`, no `+x`) must fail a revert to 4×0.5, one-shot, or an 8-attempt helper (wait-for-tick wall-clock call-count; `"${HELPER}"` `date +%s` / no `max_attempts`/`i -lt`).

Do not close #116 from this PR. Operator FULL is out of this PR.

## Test plan

- [x] `bash scripts/e2e/wget_probe_test.sh`
- [x] `BUX_E2E_FULL=0 ./scripts/e2e/smoke.sh`
- [ ] Host CI `e2e-host.yml` (`BUX_E2E_FULL=0`) on this PR against `main`
- [ ] Operator `BUX_E2E_FULL=1` is **out of this PR**

Closes #119