### PR TITLE
test(e2e): FULL addenda copy/allow/snap/recover/nvol

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,14 @@ OCI (`bux pull` / `bux create IMAGE`).
 The Layer 1 record above is that green local HVF run. Host CI
 (`BUX_E2E_FULL=0`) is not that proof.
 
+Items 11–15 are not in the `42f02b0` Layer 1 row.
+
+11. copy: host↔guest file round-trip and directory `copy_in`
+12. `bux create --allow-net example.com --allow-net www.example.com` then wget example.com succeeds
+13. snapshot create / list / delete
+14. recover: dead shim inspect JSON `"Stopped"`, then `rm` without `-f`
+15. named-vol dir: `bux volume create` then bind `${BUX_HOME}/volumes/${NV}:/data`
+
 Schema mismatches require `bux system reset` (or wiping `$BUX_HOME`).
 
 ## Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,6 +274,7 @@ dependencies = [
  "libc",
  "serde_json",
  "tar",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/bux-cli/Cargo.toml
+++ b/crates/bux-cli/Cargo.toml
@@ -24,5 +24,8 @@ serde_json.workspace = true
 tar.workspace = true
 tokio = { workspace = true, features = ["io-std"] }
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/bux-cli/src/vm.rs
+++ b/crates/bux-cli/src/vm.rs
@@ -431,6 +431,14 @@ pub fn inspect(args: &InspectArgs) -> Result<()> {
     Ok(())
 }
 
+#[cfg(unix)]
+fn unpack_guest_tar(bytes: &[u8], dest: &std::path::Path) -> std::io::Result<()> {
+    let cursor = std::io::Cursor::new(bytes);
+    let mut archive = tar::Archive::new(cursor);
+    archive.unpack(dest)?;
+    Ok(())
+}
+
 /// Parses `vm:path` guest reference. Returns `(vm, guest_path)`.
 #[cfg(unix)]
 fn parse_guest_ref(s: &str) -> Option<(&str, &str)> {
@@ -452,9 +460,8 @@ pub async fn cp(args: CpArgs) -> Result<()> {
             let handle = rt.get(id)?;
             let tar_data = handle.copy_out(guest_path).await?;
             std::fs::create_dir_all(dst)?;
-            let cursor = std::io::Cursor::new(tar_data);
-            let mut archive = tar::Archive::new(cursor);
-            archive.unpack(dst)?;
+            // unpack → Entry::unpack_in skips ParentDir (workspace tar 0.4.46).
+            unpack_guest_tar(&tar_data, std::path::Path::new(dst))?;
         }
         // host → guest
         (None, Some((id, guest_path))) => {
@@ -689,4 +696,45 @@ unix_only_stub! {
     restart(args: RestartArgs);
     stats(args: StatsArgs);
     clone_box(args: CloneArgs);
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod unpack_guest_tar_tests {
+    use super::unpack_guest_tar;
+
+    #[test]
+    fn unpack_guest_tar_skips_parent_dir_member() {
+        const NAME: &[u8] = b"../outside.txt\0";
+        let dest_dir = tempfile::tempdir().expect("tempdir");
+        let dest = dest_dir.path();
+        let outside = dest.parent().expect("dest parent").join("outside.txt");
+
+        let mut buf = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut buf);
+            let mut header = tar::Header::new_gnu();
+            header.set_entry_type(tar::EntryType::Regular);
+            header.set_size(1);
+            header.set_mode(0o644);
+            // set_path rejects `..`; write the ustar name field so unpack_in sees ParentDir.
+            header
+                .as_old_mut()
+                .name
+                .get_mut(..NAME.len())
+                .expect("ustar name field fits ../outside.txt")
+                .copy_from_slice(NAME);
+            header.set_cksum();
+            builder
+                .append(&header, b"x".as_slice())
+                .expect("append ../outside.txt");
+            builder.finish().expect("finish tar");
+        }
+
+        unpack_guest_tar(&buf, dest).expect("unpack_guest_tar");
+        assert!(
+            !outside.exists(),
+            "ParentDir member must not land at dest.parent()/outside.txt"
+        );
+    }
 }

--- a/crates/bux-cli/src/vm.rs
+++ b/crates/bux-cli/src/vm.rs
@@ -439,6 +439,37 @@ fn unpack_guest_tar(bytes: &[u8], dest: &std::path::Path) -> std::io::Result<()>
     Ok(())
 }
 
