### PR TITLE
fix: rustdoc copy_in_traversal_blocked for workspace clippy

### DIFF
--- a/crates/bux-guest/src/files.rs
+++ b/crates/bux-guest/src/files.rs
@@ -230,6 +230,7 @@ pub(crate) fn copy_in_parent_under_dest(canonical_dest: &Path, entry: &Path) -> 
     Ok(())
 }
 
+/// PermissionDenied constructor for the fail-closed parent-under-dest check.
 fn copy_in_traversal_blocked(entry: &Path) -> io::Error {
     io::Error::new(
         io::ErrorKind::PermissionDenied,


### PR DESCRIPTION
## Summary

Linux workspace clippy `-D warnings` fails on `copy_in_traversal_blocked` (`missing_docs_in_private_items`). One-line rustdoc. Not a product FULL PR. Layer 1 SHA unchanged.

## Test plan

- [x] `cargo clippy -p bux-guest --all-targets --all-features -- -D warnings`
- [ ] Linux `ci.yml` clippy