### PR TITLE
docs: record first green BUX_E2E_FULL on local HVF

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,28 +111,36 @@ BUX_E2E_FULL=1 ./scripts/e2e/smoke.sh
 job. GitHub-hosted runners must not set `BUX_E2E_FULL=1`. Self-hosted runners
 can take it later without redesign.
 
-The first green FULL is recorded by the operator on **local HVF (Apple
-Silicon)**. Until this file contains that record, do not call the tree
-production-ready. KVM later without redesign.
+The first green FULL is recorded below on **local HVF (Apple Silicon)**.
+Host CI (`BUX_E2E_FULL=0`) is not that proof. KVM later without redesign.
 
 ### Layer 1 FULL record
 
-Empty. Fill from `./target/debug/bux` after a local HVF run. Do not invent values.
+Operator FULL 2026-08-28 local HVF (smoke START 2026-08-27T19:48:37Z UTC,
+`SMOKE_EXIT=0`, `OK (full e2e)`). Capture binary `./target/debug/bux` (not
+PATH `bux`). `$BUX_HOME` was `/Users/xu/bux-full-hvf-119` (no `bux-e2e`
+substring).
 
 | Field | Value |
 | ----- | ----- |
-| Date | |
-| uname | |
-| kern.hv_support | |
-| rustc | |
-| git | |
-| BUX_GUEST_PATH triple | |
-| ELF sha256 | |
-| host.virtualization | |
-| host.krun_features | |
-| host.mandatory_access_control | |
-| image reference | |
-| image digest | |
+| Date | 2026-08-28 |
+| uname | Darwin X-2.local 25.6.0 Darwin Kernel Version 25.6.0: Fri Jul 31 19:16:20 PDT 2026; root:xnu-12377.161.14~5/RELEASE_ARM64_T8142 arm64 |
+| kern.hv_support | 1 |
+| rustc | rustc 1.97.1 (8bab26f4f 2026-07-14) |
+| git | 42f02b0bbfe3c883417ad132f21e025afcc102a0 |
+| BUX_GUEST_PATH triple | aarch64-unknown-linux-musl |
+| ELF sha256 | 03ade6fffdc2d7968f5429a2257c14b9c42e2501d6fd14153a7500dceb2157d2 |
+| host.virtualization | true |
+| host.krun_features | ["net","blk"] |
+| host.mandatory_access_control | true |
+| image reference | docker.io/library/alpine:latest |
+| image digest | sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18 |
+
+Leftover sibling `BUX_GUEST_PATH` host mode **0644** is OK to record (inject
+0555 is #108 sidecar). Item 7 `NO_ETH0` sysfs still counts as offline proof.
+Item 5/7 wget-fail is unclassified; do not treat as HVF proof of
+`allow_net` / offline **policy**. This record is not GitHub-hosted
+`BUX_E2E_FULL=1`.
 
 Capture `.host.*` with `./target/debug/bux system info --format json` and image
 reference/digest with `./target/debug/bux images --format json`. Pin `$BUX_HOME`
@@ -192,8 +200,8 @@ OCI (`bux pull` / `bux create IMAGE`).
    restart must still survive CLI exit)
 10. secrets: value not in `bux.db` or guest `/proc/1/environ`
 
-Until that checklist is green on local HVF (Apple Silicon), do not call the
-tree production-ready.
+The Layer 1 record above is that green local HVF run. Host CI
+(`BUX_E2E_FULL=0`) is not that proof.
 
 Schema mismatches require `bux system reset` (or wiping `$BUX_HOME`).
 

--- a/docs/bux-redesign.md
+++ b/docs/bux-redesign.md
@@ -24,11 +24,12 @@ Spine:
 | D1 | Fixed: gvproxy in `bux-shim-bin`; `VmConfig.detach` gates parent-death |
 | D2 | Fixed in engine: `disable_implicit_vsock` + `add_vsock(0)`; **guest proof is FULL `offline-no-eth0`** |
 | D3 | Fixed in agent: virtiofs mount from `GuestBootConfig`; **guest proof is FULL volume ls** |
-| D4 | Open: FULL never recorded green |
+| D4 | Fixed: CONTRIBUTING Layer 1 |
 | D5 | Open: engine fix landed, guest proof pending |
 
-D1–D3 are complete in code. Production is a recorded green `BUX_E2E_FULL=1` on
-local HVF (Apple Silicon). Host CI (`BUX_E2E_FULL=0`) is not that proof.
+D1–D3 are complete in code. D4 is the recorded green `BUX_E2E_FULL=1` on local
+HVF (Apple Silicon) in CONTRIBUTING Layer 1. Host CI (`BUX_E2E_FULL=0`) is not
+that proof.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Operator `BUX_E2E_FULL=1` on local HVF exited 0 (`OK (full e2e)`) on tree `42f02b0` (#118 encoder + #120 8s TAP deadline). Capture binary `./target/debug/bux`. `$BUX_HOME=/Users/xu/bux-full-hvf-119`.

Fills CONTRIBUTING Layer 1 from that run. Marks D4 **Fixed**. D5 stays Open. Host CI `BUX_E2E_FULL=0` is still not that proof.

Honesty: leftover guest ELF host mode 0644 is recorded. Item 7 `NO_ETH0` sysfs still counts. Item 5/7 wget-fail is unclassified; not HVF proof of allow_net/offline policy. Not GitHub-hosted FULL=1.

## Test plan

- [x] Field values match `./target/debug/bux system info --format json` and `./target/debug/bux images --format json` from the green run
- [x] D5 still Open
- [x] No `e2e-host.yml` FULL=1
- [x] No addenda 11–16