+#[cfg(unix)]
+fn pack_dir_for_copy_in(src: &std::path::Path) -> std::io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    {
+        let mut ar = tar::Builder::new(&mut buf);
+        append_dir_tree(&mut ar, src, std::path::Path::new(""))?;
+        ar.finish()?;
+    }
+    Ok(buf)
+}
+
+#[cfg(unix)]
+fn append_dir_tree<W: std::io::Write>(
+    ar: &mut tar::Builder<W>,
+    src: &std::path::Path,
+    rel: &std::path::Path,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let child_rel = rel.join(entry.file_name());
+        let child_src = entry.path();
+        if entry.file_type()?.is_dir() {
+            ar.append_dir(&child_rel, &child_src)?;
+            append_dir_tree(ar, &child_src, &child_rel)?;
+        } else {
+            ar.append_path_with_name(&child_src, &child_rel)?;
+        }
+    }
+    Ok(())
+}
+
 /// Parses `vm:path` guest reference. Returns `(vm, guest_path)`.
 #[cfg(unix)]
 fn parse_guest_ref(s: &str) -> Option<(&str, &str)> {
@@ -468,12 +499,8 @@ pub async fn cp(args: CpArgs) -> Result<()> {
             let handle = rt.get(id)?;
             let meta = std::fs::metadata(src)?;
             if meta.is_dir() {
-                let mut buf = Vec::new();
-                {
-                    let mut ar = tar::Builder::new(&mut buf);
-                    ar.append_dir_all(".", src)?;
-                    ar.finish()?;
-                }
+                // leftover guest ELF denies CurDir-only `./`; do not pack that member.
+                let buf = pack_dir_for_copy_in(std::path::Path::new(src))?;
                 handle.copy_in(guest_path, &buf).await?;
             } else {
                 let data = std::fs::read(src)?;
@@ -701,7 +728,7 @@ unix_only_stub! {
 #[cfg(test)]
 #[cfg(unix)]
 mod unpack_guest_tar_tests {
-    use super::unpack_guest_tar;
+    use super::{pack_dir_for_copy_in, unpack_guest_tar};
 
     #[test]
     fn unpack_guest_tar_skips_parent_dir_member() {
@@ -736,5 +763,27 @@ mod unpack_guest_tar_tests {
             !outside.exists(),
             "ParentDir member must not land at dest.parent()/outside.txt"
         );
+    }
+
+    #[test]
+    fn pack_dir_for_copy_in_omits_curdir_member() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("x.txt"), b"ok\n").expect("write x.txt");
+        let bytes = pack_dir_for_copy_in(dir.path()).expect("pack");
+        let mut archive = tar::Archive::new(bytes.as_slice());
+        let mut saw_x = false;
+        for entry in archive.entries().expect("entries") {
+            let entry = entry.expect("entry");
+            let path = entry.path().expect("path").into_owned();
+            assert!(
+                path.components()
+                    .any(|c| matches!(c, std::path::Component::Normal(_))),
+                "must not pack CurDir-only member {path:?}"
+            );
+            if path.as_os_str() == "x.txt" {
+                saw_x = true;
+            }
+        }
+        assert!(saw_x, "packed dir must contain x.txt");
     }
 }

--- a/crates/bux-guest/src/files.rs
+++ b/crates/bux-guest/src/files.rs
@@ -212,6 +212,13 @@ pub(crate) fn copy_in_parent_under_dest(canonical_dest: &Path, entry: &Path) -> 
     {
         return Err(copy_in_traversal_blocked(entry));
     }
+    // append_dir_all(".", src) emits `./`; join drops CurDir so parent() is dest's parent.
+    if !entry
+        .components()
+        .any(|c| matches!(c, std::path::Component::Normal(_)))
+    {
+        return Ok(());
+    }
     let target = canonical_dest.join(entry);
     let parent = target.parent().unwrap_or(canonical_dest);
     let resolved = parent
@@ -283,6 +290,8 @@ mod copy_in_parent_tests {
     fn allows_direct_child() {
         with_canonical_dest(|dest| {
             copy_in_parent_under_dest(dest, Path::new("ok.txt")).expect("direct child under dest");
+            copy_in_parent_under_dest(dest, Path::new(".")).expect("dot archive member");
+            copy_in_parent_under_dest(dest, Path::new("./")).expect("dot-slash archive member");
         });
     }
 }

--- a/crates/bux-guest/src/files.rs
+++ b/crates/bux-guest/src/files.rs
@@ -103,16 +103,7 @@ pub async fn handle_copy_in(
         for raw_entry in archive.entries()? {
             let mut entry = raw_entry?;
             let path = entry.path()?.into_owned();
-            let target = canonical_dest.join(&path);
-            // Resolve symlinks in prefix only, not the final component.
-            if let Ok(resolved) = target.parent().unwrap_or(&canonical_dest).canonicalize()
-                && !resolved.starts_with(&canonical_dest)
-            {
-                return Err(io::Error::new(
-                    io::ErrorKind::PermissionDenied,
-                    format!("path traversal blocked: {}", path.display()),
-                ));
-            }
+            copy_in_parent_under_dest(&canonical_dest, &path)?;
             entry.unpack_in(&canonical_dest)?;
         }
         Ok(())
@@ -209,4 +200,89 @@ async fn recv_upload_to_file(
 fn temp_file_path(tag: &str) -> std::path::PathBuf {
     let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
     Path::new("/tmp").join(format!("bux-{tag}-{}-{seq}", std::process::id()))
+}
+
+/// Resolve the parent only: the leaf is created by unpack and may not exist.
+/// `canonicalize` failure is deny: a missing prefix must not skip the check.
+pub(crate) fn copy_in_parent_under_dest(canonical_dest: &Path, entry: &Path) -> io::Result<()> {
+    if entry.is_absolute()
+        || entry
+            .components()
+            .any(|c| matches!(c, std::path::Component::ParentDir))
+    {
+        return Err(copy_in_traversal_blocked(entry));
+    }
+    let target = canonical_dest.join(entry);
+    let parent = target.parent().unwrap_or(canonical_dest);
+    let resolved = parent
+        .canonicalize()
+        .map_err(|_| copy_in_traversal_blocked(entry))?;
+    if !resolved.starts_with(canonical_dest) {
+        return Err(copy_in_traversal_blocked(entry));
+    }
+    Ok(())
+}
+
+fn copy_in_traversal_blocked(entry: &Path) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        format!("path traversal blocked: {}", entry.display()),
+    )
+}
+
+#[cfg(test)]
+mod copy_in_parent_tests {
+    use super::*;
+
+    fn with_canonical_dest(f: impl FnOnce(&Path)) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let dest = dir.path().canonicalize().expect("canonicalize dest");
+        f(&dest);
+    }
+
+    #[test]
+    fn rejects_parent_dir_component() {
+        with_canonical_dest(|dest| {
+            let err = copy_in_parent_under_dest(dest, Path::new("../outside.txt"))
+                .expect_err(".. must fail closed");
+            assert_eq!(
+                err.kind(),
+                io::ErrorKind::PermissionDenied,
+                "expected PermissionDenied for ParentDir"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_absolute_member() {
+        with_canonical_dest(|dest| {
+            let err = copy_in_parent_under_dest(dest, Path::new("/etc/passwd"))
+                .expect_err("absolute member must fail closed");
+            assert_eq!(
+                err.kind(),
+                io::ErrorKind::PermissionDenied,
+                "expected PermissionDenied for absolute member"
+            );
+        });
+    }
+
+    #[test]
+    fn rejects_canonicalize_failure() {
+        with_canonical_dest(|dest| {
+            let err = copy_in_parent_under_dest(dest, Path::new("missing/x.txt"))
+                .expect_err("missing parent canonicalize must fail closed");
+            assert_eq!(
+                err.kind(),
+                io::ErrorKind::PermissionDenied,
+                "expected PermissionDenied when canonicalize fails"
+            );
+        });
+    }
+
+    #[test]
+    fn allows_direct_child() {
+        with_canonical_dest(|dest| {
+            copy_in_parent_under_dest(dest, Path::new("ok.txt")).expect("direct child under dest");
+        });
+    }
 }

--- a/crates/bux-guest/src/files.rs
+++ b/crates/bux-guest/src/files.rs
@@ -212,7 +212,7 @@ pub(crate) fn copy_in_parent_under_dest(canonical_dest: &Path, entry: &Path) -> 
     {
         return Err(copy_in_traversal_blocked(entry));
     }
-    // append_dir_all(".", src) emits `./`; join drops CurDir so parent() is dest's parent.
+    // CurDir-only `./`: join drops CurDir so parent() is dest's parent.
     if !entry
         .components()
         .any(|c| matches!(c, std::path::Component::Normal(_)))

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -353,6 +353,22 @@ test "${exit42_code}" -eq 42
 test "${pty_true_code}" -eq 0
 test "${pty_exit42_code}" -eq 42
 
+echo "==> copy round-trip"
+printf 'cp-ok\n' > "${BUX_HOME}/cp-in.txt"
+bux cp "${BUX_HOME}/cp-in.txt" "${NAME}:/tmp/cp-in.txt"
+in_cat="$(bux exec "${NAME}" -- cat /tmp/cp-in.txt)"
+echo "${in_cat}" | grep -qx cp-ok
+bux exec "${NAME}" -- sh -c 'printf "%s\n" cp-out > /tmp/cp-out.txt'
+mkdir -p "${BUX_HOME}/cp-out"
+bux cp "${NAME}:/tmp/cp-out.txt" "${BUX_HOME}/cp-out"
+test -f "${BUX_HOME}/cp-out/cp-out.txt"
+grep -qx cp-out "${BUX_HOME}/cp-out/cp-out.txt"
+
+mkdir -p "${BUX_HOME}/cp-dir"
+printf 'dir-ok\n' > "${BUX_HOME}/cp-dir/x.txt"
+bux cp "${BUX_HOME}/cp-dir" "${NAME}:/tmp/cp-dir"
+bux exec "${NAME}" -- cat /tmp/cp-dir/x.txt | grep -qx dir-ok
+
 echo "==> egress (unrestricted)"
 require_wget_ok "${NAME}" 10 "egress"
 guest_wget "${NAME}" 10 >/tmp/bux-e2e-egress.out
@@ -370,6 +386,15 @@ if ! require_wget_fail "${DENY}" 3 "allow_net deny"; then
   exit 1
 fi
 bux rm -f "${DENY}"
+
+ALW="e2e-allow-$(date +%s)"
+echo "==> allow_net allow ${ALW}"
+create_or_dump --name "${ALW}" --allow-net example.com --allow-net www.example.com "${IMAGE}"
+if ! require_wget_ok "${ALW}" 10 "allow_net allow"; then
+  bux rm -f "${ALW}" || true
+  exit 1
+fi
+bux rm -f "${ALW}"
 
 PUB="e2e-pub-$(date +%s)"
 echo "==> D1 publish ${PUB} (-p 0:80; CLI exits; host TCP must reach guest)"
@@ -454,5 +479,45 @@ if grep -a -F "${SECRET_VAL}" "${BUX_HOME}/guest-environ.bin" >/dev/null; then
   exit 1
 fi
 bux rm -f "${SEC}"
+
+SNAP="e2e-snap-$(date +%s)"
+echo "==> snapshot create/list/rm ${SNAP}"
+create_or_dump --name "${SNAP}" "${IMAGE}"
+sid="$(bux snapshot create --name e2e-s1 "${SNAP}")"
+test -n "${sid}"
+bux snapshot ls "${SNAP}" | grep -q "${sid}"
+test -f "${BUX_HOME}/snapshots/${sid}.qcow2"
+bux snapshot rm "${sid}"
+test ! -f "${BUX_HOME}/snapshots/${sid}.qcow2"
+bux rm -f "${SNAP}"
+
+REC="e2e-rec-$(date +%s)"
+echo "==> recover dead shim ${REC}"
+create_or_dump --name "${REC}" "${IMAGE}"
+insp="$(bux inspect "${REC}")"
+rec_pid="$(printf '%s\n' "${insp}" | sed -n 's/.*"pid":[[:space:]]*\(-\{0,1\}[0-9][0-9]*\).*/\1/p' | head -n 1)"
+test -n "${rec_pid}" && test "${rec_pid}" != "0"
+kill -9 "${rec_pid}" || true
+ok=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  rec_status="$(bux inspect "${REC}")"
+  if echo "${rec_status}" | grep -E '"status":[[:space:]]*"Stopped"' >/dev/null; then
+    ok=1
+    break
+  fi
+  sleep 0.25
+done
+test "${ok}" -eq 1
+bux rm "${REC}"
+
+NVOL="e2e-nvol-$(date +%s)"
+NV="e2e-nv-$(date +%s)"
+echo "==> named volume dir ${NVOL}"
+bux volume create "${NV}"
+printf 'nv-ok\n' > "${BUX_HOME}/volumes/${NV}/marker"
+create_or_dump --name "${NVOL}" -v "${BUX_HOME}/volumes/${NV}:/data" "${IMAGE}"
+bux exec "${NVOL}" -- cat /data/marker | grep -qx nv-ok
+bux rm -f "${NVOL}"
+bux volume rm "${NV}"
 
 echo "OK (full e2e)"


### PR DESCRIPTION
## Summary

FULL addenda items 11–15 from 48357719 (cite, not rewritten). Directory `copy_in` is required.

CONTRIBUTING pick (a): items 1–10 and the Layer 1 sentence stay scoped to the `42f02b0` ten-item run. Items 11–15 append **after** that sentence with “not in the `42f02b0` Layer 1 row”. SHA cell unchanged.

Smoke landmarks (order ≠ checklist): copy after exec/before egress; allow after deny `rm` via `require_wget_ok` (no second `retry_until_needle WGET_OK`); snap/recover/nvol after item 10.

Guest `copy_in` parent-under-dest is fail-closed (`../`, absolute, canonicalize failure). CurDir-only members (`./` from `append_dir_all(".", src)`) are allowed. Host unpack goes through `unpack_guest_tar`. Leftover ELF expected on Darwin FULL; item 11 is not the helper test.

Operator FULL is out of this PR.

## Test plan

- [x] `cargo test -p bux-cli`
- [x] `cargo clippy -p bux-cli --all-targets -- -D warnings`
- [x] `bash scripts/e2e/wget_probe_test.sh` (`grep -c` stays 1)
- [x] `BUX_E2E_FULL=0 ./scripts/e2e/smoke.sh`
- [ ] Host CI `e2e-host.yml` against `main`
- [ ] Operator `BUX_E2E_FULL=1` is **out of this PR**