### PR TITLE
release: 0.8.0 production-bar closeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,37 @@ on:
     branches: [main]
 
 jobs:
+  # SHA is qntx/workflows main at 2026-08-28 (cb94c5b5b8b4c22587840a7db6d2db503c17369c).
+  # That revision's ci-rust.yml runs fmt/clippy/build/`cargo test --workspace` on ubuntu-latest only.
   ci:
-    uses: qntx/workflows/.github/workflows/ci-rust.yml@main
+    uses: qntx/workflows/.github/workflows/ci-rust.yml@cb94c5b5b8b4c22587840a7db6d2db503c17369c
     with:
       submodules: true
       toolchain: "1.97.1"
+
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      # v2.1.1 ships cargo-deny 0.20.2 (matches local check).
+      - uses: EmbarkStudios/cargo-deny-action@6f99e342a8f0f8f8d1bdc9dc43e9a6f2dd611259
+        with:
+          command: check
+
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
+      - uses: Swatinem/rust-cache@v2
+      # Guest unit tests (reaper, ca_no_command, sig_ign_waitpid) are cfg(linux).
+      # Never BUX_E2E_FULL=1 on GitHub-hosted runners.
+      - name: Workspace tests
+        run: cargo test --workspace

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   # SHA is qntx/workflows main at 2026-08-28 (cb94c5b5b8b4c22587840a7db6d2db503c17369c).
-  # That revision's ci-rust.yml runs fmt/clippy/build/`cargo test --workspace` on ubuntu-latest only.
+  # That revision's ci-rust.yml runs fmt/clippy/build/`cargo test --workspace --verbose --all-features` on ubuntu-latest only.
   ci:
     uses: qntx/workflows/.github/workflows/ci-rust.yml@cb94c5b5b8b4c22587840a7db6d2db503c17369c
     with:
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      # v2.1.1 ships cargo-deny 0.20.2 (matches local check).
-      - uses: EmbarkStudios/cargo-deny-action@6f99e342a8f0f8f8d1bdc9dc43e9a6f2dd611259
+      # v2.1.1 (3c634983…) ships cargo-deny 0.20.2; v2.1.0's entrypoint shift is broken.
+      - uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25
         with:
           command: check
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,12 +105,17 @@ cargo test -p bux-proto --lib
 # Full VM e2e — documented **manual** gate on local HVF (Apple Silicon).
 # Never set BUX_E2E_FULL=1 on GitHub-hosted runners.
 BUX_E2E_FULL=1 ./scripts/e2e/smoke.sh
+# Load / chaos — same FULL pin as smoke (cli+shim, guest ELF). Manual HVF/KVM.
+# GitHub-hosted CI does not run these; e2e-host.yml stays BUX_E2E_FULL=0.
+BUX_E2E_FULL=1 ./scripts/e2e/load.sh
+BUX_E2E_FULL=1 ./scripts/e2e/chaos.sh
 ```
 
 `.github/workflows/e2e-host.yml` forces `BUX_E2E_FULL=0` on `ubuntu-latest` and
 `macos-latest`. Host-only is not production proof. `BUX_E2E_FULL=1` is not a CI
 job. GitHub-hosted runners must not set `BUX_E2E_FULL=1`. Self-hosted runners
-can take it later without redesign.
+can take it later without redesign. `load.sh` and `chaos.sh` are the same
+manual gate, not GitHub-hosted jobs.
 
 The first green FULL is recorded below on **local HVF (Apple Silicon)**.
 Host CI (`BUX_E2E_FULL=0`) is not that proof. KVM later without redesign.
@@ -229,6 +234,21 @@ Item 17 is not in the Layer 1 or clone FULL rows.
 17. snapshot restore flatten: write `/restore-marker` → `bux snapshot create` →
     `bux snapshot restore` → `exec` cat marker; source still listed; `rm`
     restore; `rm` source drops snapshot rows (`ON DELETE CASCADE`)
+
+`scripts/e2e/load.sh` (`BUX_E2E_FULL=1`, dedicated `$BUX_HOME`):
+
+- `bux create` 8 detached alpine VMs (default 512 MiB each); all `bux ps` Running
+- 16 concurrent `bux exec <one-vm> -- echo ok`; all exit 0
+- `bux rm -f` all 8; `bux ps -q` empty; no leftover `$BUX_HOME/disks/vms/*.qcow2`
+- If the host cannot allocate 8×512 MiB, the script exits with a message (no
+  OOM flake)
+
+`scripts/e2e/chaos.sh` (`BUX_E2E_FULL=1`):
+
+- create → `kill -9` shim PID → `inspect` JSON `"Stopped"` within 5s → `bux rm`
+  without `-f`
+- no leftover overlay `$BUX_HOME/disks/vms/{id}.qcow2` for that id
+- no `ulimit` disk-full test
 
 Schema mismatches require `bux system reset` (or wiping `$BUX_HOME`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,6 +224,12 @@ Operator FULL 2026-08-28 on `04fca66945fe24fc16fda5aff113c8e4782cbc68`
 (capture binary `./target/debug/bux`, `$BUX_HOME=/Users/xu/bux-full-hvf-clone`)
 exited 0 including clone flatten (`SMOKE_EXIT=0`, `OK (full e2e)`).
 
+Item 17 is not in the Layer 1 or clone FULL rows.
+
+17. snapshot restore flatten: write `/restore-marker` → `bux snapshot create` →
+    `bux snapshot restore` → `exec` cat marker; source still listed; `rm`
+    restore; `rm` source drops snapshot rows (`ON DELETE CASCADE`)
+
 Schema mismatches require `bux system reset` (or wiping `$BUX_HOME`).
 
 ## Lints

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,8 @@ bux system info --format json
 - Guest agent: postcard protocol v9; Phase A process identity only.
 - Schema: SQLite `user_version` 5 — **no migrations**; wipe `BUX_HOME` on mismatch.
 
-Current architecture: `docs/bux-redesign.md`.
+Current architecture: `docs/bux-redesign.md`. Production-ready 1.0 bar:
+`docs/1.0-release-bar.md` (crate version for that increment: 0.8.0).
 
 ## Tests
 
@@ -136,8 +137,8 @@ substring).
 | image reference | docker.io/library/alpine:latest |
 | image digest | sha256:e7a1a92a5bfeee40966aea60f0796b0e7917cc35591542701834f03a68fa3d18 |
 
-Leftover sibling `BUX_GUEST_PATH` host mode **0644** is OK to record (inject
-0555 is #108 sidecar). Item 7 `NO_ETH0` sysfs still counts as offline proof.
+Leftover sibling `BUX_GUEST_PATH` host mode **0644** is OK to record; Runtime
+inject writes the guest ELF at mode `0555`. Item 7 `NO_ETH0` sysfs still counts as offline proof.
 Item 5/7 wget-fail is unclassified; do not treat as HVF proof of
 `allow_net` / offline **policy**. This record is not GitHub-hosted
 `BUX_E2E_FULL=1`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,10 +238,12 @@ Item 17 is not in the Layer 1 or clone FULL rows.
 `scripts/e2e/load.sh` (`BUX_E2E_FULL=1`, dedicated `$BUX_HOME`):
 
 - `bux create` 8 detached alpine VMs (default 512 MiB each); all `bux ps` Running
-- 16 concurrent `bux exec <one-vm> -- echo ok`; all exit 0
+- 16 concurrent `Vm::exec_output(echo ok)` on **one** `Runtime`
+  (`crates/bux/examples/concurrent_exec.rs`); all exit 0. Not 16 `bux exec`
+  CLI processes (R5 exclusive `bux.lock`)
 - `bux rm -f` all 8; `bux ps -q` empty; no leftover `$BUX_HOME/disks/vms/*.qcow2`
-- If the host cannot allocate 8×512 MiB, the script exits with a message (no
-  OOM flake)
+- If available RAM is below 8×512 MiB plus per-VM/host overhead, the script
+  exits with a message (no OOM flake)
 
 `scripts/e2e/chaos.sh` (`BUX_E2E_FULL=1`):
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ cargo test -p bux --lib
 cargo test -p bux-proto --lib
 # Host-only smoke (no hypervisor). This is the GitHub-hosted CI gate:
 ./scripts/e2e/smoke.sh
-# Full VM e2e — documented **manual** gate on local HVF (Apple Silicon).
+# Full VM e2e — documented **manual** gate (HVF recorded; KVM needs /dev/kvm).
 # Never set BUX_E2E_FULL=1 on GitHub-hosted runners.
 BUX_E2E_FULL=1 ./scripts/e2e/smoke.sh
 # Load / chaos — same FULL pin as smoke (cli+shim, guest ELF). Manual HVF/KVM.
@@ -118,7 +118,8 @@ can take it later without redesign. `load.sh` and `chaos.sh` are the same
 manual gate, not GitHub-hosted jobs.
 
 The first green FULL is recorded below on **local HVF (Apple Silicon)**.
-Host CI (`BUX_E2E_FULL=0`) is not that proof. KVM later without redesign.
+Host CI (`BUX_E2E_FULL=0`) is not that proof. Linux KVM has **no** Layer 1
+row in this tree (procedure under **Linux KVM FULL record**).
 
 ### Layer 1 FULL record
 
@@ -147,6 +148,31 @@ inject writes the guest ELF at mode `0555`. Item 7 `NO_ETH0` sysfs still counts 
 Item 5/7 wget-fail is unclassified; do not treat as HVF proof of
 `allow_net` / offline **policy**. This record is not GitHub-hosted
 `BUX_E2E_FULL=1`.
+
+### Linux KVM FULL record
+
+Empty. 0.8 ships **without** a Linux KVM FULL record until an operator with
+`/dev/kvm` runs `BUX_E2E_FULL=1 ./scripts/e2e/smoke.sh` and the script prints
+`OK (full e2e)`. Do not copy the HVF `uname`, git SHA, ELF sha256, or image
+digest. Do not invent those values or `SMOKE_EXIT=0`. Host identity is a
+checklist input, not a GitHub-hosted job. `.github/workflows/e2e-host.yml`
+keeps `BUX_E2E_FULL=0` on `ubuntu-latest`. If smoke fails, a code PR first.
+
+After that green run, fill a Layer 1 row from **that** host (capture binary
+`./target/debug/bux`, not PATH `bux`; `$BUX_HOME` without substring
+`bux-e2e`):
+
+| Field | How to capture |
+| ----- | -------------- |
+| Date | calendar date of the run |
+| uname | `uname -a` |
+| /dev/kvm | character device present (`test -c /dev/kvm`) |
+| rustc | `rustc --version` |
+| git | `git rev-parse HEAD` of the tree that ran smoke |
+| guest ELF sha256 | sha256 of `$BUX_GUEST_PATH` (the ELF smoke used) |
+| image digest | `./target/debug/bux images --format json` |
+| SMOKE_EXIT | `0` only with `OK (full e2e)` |
+| boot_s | optional; wall seconds create → first successful exec; not a fail gate |
 
 Capture `.host.*` with `./target/debug/bux system info --format json` and image
 reference/digest with `./target/debug/bux images --format json`. Pin `$BUX_HOME`
@@ -207,7 +233,7 @@ OCI (`bux pull` / `bux create IMAGE`).
 10. secrets: value not in `bux.db` or guest `/proc/1/environ`
 
 The Layer 1 record above is that green local HVF run. Host CI
-(`BUX_E2E_FULL=0`) is not that proof.
+(`BUX_E2E_FULL=0`) is not that proof. Linux KVM FULL remains empty.
 
 Items 11–15 are not in the `42f02b0` Layer 1 row.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]
@@ -318,6 +319,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,6 +277,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1572,6 +1573,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +1703,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2397,6 +2416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,6 +2643,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2844,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2918,6 +2985,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bux"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bux-e2fs",
  "bux-jail",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "bux-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bux",
@@ -294,7 +294,7 @@ dependencies = [
 
 [[package]]
 name = "bux-guest"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bux-proto",
  "futures",
@@ -355,7 +355,7 @@ dependencies = [
 
 [[package]]
 name = "bux-oci"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "flate2",
  "oci-client",
@@ -370,7 +370,7 @@ dependencies = [
 
 [[package]]
 name = "bux-proto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "postcard",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ default-members = ["crates/bux"]
 resolver = "3"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/qntx/bux"
 
 [workspace.dependencies]
-bux = { version = "0.7", path = "crates/bux" }
-bux-oci = { version = "0.7", path = "crates/bux-oci" }
-bux-proto = { version = "0.7", path = "crates/bux-proto" }
+bux = { version = "0.8", path = "crates/bux" }
+bux-oci = { version = "0.8", path = "crates/bux-oci" }
+bux-proto = { version = "0.8", path = "crates/bux-proto" }
 
 bux-bwrap = { version = "0.2", path = "crates/bux-bwrap" }
 bux-jail = { version = "0.1", path = "crates/bux-jail" }

--- a/README.md
+++ b/README.md
@@ -1,18 +1,83 @@
-<!-- markdownlint-disable MD033 MD041 MD036 -->
-
 # Bux
 
-Embedded micro-VM sandbox for running AI agents, powered by [libkrun](https://github.com/containers/libkrun) with KVM (Linux) or Hypervisor.framework (macOS).
+Embeddable micro-VM sandbox for untrusted agent code. Product entry is
+`Runtime` + `Vm` + `VmOptions` in the `bux` crate. The `bux` CLI is a client of
+that API. Isolation vs the host is the hardware VM (Linux KVM / macOS HVF) plus
+shim jail. Concurrent execs in one VM are not isolated from each other or from
+the guest agent (Phase A).
 
----
+Production-ready 1.0 bar: [`docs/1.0-release-bar.md`](docs/1.0-release-bar.md)
+(crate version for that increment: 0.8.0). Architecture:
+[`docs/bux-redesign.md`](docs/bux-redesign.md).
 
-<div align="center">
+## Install
 
-A **[QuantX](https://qntx.org)** open-source project.
+```bash
+cargo build -p bux-cli -p bux-shim-bin
+```
 
-<a href="https://qntx.org"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
+Linux guest agent (static musl, injected as PID 1):
 
-Code is law. We write both.
+```bash
+cargo build -p bux-guest --target aarch64-unknown-linux-musl   # or x86_64-unknown-linux-musl
+```
 
-</div>
+Requires a C toolchain for libkrun / e2fs / qcow2 native deps, and Go for
+`bux-gvproxy`. Pins and bindgen: [`docs/native-deps.md`](docs/native-deps.md).
+Build, tarball layout, and FULL procedure: [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+`cd.yml` ships `bux`, `bux-shim`, `bux-guest-<triple>`, and `libkrun*` /
+`libkrunfw*` (including soname aliases) in one directory.
+
+## Embed
+
+```rust
+use bux::{ExecStart, Runtime, VmOptions};
+
+let rt = Runtime::open(bux::default_data_dir())?;
+let mut vm = rt
+    .create(VmOptions::from_image("python:slim").vcpus(2).ram_mib(1024))
+    .await?;
+
+vm.exec_output(ExecStart::new("python").args(vec!["-c".into(), "print(1)".into()]))
+    .await?;
+vm.stop().await?;
+```
+
+Also: `crates/bux/examples/embed.rs`. Sidecar `bux-shim` and `bux-guest` are
+`RuntimeOptions::shim_path` / `guest_path`, else `BUX_SHIM_PATH` /
+`BUX_GUEST_PATH`, a sibling of the running executable, then `$PATH`.
+
+## Isolation model
+
+- **Host boundary:** libkrun VM (KVM or HVF). Jailer on by default (Linux:
+  bubblewrap + Landlock; macOS: `sandbox-exec` Seatbelt).
+- **Phase A:** workload processes share the guest rootfs and kernel namespaces
+  with the agent. Compromise of a workload is compromise of the agent
+  filesystem. Hardware boundary vs the host still holds.
+- **Egress:** empty `allow_net` is unrestricted. Non-empty is default-deny
+  except listed IP / CIDR / hostname / `*.suffix`.
+- **Snapshots:** rows `ON DELETE CASCADE` on the source VM.
+- **Secrets:** values are memory-only on `Runtime`; they must not appear in
+  `bux.db` or guest `/proc/1/environ`.
+
+`bux system info --format json` is the capture surface (flock-free).
+
+## Capture env
+
+| Variable | Purpose |
+|----------|---------|
+| `BUX_HOME` | Runtime data directory (lock, SQLite, disks, volumes, socks) |
+| `BUX_SHIM_PATH` | Absolute path to `bux-shim` (else next to CLI or `$PATH`) |
+| `BUX_GUEST_PATH` | Absolute path to a static Linux `bux-guest` ELF (Runtime inject) |
+| `BUX_GUEST_DIR` | Build-time directory of a prebuilt Linux guest ELF (`bux-cli` stages a sibling copy) |
+| `PATH` | Locates `bux-shim`, `bwrap` (Linux), `sandbox-exec` (macOS), `go` |
+
+## CLI
+
+See [`crates/bux-cli/README.md`](crates/bux-cli/README.md).
+
+## License
+
+MIT OR Apache-2.0. See [`LICENSE-MIT`](LICENSE-MIT) and
+[`LICENSE-APACHE`](LICENSE-APACHE).

--- a/README.md
+++ b/README.md
@@ -6,9 +6,11 @@ that API. Isolation vs the host is the hardware VM (Linux KVM / macOS HVF) plus
 shim jail. Concurrent execs in one VM are not isolated from each other or from
 the guest agent (Phase A).
 
-Production-ready 1.0 bar: [`docs/1.0-release-bar.md`](docs/1.0-release-bar.md)
-(crate version for that increment: 0.8.0). Architecture:
-[`docs/bux-redesign.md`](docs/bux-redesign.md).
+This tree is workspace **0.7.0**. Production-ready 1.0 bar:
+[`docs/1.0-release-bar.md`](docs/1.0-release-bar.md) (crate version for that
+increment: 0.8.0; do not tag `v1.0.0`). Architecture:
+[`docs/bux-redesign.md`](docs/bux-redesign.md). Isolation:
+[`docs/security-model.md`](docs/security-model.md).
 
 ## Install
 
@@ -24,10 +26,41 @@ cargo build -p bux-guest --target aarch64-unknown-linux-musl   # or x86_64-unkno
 
 Requires a C toolchain for libkrun / e2fs / qcow2 native deps, and Go for
 `bux-gvproxy`. Pins and bindgen: [`docs/native-deps.md`](docs/native-deps.md).
-Build, tarball layout, and FULL procedure: [`CONTRIBUTING.md`](CONTRIBUTING.md).
+Build, tarball layout, Darwin guest fetch, and FULL procedure:
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 `cd.yml` ships `bux`, `bux-shim`, `bux-guest-<triple>`, and `libkrun*` /
 `libkrunfw*` (including soname aliases) in one directory.
+
+## Getting started
+
+Use `./target/debug/bux` from the build above, not a PATH `bux`. `bux-shim`
+must sit next to that binary or be set via `BUX_SHIM_PATH`. Darwin does not
+compile the guest; fetch a static Linux ELF with `scripts/e2e/fetch-guest.sh`
+and set `BUX_GUEST_PATH`. Linux may `cargo build -p bux-guest --target
+$ARCH-unknown-linux-musl` when that rustc target and `musl-gcc` are present.
+
+```bash
+export BUX_HOME="${BUX_HOME:-$PWD/.bux-home}"
+./target/debug/bux system info --format json
+./target/debug/bux pull alpine
+./target/debug/bux create --name t1 alpine
+./target/debug/bux exec t1 -- echo ok
+./target/debug/bux stop t1
+./target/debug/bux rm t1
+```
+
+`create` is always detach: the CLI exits; the VM survives. Equivalent to
+`bux run -d IMAGE` with no command override.
+
+Empty `--allow-net` is **unrestricted** egress. Non-empty is default-deny
+except listed IP / CIDR / hostname / `*.suffix`. Offline:
+`--network=disabled` (no `eth0`). Production profile is an allow-list or
+disabled, not the default.
+
+`bux system info --format json` is the capture surface (flock-free; does not
+`Runtime::open`). Schema `user_version` 5: mismatch refuses to open — wipe
+`$BUX_HOME` or `bux system reset`.
 
 ## Embed
 
@@ -44,24 +77,47 @@ vm.exec_output(ExecStart::new("python").args(vec!["-c".into(), "print(1)".into()
 vm.stop().await?;
 ```
 
-Also: `crates/bux/examples/embed.rs`. Sidecar `bux-shim` and `bux-guest` are
+Compile gate: `cargo build -p bux --example embed`
+([`crates/bux/examples/embed.rs`](crates/bux/examples/embed.rs)), matching
+`crates/bux/src/lib.rs`. Sidecar `bux-shim` and `bux-guest` are
 `RuntimeOptions::shim_path` / `guest_path`, else `BUX_SHIM_PATH` /
 `BUX_GUEST_PATH`, a sibling of the running executable, then `$PATH`.
+`Runtime::open` takes an exclusive flock; a second open on the same data dir
+is `Error::Busy`.
+
+Linux embedders must set `$ORIGIN` rpath so libkrun can `dlopen` firmware next
+to the binary. Darwin copies already use `@loader_path`. Details:
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Isolation model
 
+See [`docs/security-model.md`](docs/security-model.md). This tree:
+
 - **Host boundary:** libkrun VM (KVM or HVF). Jailer on by default (Linux:
-  bubblewrap + Landlock; macOS: `sandbox-exec` Seatbelt).
+  bubblewrap + Landlock fail-closed unless `allow_degraded`; macOS:
+  `sandbox-exec` Seatbelt). Missing virtualization is an `isolation_warnings`
+  entry on `HostInfo`, not a create hard-fail.
 - **Phase A:** workload processes share the guest rootfs and kernel namespaces
   with the agent. Compromise of a workload is compromise of the agent
-  filesystem. Hardware boundary vs the host still holds.
+  filesystem. Hardware boundary vs the host still holds. Inspect
+  `isolation_note` carries this text.
 - **Egress:** empty `allow_net` is unrestricted. Non-empty is default-deny
-  except listed IP / CIDR / hostname / `*.suffix`.
-- **Snapshots:** rows `ON DELETE CASCADE` on the source VM.
+  except listed IP / CIDR / hostname / `*.suffix`. Gateway and guest TAP IPs
+  stay allowed. Inspect serializes `network` (`NetworkSpec`).
+- **Snapshots:** create / list / delete of the QCOW2 overlay. Rows
+  `ON DELETE CASCADE` on the source VM (`bux rm` of the source drops snapshot
+  rows). No restore on this tree.
+- **Volumes:** bind and named. Sensitive host prefixes denied unless
+  `allow_sensitive`. `read_only` / CLI `:ro` is metadata; engine virtio-fs is
+  RW.
 - **Secrets:** values are memory-only on `Runtime`; they must not appear in
-  `bux.db` or guest `/proc/1/environ`.
+  `bux.db` or guest `/proc/1/environ`. MITM CA validity is 24h.
+- **Protocol:** postcard v9.
 
-`bux system info --format json` is the capture surface (flock-free).
+1.0-bar items that are **not** current (virtio-fs `:ro` via
+`krun_add_virtiofs3`, snapshot restore, protocol v10, Linux seccomp with
+in-process gvproxy, create fail-closed without virtualization, KVM FULL
+record): [`docs/1.0-release-bar.md`](docs/1.0-release-bar.md).
 
 ## Capture env
 

--- a/crates/bux-cli/Cargo.toml
+++ b/crates/bux-cli/Cargo.toml
@@ -23,6 +23,7 @@ libc.workspace = true
 serde_json.workspace = true
 tar.workspace = true
 tokio = { workspace = true, features = ["io-std"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/bux-cli/README.md
+++ b/crates/bux-cli/README.md
@@ -1,0 +1,50 @@
+# bux-cli
+
+CLI client of the `bux` `Runtime` / `Vm` / `VmOptions` API. Binary name: `bux`.
+
+Build: `cargo build -p bux-cli -p bux-shim-bin`. Capture env, tarball layout,
+and FULL procedure: [`CONTRIBUTING.md`](../../CONTRIBUTING.md). Architecture:
+[`docs/bux-redesign.md`](../../docs/bux-redesign.md). Production-ready 1.0 bar:
+[`docs/1.0-release-bar.md`](../../docs/1.0-release-bar.md).
+
+## Commands
+
+| Command | Role |
+|---------|------|
+| `run` | Create and run a command in a new micro-VM |
+| `create` | Create and start a managed VM without an initial command (print ID) |
+| `exec` | Execute a command in a running VM |
+| `logs` | Show shim stderr for a VM |
+| `ps` / `ls` | List VMs |
+| `stop` / `kill` / `rm` | Stop, force-kill, or remove VMs |
+| `inspect` | Detailed VM information |
+| `cp` | Copy files between host and a running VM (`<vm>:<path>`) |
+| `wait` | Block until VMs stop |
+| `prune` | Remove all stopped VMs |
+| `rename` / `restart` | Rename; restart a stopped or running VM |
+| `stats` | VM identity, status, and health |
+| `snapshot create` / `list` / `rm` | Disk overlay snapshots |
+| `clone` | Disk-clone (overlay flatten); always boots detached |
+| `export` | Export a VM disk as standalone QCOW2 |
+| `pull` / `images` / `rmi` | OCI images |
+| `volume create` / `list` / `rm` | Named volumes under `{data_dir}/volumes/` |
+| `disk create` / `list` / `rm` | Ext4 base images |
+| `sweep` | Apply idle auto-stop / auto-delete policies |
+| `system info` | Host capabilities, data dir, capture env (flock-free) |
+| `system reset` | Delete the runtime data directory (requires flock) |
+| `info` | Alias of `system info` |
+
+List/info commands take `--format table|json` where present.
+
+`create` is always detach (CLI exits; VM survives). Equivalent to
+`bux run -d IMAGE` with no command override.
+
+## Capture env
+
+| Variable | Purpose |
+|----------|---------|
+| `BUX_HOME` | Runtime data directory |
+| `BUX_SHIM_PATH` | Absolute path to `bux-shim` |
+| `BUX_GUEST_PATH` | Absolute path to a static Linux `bux-guest` ELF |
+| `BUX_GUEST_DIR` | Build-time directory of a prebuilt Linux guest ELF |
+| `PATH` | Locates `bux-shim`, `bwrap`, `sandbox-exec`, `go` |

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -191,6 +191,18 @@ enum SnapshotAction {
         /// Snapshot ID.
         id: String,
     },
+    /// Restore a snapshot as a new VM (flatten overlay; copies `vcpus`, ram, network, `auto_remove`).
+    ///
+    /// The restored VM always boots detached, matching `bux clone`. Restore
+    /// requires the source VM row: `bux snapshot restore` after `bux rm` of the
+    /// source is `NotFound` (`ON DELETE CASCADE`).
+    Restore {
+        /// Snapshot ID.
+        id: String,
+        /// Optional name for the restored VM.
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 /// Subcommands for `bux disk`.
@@ -299,6 +311,10 @@ async fn snapshot_cmd(action: SnapshotAction) -> Result<()> {
         SnapshotAction::Rm { id } => {
             rt.delete_snapshot(&id)?;
             println!("{id}");
+        }
+        SnapshotAction::Restore { id, name } => {
+            let handle = rt.restore(&id, name).await?;
+            println!("{}", handle.info().id);
         }
     }
     Ok(())

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -22,9 +22,37 @@ use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 
+/// Tracing filter for `--log-level`. `RUST_LOG` is used when this flag is absent.
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+enum LogLevel {
+    Error,
+    Warn,
+    Info,
+    Debug,
+    Trace,
+}
+
+impl LogLevel {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Trace => "trace",
+        }
+    }
+}
+
 #[derive(Parser)]
 #[command(name = "bux", version, about = "Micro-VM sandbox powered by libkrun")]
 struct Cli {
+    /// Tracing log level. Default `warn` when unset and `RUST_LOG` is absent.
+    ///
+    /// Overrides `RUST_LOG` when passed.
+    #[arg(long, global = true, value_enum)]
+    log_level: Option<LogLevel>,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -237,10 +265,26 @@ pub(crate) enum OutputFormat {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
-    if let Err(e) = Cli::parse().dispatch().await {
+    let cli = Cli::parse();
+    init_tracing(cli.log_level);
+    if let Err(e) = cli.dispatch().await {
         eprintln!("bux: {e:#}");
         std::process::exit(1);
     }
+}
+
+fn init_tracing(log_level: Option<LogLevel>) {
+    let filter = log_level.map_or_else(
+        || {
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn"))
+        },
+        |level| tracing_subscriber::EnvFilter::new(level.as_str()),
+    );
+    tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .init();
 }
 
 impl Cli {
@@ -519,4 +563,44 @@ fn human_size(bytes: u64) -> String {
         size /= 1024.0;
     }
     format!("{size:.1} TB")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic, reason = "tests")]
+mod log_level_tests {
+    use super::*;
+
+    fn parse(argv: &[&str]) -> Cli {
+        Cli::try_parse_from(std::iter::once("bux").chain(argv.iter().copied()))
+            .unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    #[test]
+    fn default_is_unset() {
+        let cli = parse(&["images"]);
+        assert!(cli.log_level.is_none());
+    }
+
+    #[test]
+    fn before_subcommand() {
+        let cli = parse(&["--log-level", "debug", "images"]);
+        assert!(matches!(cli.log_level, Some(LogLevel::Debug)));
+    }
+
+    #[test]
+    fn after_subcommand_via_global() {
+        let cli = parse(&["images", "--log-level", "trace"]);
+        assert!(matches!(cli.log_level, Some(LogLevel::Trace)));
+    }
+
+    #[test]
+    fn rejects_invalid_level() {
+        assert!(Cli::try_parse_from(["bux", "--log-level", "verbose", "images"]).is_err());
+    }
+
+    #[test]
+    fn top_level_help_lists_log_level() {
+        let help = Cli::command().render_help().to_string();
+        assert!(help.contains("--log-level"), "{help}");
+    }
 }

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -106,7 +106,7 @@ enum Command {
     /// Restart a stopped or running VM.
     Restart(vm::RestartArgs),
 
-    /// Display VM identity, status, and health.
+    /// Display VM identity, status, and health; `--runtime` dumps `RuntimeMetrics`.
     Stats(vm::StatsArgs),
 
     /// Manage VM snapshots.
@@ -602,5 +602,50 @@ mod log_level_tests {
     fn top_level_help_lists_log_level() {
         let help = Cli::command().render_help().to_string();
         assert!(help.contains("--log-level"), "{help}");
+    }
+}
+
+#[cfg(test)]
+mod cli_parse_tests {
+    use super::*;
+
+    #[test]
+    fn stats_runtime_does_not_require_vm() {
+        let cli = Cli::try_parse_from(["bux", "stats", "--runtime"]).expect("parse");
+        assert!(
+            matches!(
+                cli.command,
+                Command::Stats(ref args) if args.runtime && args.vm.is_none()
+            ),
+            "expected stats --runtime without vm"
+        );
+    }
+
+    #[test]
+    fn stats_vm_does_not_set_runtime() {
+        let cli = Cli::try_parse_from(["bux", "stats", "abc"]).expect("parse");
+        assert!(
+            matches!(
+                cli.command,
+                Command::Stats(ref args) if !args.runtime && args.vm.as_deref() == Some("abc")
+            ),
+            "expected stats <id> without --runtime"
+        );
+    }
+
+    #[test]
+    fn stats_requires_vm_or_runtime() {
+        assert!(
+            Cli::try_parse_from(["bux", "stats"]).is_err(),
+            "stats with neither vm nor --runtime must fail"
+        );
+    }
+
+    #[test]
+    fn stats_runtime_conflicts_with_vm() {
+        assert!(
+            Cli::try_parse_from(["bux", "stats", "--runtime", "abc"]).is_err(),
+            "stats --runtime must not take a vm id"
+        );
     }
 }

--- a/crates/bux-cli/src/run.rs
+++ b/crates/bux-cli/src/run.rs
@@ -1,7 +1,58 @@
 //! `bux run` — create and run a command in a new micro-VM.
 
 use anyhow::{Context, Result};
-use bux::{NetworkSpec, VmOptions};
+use bux::{NetworkSpec, SecurityOptions, VmOptions};
+
+/// Isolation flags shared by `bux run` and `bux create`.
+///
+/// Clap bools are `--flag` / `--no-flag` (not `--flag true|false`). Absent flags
+/// keep `SecurityOptions` defaults.
+#[derive(clap::Args, Debug, Clone, Copy)]
+struct SecurityArgs {
+    /// Use the platform jailer (bwrap / seatbelt). Default on.
+    #[arg(long, overrides_with = "no_jailer")]
+    jailer: bool,
+
+    /// Disable the platform jailer.
+    #[arg(long, overrides_with = "jailer")]
+    no_jailer: bool,
+
+    /// Request Landlock LSM. Default on Linux, off elsewhere.
+    #[arg(long, overrides_with = "no_landlock")]
+    landlock: bool,
+
+    /// Disable Landlock.
+    #[arg(long, overrides_with = "landlock")]
+    no_landlock: bool,
+
+    /// Continue if a requested isolation layer is unavailable.
+    #[arg(long)]
+    allow_degraded: bool,
+}
+
+impl SecurityArgs {
+    fn options(self) -> SecurityOptions {
+        let defaults = SecurityOptions::default();
+        SecurityOptions::new()
+            .jailer(resolve_flag(self.jailer, self.no_jailer, defaults.jailer))
+            .landlock(resolve_flag(
+                self.landlock,
+                self.no_landlock,
+                defaults.landlock,
+            ))
+            .allow_degraded(self.allow_degraded)
+    }
+}
+
+const fn resolve_flag(on: bool, off: bool, default: bool) -> bool {
+    if off {
+        false
+    } else if on {
+        true
+    } else {
+        default
+    }
+}
 
 /// Arguments for `bux run`.
 ///
@@ -54,6 +105,9 @@ pub struct RunArgs {
     /// Network mode: `enabled` (gvproxy, default) or `disabled` (offline).
     #[arg(long, default_value = "enabled", value_parser = ["enabled", "disabled"])]
     network: String,
+
+    #[command(flatten)]
+    security: SecurityArgs,
 
     /// Host MITM secret (`name=value@host1,host2` or `name=value` using --allow-net hosts).
     ///
@@ -133,6 +187,9 @@ pub struct CreateArgs {
     #[arg(long, default_value = "enabled", value_parser = ["enabled", "disabled"])]
     network: String,
 
+    #[command(flatten)]
+    security: SecurityArgs,
+
     /// Host MITM secret (`name=value@host` or `name=value`).
     ///
     /// Visible on `/proc/<pid>/cmdline`. Prefer `--secret-file` on shared hosts.
@@ -163,6 +220,7 @@ impl CreateArgs {
             publish: self.publish,
             allow_net: self.allow_net,
             network: self.network,
+            security: self.security,
             secrets: self.secrets,
             secret_file: self.secret_file,
             volume: self.volume,
@@ -197,7 +255,8 @@ impl RunArgs {
             .vcpus(self.cpus)
             .ram_mib(self.memory)
             .auto_remove(self.rm)
-            .detach(self.detach);
+            .detach(self.detach)
+            .security(self.security.options());
 
         if let Some(ref n) = self.name {
             opts = opts.name(n.clone());
@@ -523,5 +582,156 @@ mod secret_tests {
         assert_eq!(secrets[0].name, "k");
         assert_eq!(secrets[0].value, "v");
         assert_eq!(secrets[0].hosts, vec!["api.example.com"]);
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    reason = "tests"
+)]
+mod security_flag_tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[derive(Parser)]
+    #[command(name = "run")]
+    struct RunParser {
+        #[command(flatten)]
+        args: RunArgs,
+    }
+
+    #[derive(Parser)]
+    #[command(name = "create")]
+    struct CreateParser {
+        #[command(flatten)]
+        args: CreateArgs,
+    }
+
+    fn parse_run(argv: &[&str]) -> RunArgs {
+        RunParser::try_parse_from(std::iter::once("run").chain(argv.iter().copied()))
+            .unwrap_or_else(|e| panic!("{e}"))
+            .args
+    }
+
+    fn parse_create(argv: &[&str]) -> CreateArgs {
+        CreateParser::try_parse_from(std::iter::once("create").chain(argv.iter().copied()))
+            .unwrap_or_else(|e| panic!("{e}"))
+            .args
+    }
+
+    #[test]
+    fn run_defaults_match_library() {
+        let opts = parse_run(&["alpine"]).security.options();
+        assert_eq!(opts, SecurityOptions::default());
+    }
+
+    #[test]
+    fn create_defaults_match_library() {
+        let opts = parse_create(&["alpine"]).security.options();
+        assert_eq!(opts, SecurityOptions::default());
+    }
+
+    #[test]
+    fn run_no_jailer() {
+        let opts = parse_run(&["--no-jailer", "alpine"]).security.options();
+        assert!(!opts.jailer);
+        assert_eq!(opts.landlock, SecurityOptions::default().landlock);
+        assert!(!opts.allow_degraded);
+    }
+
+    #[test]
+    fn create_no_jailer() {
+        let opts = parse_create(&["--no-jailer", "alpine"]).security.options();
+        assert!(!opts.jailer);
+    }
+
+    #[test]
+    fn run_jailer_explicit() {
+        let opts = parse_run(&["--jailer", "alpine"]).security.options();
+        assert!(opts.jailer);
+    }
+
+    #[test]
+    fn run_no_landlock() {
+        let opts = parse_run(&["--no-landlock", "alpine"]).security.options();
+        assert!(!opts.landlock);
+    }
+
+    #[test]
+    fn run_landlock_explicit() {
+        let opts = parse_run(&["--landlock", "alpine"]).security.options();
+        assert!(opts.landlock);
+    }
+
+    #[test]
+    fn create_landlock_and_degraded() {
+        let opts = parse_create(&["alpine", "--landlock", "--allow-degraded"])
+            .security
+            .options();
+        assert!(opts.landlock);
+        assert!(opts.allow_degraded);
+    }
+
+    #[test]
+    fn run_allow_degraded() {
+        let opts = parse_run(&["--allow-degraded", "alpine"])
+            .security
+            .options();
+        assert!(opts.allow_degraded);
+    }
+
+    #[test]
+    fn last_flag_wins_no_jailer() {
+        let opts = parse_run(&["--jailer", "--no-jailer", "alpine"])
+            .security
+            .options();
+        assert!(!opts.jailer);
+    }
+
+    #[test]
+    fn last_flag_wins_jailer() {
+        let opts = parse_run(&["--no-jailer", "--jailer", "alpine"])
+            .security
+            .options();
+        assert!(opts.jailer);
+    }
+
+    #[test]
+    fn jailer_does_not_take_true_false_value() {
+        let err = RunParser::try_parse_from(["run", "--jailer=false", "alpine"])
+            .err()
+            .expect("--jailer is a switch, not --jailer=false");
+        assert!(err.to_string().contains("unexpected value"), "{err}");
+    }
+
+    #[test]
+    fn run_help_lists_pairs() {
+        let help = RunParser::command().render_long_help().to_string();
+        for flag in [
+            "--jailer",
+            "--no-jailer",
+            "--landlock",
+            "--no-landlock",
+            "--allow-degraded",
+        ] {
+            assert!(help.contains(flag), "missing {flag} in {help}");
+        }
+    }
+
+    #[test]
+    fn create_help_lists_pairs() {
+        let help = CreateParser::command().render_long_help().to_string();
+        for flag in [
+            "--jailer",
+            "--no-jailer",
+            "--landlock",
+            "--no-landlock",
+            "--allow-degraded",
+        ] {
+            assert!(help.contains(flag), "missing {flag} in {help}");
+        }
     }
 }

--- a/crates/bux-cli/src/vm.rs
+++ b/crates/bux-cli/src/vm.rs
@@ -599,8 +599,13 @@ pub struct RestartArgs {
 /// Arguments for `bux stats`.
 #[derive(clap::Args)]
 pub struct StatsArgs {
+    /// Dump process-local `RuntimeMetrics` as JSON (opens the runtime; Busy if locked).
+    #[arg(long, conflicts_with = "vm")]
+    pub runtime: bool,
+
     /// VM ID or name.
-    pub vm: String,
+    #[arg(required_unless_present = "runtime")]
+    pub vm: Option<String>,
 }
 
 /// Arguments for `bux clone`.
@@ -639,17 +644,39 @@ pub async fn restart(args: RestartArgs) -> Result<()> {
     Ok(())
 }
 
+/// JSON object whose keys are exactly the [`bux::RuntimeMetrics`] getter names.
+#[cfg(unix)]
+fn runtime_metrics_json(m: &bux::RuntimeMetrics) -> Result<String> {
+    let obj = serde_json::json!({
+        "vms_created_total": m.vms_created_total(),
+        "num_running_vms": m.num_running_vms(),
+        "vms_failed_total": m.vms_failed_total(),
+        "total_uptime_ms": m.total_uptime_ms(),
+        "disk_bytes_used": m.disk_bytes_used(),
+    });
+    Ok(serde_json::to_string_pretty(&obj)?)
+}
+
 #[cfg(unix)]
 pub async fn stats(args: &StatsArgs) -> Result<()> {
+    if args.runtime {
+        let rt = open_runtime()?;
+        println!("{}", runtime_metrics_json(rt.metrics())?);
+        return Ok(());
+    }
+    let vm = args.vm.as_deref().context("VM ID or name required")?;
     let rt = open_runtime()?;
-    let handle = rt.get(&args.vm)?;
+    let handle = rt.get(vm)?;
     let info = handle.info();
     let health = handle.health().await;
+    let metrics = handle.metrics();
     println!("ID:             {}", info.id);
     println!("Name:           {}", info.name.as_deref().unwrap_or("-"));
     println!("Status:         {:?}", info.status);
     println!("Health:         {health:?}");
     println!("PID:            {}", info.pid);
+    println!("boot_duration_ms: {}", metrics.boot_duration_ms());
+    println!("exec_count:     {}", metrics.exec_count());
     Ok(())
 }
 
@@ -785,5 +812,35 @@ mod unpack_guest_tar_tests {
             }
         }
         assert!(saw_x, "packed dir must contain x.txt");
+    }
+}
+
+#[cfg(test)]
+#[cfg(unix)]
+mod stats_tests {
+    use super::runtime_metrics_json;
+
+    const RUNTIME_METRIC_KEYS: [&str; 5] = [
+        "vms_created_total",
+        "num_running_vms",
+        "vms_failed_total",
+        "total_uptime_ms",
+        "disk_bytes_used",
+    ];
+
+    #[test]
+    fn runtime_metrics_json_keys_match_getters() {
+        let m = bux::RuntimeMetrics::new();
+        let v: serde_json::Value =
+            serde_json::from_str(&runtime_metrics_json(&m).expect("json")).expect("parse");
+        let obj = v.as_object().expect("object");
+        assert_eq!(
+            obj.len(),
+            RUNTIME_METRIC_KEYS.len(),
+            "runtime JSON must be getter keys only: {obj:?}"
+        );
+        for key in RUNTIME_METRIC_KEYS {
+            assert_eq!(obj[key].as_i64(), Some(0), "{key}");
+        }
     }
 }

--- a/crates/bux-cli/tests/stats_runtime.rs
+++ b/crates/bux-cli/tests/stats_runtime.rs
@@ -1,0 +1,89 @@
+//! `bux system info` stays flock-free; `bux stats --runtime` takes `bux.lock`.
+
+#![allow(
+    unused_crate_dependencies,
+    clippy::tests_outside_test_module,
+    missing_docs,
+    reason = "binary integration test"
+)]
+#![cfg(unix)]
+
+use std::process::Command;
+
+const RUNTIME_METRIC_KEYS: [&str; 5] = [
+    "vms_created_total",
+    "num_running_vms",
+    "vms_failed_total",
+    "total_uptime_ms",
+    "disk_bytes_used",
+];
+
+#[test]
+fn system_info_is_flock_free_stats_runtime_takes_lock() {
+    let home = tempfile::tempdir().expect("tempdir");
+    let bin = env!("CARGO_BIN_EXE_bux");
+
+    {
+        let _held = bux::Runtime::open(home.path()).expect("hold flock");
+
+        let info = Command::new(bin)
+            .args(["system", "info", "--format", "json"])
+            .env("BUX_HOME", home.path())
+            .output()
+            .expect("system info");
+        assert!(
+            info.status.success(),
+            "system info must not call Runtime::open: {}",
+            String::from_utf8_lossy(&info.stderr)
+        );
+        let info_json: serde_json::Value =
+            serde_json::from_slice(&info.stdout).expect("system info json");
+        let info_obj = info_json.as_object().expect("system info object");
+        assert!(
+            info_obj.contains_key("host") && info_obj.contains_key("data_dir"),
+            "system info shape: {info_obj:?}"
+        );
+        for key in RUNTIME_METRIC_KEYS {
+            assert!(
+                !info_obj.contains_key(key),
+                "system info must not dump RuntimeMetrics key {key}"
+            );
+        }
+
+        let busy = Command::new(bin)
+            .args(["stats", "--runtime"])
+            .env("BUX_HOME", home.path())
+            .output()
+            .expect("stats --runtime while locked");
+        assert!(
+            !busy.status.success(),
+            "stats --runtime must take the flock"
+        );
+        let err = String::from_utf8_lossy(&busy.stderr);
+        assert!(
+            err.contains("another bux runtime"),
+            "expected Busy, got: {err}"
+        );
+    }
+
+    let ok = Command::new(bin)
+        .args(["stats", "--runtime"])
+        .env("BUX_HOME", home.path())
+        .output()
+        .expect("stats --runtime after unlock");
+    assert!(
+        ok.status.success(),
+        "{}",
+        String::from_utf8_lossy(&ok.stderr)
+    );
+    let stats: serde_json::Value = serde_json::from_slice(&ok.stdout).expect("stats json");
+    let obj = stats.as_object().expect("stats object");
+    assert_eq!(
+        obj.len(),
+        RUNTIME_METRIC_KEYS.len(),
+        "runtime JSON must be getter keys only: {obj:?}"
+    );
+    for key in RUNTIME_METRIC_KEYS {
+        assert!(obj.contains_key(key), "missing {key} in {obj:?}");
+    }
+}

--- a/crates/bux-guest/src/ca_trust.rs
+++ b/crates/bux-guest/src/ca_trust.rs
@@ -1,14 +1,32 @@
 //! Install MITM CA certificate into guest trust stores (overlay-writable paths).
 
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::Path;
 
-/// Write the CA PEM to well-known trust paths.
+/// alpine wget reads this env; sibling PEM paths are not loaded automatically.
+const SSL_CERT_FILE: &str = "/etc/ssl/certs/bux-mitm-ca.pem";
+
+/// Write the CA PEM to well-known trust paths and activate `SSL_CERT_FILE`.
 pub fn install_mitm_ca(pem: &str) -> io::Result<()> {
     write_ca_pem(Path::new("/"), pem)?;
+    activate_ssl_cert_file();
     eprintln!("[bux-guest] installed MITM CA into guest trust paths");
     Ok(())
+}
+
+/// Exec children inherit this; alpine wget does not load sibling PEM paths.
+fn activate_ssl_cert_file() {
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "PID 1, single-threaded before listen; exec children inherit SSL_CERT_FILE"
+    )]
+    {
+        // SAFETY: guest agent is PID 1 and still single-threaded (no vsock tasks yet).
+        unsafe {
+            std::env::set_var("SSL_CERT_FILE", SSL_CERT_FILE);
+        }
+    }
 }
 
 /// Write PEM to well-known trust paths. Missing parents: create. IO errors return.
@@ -33,30 +51,86 @@ fn write_ca_pem(root: &Path, pem: &str) -> io::Result<()> {
         let _ = fs::create_dir_all(parent);
     }
     let _ = fs::write(&anchor, pem.as_bytes());
+
+    let bundle = root.join("etc/ssl/certs/ca-certificates.crt");
+    if bundle.exists() {
+        let mut f = fs::OpenOptions::new().append(true).open(&bundle)?;
+        f.write_all(b"\n")?;
+        f.write_all(pem.as_bytes())?;
+        if !pem.ends_with('\n') {
+            f.write_all(b"\n")?;
+        }
+    }
     Ok(())
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "tests")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::missing_docs_in_private_items,
+    reason = "tests"
+)]
 mod tests {
     use super::*;
+
+    const PEM: &str = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n";
 
     #[test]
     fn write_ca_pem_writes_primary_paths() {
         let dir = tempfile::tempdir().unwrap();
-        let pem = "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n";
-        write_ca_pem(dir.path(), pem).unwrap();
+        write_ca_pem(dir.path(), PEM).unwrap();
         assert_eq!(
             fs::read(
                 dir.path()
                     .join("usr/local/share/ca-certificates/bux-mitm-ca.crt")
             )
             .unwrap(),
-            pem.as_bytes()
+            PEM.as_bytes()
         );
         assert_eq!(
             fs::read(dir.path().join("etc/ssl/certs/bux-mitm-ca.pem")).unwrap(),
-            pem.as_bytes()
+            PEM.as_bytes()
         );
+        assert!(
+            !dir.path()
+                .join("etc/ssl/certs/ca-certificates.crt")
+                .exists()
+        );
+    }
+
+    #[test]
+    fn write_ca_pem_appends_existing_bundle() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle = dir.path().join("etc/ssl/certs/ca-certificates.crt");
+        fs::create_dir_all(bundle.parent().unwrap()).unwrap();
+        fs::write(
+            &bundle,
+            "-----BEGIN CERTIFICATE-----\nold\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        write_ca_pem(dir.path(), PEM).unwrap();
+        let got = fs::read_to_string(&bundle).unwrap();
+        assert!(got.contains("old"), "{got}");
+        assert!(got.contains("test"), "{got}");
+        assert!(
+            got.find("old").unwrap() < got.find("test").unwrap(),
+            "{got}"
+        );
+    }
+
+    #[test]
+    fn write_ca_pem_fails_when_primary_write_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        let share = dir.path().join("usr/local/share");
+        fs::create_dir_all(&share).unwrap();
+        fs::write(share.join("ca-certificates"), b"not-a-dir").unwrap();
+        assert!(write_ca_pem(dir.path(), PEM).is_err());
+    }
+
+    #[test]
+    fn write_ca_pem_fails_when_bundle_append_blocked() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("etc/ssl/certs/ca-certificates.crt")).unwrap();
+        assert!(write_ca_pem(dir.path(), PEM).is_err());
     }
 }

--- a/crates/bux-guest/src/control.rs
+++ b/crates/bux-guest/src/control.rs
@@ -74,6 +74,7 @@ pub async fn handle(
                 .await?;
                 w.flush().await?;
             }
+            // #[non_exhaustive] exhaustiveness only.
             _ => {
                 return Err(io::Error::other("unsupported control request"));
             }

--- a/crates/bux-guest/src/mounts.rs
+++ b/crates/bux-guest/src/mounts.rs
@@ -108,9 +108,7 @@ pub fn mount_essential_tmpfs() {
 
 /// Mount each boot volume as `virtiofs`. Failure is fatal (agent does not listen).
 ///
-/// `GuestVolume::read_only` is not passed to `mount(2)`: libkrun virtio-fs is
-/// RW, and a guest `MS_RDONLY` would fake a guarantee the host share does not
-/// provide.
+/// Does not pass `MS_RDONLY`: RO is the virtio-fs device, not a guest remount.
 ///
 /// # Errors
 ///

--- a/crates/bux-guest/src/server.rs
+++ b/crates/bux-guest/src/server.rs
@@ -29,7 +29,7 @@ pub fn uptime_ms() -> u64 {
 ///
 /// # Errors
 ///
-/// Returns an error if boot, network, virtiofs, reaper start, or vsock listen fails.
+/// Returns an error if boot, network, MITM CA install, virtiofs, reaper start, or vsock listen fails.
 pub async fn run() -> io::Result<()> {
     BOOT_T0.set(Instant::now()).ok();
     eprintln!("[bux-guest] T+0ms: starting");
@@ -69,12 +69,8 @@ pub async fn run() -> io::Result<()> {
     }
 
     if let Some(ref pem) = boot.mitm_ca_pem {
-        // CA writes are fail-open so secrets create can become ready.
-        if let Err(e) = ca_trust::install_mitm_ca(pem) {
-            eprintln!("[bux-guest] MITM CA install failed: {e}");
-        } else {
-            eprintln!("[bux-guest] T+{}ms: MITM CA installed", uptime_ms());
-        }
+        ca_trust::install_mitm_ca(pem)?;
+        eprintln!("[bux-guest] T+{}ms: MITM CA installed", uptime_ms());
     }
 
     mounts::mount_virtiofs_volumes(&boot.volumes)?;

--- a/crates/bux-guest/tests/ca_no_command.rs
+++ b/crates/bux-guest/tests/ca_no_command.rs
@@ -1,4 +1,4 @@
-//! Production guest sources must not spawn CA helpers or fail-closed on writes.
+//! Guest CA install must not spawn helpers; write/append errors abort `run`.
 
 #![allow(
     unused_crate_dependencies,
@@ -8,16 +8,20 @@
 #![cfg(target_os = "linux")]
 
 #[test]
-fn ca_trust_has_no_command_and_server_does_not_fail_closed_on_ca() {
+fn ca_trust_has_no_command_and_run_fail_closes_on_ca() {
     let ca = include_str!("../src/ca_trust.rs");
     assert!(!ca.contains("Command::"), "ca_trust must not spawn helpers");
     assert!(
         !ca.contains("std::process::Command"),
         "ca_trust must not import process::Command"
     );
+    assert!(
+        ca.contains("SSL_CERT_FILE"),
+        "ca_trust must set SSL_CERT_FILE"
+    );
     let server = include_str!("../src/server.rs");
     assert!(
-        !server.contains("install_mitm_ca(pem)?"),
-        "run must not fail-closed on CA"
+        server.contains("install_mitm_ca(pem)?"),
+        "run must fail-closed on CA"
     );
 }

--- a/crates/bux-gvproxy/Cargo.toml
+++ b/crates/bux-gvproxy/Cargo.toml
@@ -21,5 +21,8 @@ time = "0.3"
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+x509-parser = "0.18"
+
 [lints]
 workspace = true

--- a/crates/bux-gvproxy/README.md
+++ b/crates/bux-gvproxy/README.md
@@ -1,9 +1,8 @@
 # bux-gvproxy
 
-Safe Rust wrapper over [gvisor-tap-vsock] (gvproxy), packaged as an L1
-platform primitive for the bux workspace. Owns the Go toolchain
-integration, static linkage of `libgvproxy.a`, and the raw FFI surface
-so that higher layers can consume a tiny, safe Rust API.
+Safe Rust wrapper over [gvisor-tap-vsock] (gvproxy) for the bux workspace.
+Owns the Go toolchain integration, static linkage of `libgvproxy.a`, and the
+raw FFI surface so callers get a small safe Rust API.
 
 ## Scope
 

--- a/crates/bux-gvproxy/src/ca.rs
+++ b/crates/bux-gvproxy/src/ca.rs
@@ -32,9 +32,9 @@ impl std::fmt::Debug for MitmCa {
     }
 }
 
-/// Generate a fresh ECDSA P-256 CA certificate suitable for short-lived MITM.
+/// Generate a fresh ECDSA P-256 CA certificate suitable for MITM.
 ///
-/// Validity: roughly now−1m … now+24h (skew-tolerant, ephemeral).
+/// Validity: now−1m … now+10y (`not_before` skew).
 ///
 /// # Errors
 ///
@@ -52,7 +52,7 @@ pub fn generate() -> Result<MitmCa> {
 
     let now = OffsetDateTime::now_utc();
     params.not_before = now - Duration::minutes(1);
-    params.not_after = now + Duration::hours(24);
+    params.not_after = now + Duration::days(365 * 10);
     params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
     params.key_usages = vec![KeyUsagePurpose::CrlSign, KeyUsagePurpose::KeyCertSign];
 
@@ -85,5 +85,25 @@ mod tests {
         let dbg = format!("{ca:?}");
         assert!(dbg.contains("REDACTED"));
         assert!(!dbg.contains("BEGIN EC") && !dbg.contains("BEGIN PRIVATE"));
+    }
+
+    fn ca_not_after(pem: &str) -> OffsetDateTime {
+        let (_, block) = x509_parser::pem::parse_x509_pem(pem.as_bytes()).unwrap();
+        block
+            .parse_x509()
+            .unwrap()
+            .validity()
+            .not_after
+            .to_datetime()
+    }
+
+    #[test]
+    fn generate_ca_not_after_is_ten_years() {
+        let ca = generate().unwrap();
+        let span = ca_not_after(&ca.cert_pem) - OffsetDateTime::now_utc();
+        assert!(
+            span >= Duration::days(365 * 10 - 1) && span <= Duration::days(365 * 10 + 1),
+            "not_after delta {span:?}"
+        );
     }
 }

--- a/crates/bux-jail/README.md
+++ b/crates/bux-jail/README.md
@@ -1,7 +1,7 @@
 # bux-jail
 
 Process isolation for the `bux-shim` child process (`bux-bwrap`,
-`bux-seccomp`).
+`bux-landlock`).
 
 ## Scope
 

--- a/crates/bux-jail/README.md
+++ b/crates/bux-jail/README.md
@@ -1,7 +1,7 @@
 # bux-jail
 
-Process isolation for the `bux-shim` child process — L2 glue over L1
-primitives (`bux-bwrap`, `bux-seccomp`).
+Process isolation for the `bux-shim` child process (`bux-bwrap`,
+`bux-seccomp`).
 
 ## Scope
 

--- a/crates/bux-jail/src/landlock_setup.rs
+++ b/crates/bux-jail/src/landlock_setup.rs
@@ -20,6 +20,16 @@ pub(crate) fn build_fd(
     restrictions.build().map_err(|e| e.to_string())
 }
 
+/// Writable `/dev` leaves. `/dev` itself stays read-only because PathBeneath is recursive.
+const DEV_RW_LEAVES: &[&str] = &[
+    "/dev/kvm",
+    "/dev/null",
+    "/dev/zero",
+    "/dev/urandom",
+    "/dev/random",
+    "/dev/shm",
+];
+
 /// Assemble allow-lists matching bwrap binds + paths the shim needs.
 fn path_restrictions(jail: &JailConfig, shim: &Path, config_path: &Path) -> PathRestrictions {
     let mut r = PathRestrictions::new();
@@ -42,10 +52,7 @@ fn path_restrictions(jail: &JailConfig, shim: &Path, config_path: &Path) -> Path
         }
     }
 
-    // Device nodes (KVM, null, urandom).
-    if Path::new("/dev").exists() {
-        r = r.allow_read_write("/dev");
-    }
+    r = allow_dev(r, Path::exists);
     if Path::new("/tmp").exists() {
         r = r.allow_read_write("/tmp");
     }
@@ -82,9 +89,26 @@ fn path_restrictions(jail: &JailConfig, shim: &Path, config_path: &Path) -> Path
     r
 }
 
-/// Allow `path` (and its parent directory when present) with the given access mode.
+/// Grant `/dev` read/traverse and RW only on listed leaves that exist.
 ///
-/// Parent is required so Landlock can traverse to the leaf path.
+/// PathBeneath is recursive, so `/dev` itself must not be RW.
+fn allow_dev(mut r: PathRestrictions, exists: impl Fn(&Path) -> bool) -> PathRestrictions {
+    if exists(Path::new("/dev")) {
+        r = r.allow_read("/dev");
+    }
+    for p in DEV_RW_LEAVES {
+        if exists(Path::new(p)) {
+            r = r.allow_read_write(*p);
+        }
+    }
+    r
+}
+
+/// Allow `path` and, when present, its parent — both with the same access mode.
+///
+/// Parent access is required so Landlock can traverse to the leaf. The parent
+/// inherits the leaf's mode, so a RW leaf RW-allows its parent (`PathBeneath`
+/// is recursive). Do not use this for `/dev/*`.
 fn allow_path_and_parent(
     mut restrictions: PathRestrictions,
     path: &Path,
@@ -167,6 +191,46 @@ mod tests {
         assert!(
             !r.network_denied(),
             "virtio-net VMs must bind host ports and egress"
+        );
+    }
+
+    #[test]
+    fn dev_parent_is_read_only_leaves_are_read_write() {
+        let r = allow_dev(PathRestrictions::new(), |_| true);
+        assert!(r.read_paths().iter().any(|p| p == Path::new("/dev")));
+        assert!(
+            !r.read_write_paths().iter().any(|p| p == Path::new("/dev")),
+            "/dev must not be RW; PathBeneath is recursive"
+        );
+        for leaf in DEV_RW_LEAVES {
+            assert!(r.read_write_paths().iter().any(|p| p == Path::new(leaf)));
+        }
+
+        let jail = JailConfig {
+            rootfs: None,
+            root_disk: None,
+            readonly_paths: vec![],
+            socks_dir: PathBuf::from("/tmp/bux-socks"),
+            virtiofs_paths: vec![],
+            watchdog_fd: None,
+            sandbox: None,
+            stderr_file: None,
+            landlock: true,
+            allow_degraded_security: false,
+            die_with_parent: true,
+            network_host: false,
+        };
+        let assembled = path_restrictions(
+            &jail,
+            Path::new("/usr/bin/true"),
+            Path::new("/tmp/cfg.json"),
+        );
+        assert!(
+            !assembled
+                .read_write_paths()
+                .iter()
+                .any(|p| p == Path::new("/dev")),
+            "assembled jail must not RW-allow /dev via allow_path_and_parent"
         );
     }
 }

--- a/crates/bux-krun/README.md
+++ b/crates/bux-krun/README.md
@@ -3,10 +3,9 @@
 Safe FFI wrapper for [`libkrun`](https://github.com/libkrun/libkrun) — a
 lightweight VM engine for sandboxed code execution.
 
-> This crate is the L1 platform primitive. Higher-level RAII/Builder
-> abstractions live in the [`bux`](https://crates.io/crates/bux) crate;
-> direct consumers of the C ABI can still reach the raw bindings via
-> the [`sys`](./src/sys.rs) module.
+Higher-level Runtime/Vm APIs live in the [`bux`](https://crates.io/crates/bux)
+crate. Direct consumers of the C ABI can still reach the raw bindings via
+[`sys`](./src/sys.rs).
 
 ## Layout
 

--- a/crates/bux-krun/src/ctx.rs
+++ b/crates/bux-krun/src/ctx.rs
@@ -334,6 +334,25 @@ pub fn add_virtiofs2(ctx: u32, tag: &str, host_path: &str, shm_size: u64) -> Res
     })
 }
 
+/// Add a virtio-fs shared directory with DAX SHM size and a read-only flag.
+///
+/// # Errors
+///
+/// Returns [`Error::InteriorNul`] / [`Error::Krun`] as above.
+pub fn add_virtiofs3(
+    ctx: u32,
+    tag: &str,
+    host_path: &str,
+    shm_size: u64,
+    read_only: bool,
+) -> Result<()> {
+    let c_tag = CString::new(tag)?;
+    let c_path = CString::new(host_path)?;
+    check("add_virtiofs3", unsafe {
+        sys::krun_add_virtiofs3(ctx, c_tag.as_ptr(), c_path.as_ptr(), shm_size, read_only)
+    })
+}
+
 // ----------------------------------------------------------------------
 // Disks
 // ----------------------------------------------------------------------
@@ -1027,6 +1046,17 @@ mod tests {
             Feature::InitBlob as u64,
             u64::from(sys::KRUN_FEATURE_INIT_BLOB),
             "Feature::InitBlob must match KRUN_FEATURE_INIT_BLOB",
+        );
+    }
+
+    #[test]
+    fn add_virtiofs3_invokes_krun_add_virtiofs3() {
+        let _: unsafe extern "C" fn(u32, *const c_char, *const c_char, u64, bool) -> i32 =
+            sys::krun_add_virtiofs3;
+        let err = add_virtiofs3(u32::MAX, "vol0", "/tmp", 0, true);
+        assert!(
+            matches!(&err, Err(Error::Krun { op, code }) if *op == "add_virtiofs3" && *code < 0),
+            "{err:?}"
         );
     }
 }

--- a/crates/bux-landlock/README.md
+++ b/crates/bux-landlock/README.md
@@ -43,10 +43,6 @@ if let Some(fd) = fd_opt {
 - Linux 5.13+ < 6.7 (no network rules): `deny_network()` silently
   no-ops thanks to the `BestEffort` compatibility mode.
 
-## Status
-
-Fresh crate, extracted per the Phase 1 L1 refactor. See
-`docs/design/L1-platform-primitives.md` in the workspace root for the
-design rationale.
+Used by `bux-jail`. Architecture: [`docs/bux-redesign.md`](../../docs/bux-redesign.md).
 
 [`landlock`]: https://crates.io/crates/landlock

--- a/crates/bux-landlock/src/restrictions.rs
+++ b/crates/bux-landlock/src/restrictions.rs
@@ -179,4 +179,28 @@ mod tests {
         assert_eq!(r.read_write_paths().len(), 1);
         assert!(r.network_denied());
     }
+
+    #[test]
+    fn parent_read_and_leaf_write_stay_on_separate_lists() {
+        let r = PathRestrictions::new()
+            .allow_read("/dev")
+            .allow_read_write("/dev/kvm")
+            .allow_read_write("/dev/null")
+            .allow_read_write("/dev/zero")
+            .allow_read_write("/dev/urandom")
+            .allow_read_write("/dev/random")
+            .allow_read_write("/dev/shm");
+        assert_eq!(r.read_paths(), [Path::new("/dev")]);
+        assert_eq!(
+            r.read_write_paths(),
+            [
+                Path::new("/dev/kvm"),
+                Path::new("/dev/null"),
+                Path::new("/dev/zero"),
+                Path::new("/dev/urandom"),
+                Path::new("/dev/random"),
+                Path::new("/dev/shm"),
+            ]
+        );
+    }
 }

--- a/crates/bux-oci/README.md
+++ b/crates/bux-oci/README.md
@@ -71,7 +71,7 @@ Layers are applied in order (bottom → top) via sequential tar extraction into 
 ## Limitations
 
 - **Pull-only** — no OCI image build or push. Image creation is out of scope.
-- **No layer deduplication** — each image stores a fully merged rootfs. Shared base layers are not deduplicated across images.
+- **No overlay sharing of merged rootfs** — each manifest digest has its own `rootfs/{digest}/` tree. Layer tarballs in `layers/` are content-addressed and ref-counted across images.
 
 ## License
 

--- a/crates/bux-oci/README.md
+++ b/crates/bux-oci/README.md
@@ -55,15 +55,15 @@ oci.remove("ubuntu:24.04")?;
 
 ## Storage Layout
 
+SQLite index plus content-addressed blobs (`src/store.rs`). Default root is
+`$BUX_HOME` or `<platform_data_dir>/bux`.
+
 ```text
-$BUX_HOME/                          # or <platform_data_dir>/bux
-├── images.json                     # Metadata index (reference, digest, size)
-└── rootfs/
-    ├── <storage_key>/              # Extracted filesystem tree
-    │   ├── bin/
-    │   ├── etc/
-    │   └── ...
-    └── <storage_key>.json          # Cached image config (Cmd, Env, ...)
+{root}/
+├── images.db                 # SQLite: image index + layer refs
+├── layers/                   # sha256-addressed layer tarballs
+├── configs/                  # sha256-addressed image config blobs
+└── rootfs/{digest}/          # extracted rootfs (keyed by manifest digest)
 ```
 
 Layers are applied in order (bottom → top) via sequential tar extraction into a single directory, producing a merged rootfs equivalent to an overlay filesystem.
@@ -75,4 +75,5 @@ Layers are applied in order (bottom → top) via sequential tar extraction into 
 
 ## License
 
-Same as the parent `bux` project. See [LICENSE](../LICENSE).
+Same as the parent `bux` project. See [`LICENSE-MIT`](../../LICENSE-MIT) and
+[`LICENSE-APACHE`](../../LICENSE-APACHE).

--- a/crates/bux-proto/src/boot.rs
+++ b/crates/bux-proto/src/boot.rs
@@ -26,14 +26,11 @@ pub enum GuestNetworkMode {
 /// virtio-fs share the guest agent must mount before vsock listen.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct GuestVolume {
-    /// libkrun virtio-fs tag from `krun_add_virtiofs`.
+    /// libkrun virtio-fs tag from `krun_add_virtiofs3`.
     pub tag: String,
     /// Absolute guest mount point (no `..`; not filesystem root).
     pub guest_path: String,
-    /// Read-only preference recorded by the host.
-    ///
-    /// Best-effort metadata: libkrun does not pass a RO flag today, so the
-    /// kernel mount is RW even when this is `true`. Not a guest mount option.
+    /// Host share is read-only. Not a guest `MS_RDONLY` mount flag.
     #[serde(default)]
     pub read_only: bool,
 }
@@ -95,8 +92,6 @@ pub struct GuestBootConfig {
     #[serde(default)]
     pub vm_id: String,
     /// virtio-fs volumes to mount at PID 1 (tag → `guest_path`).
-    ///
-    /// `GuestVolume::read_only` is metadata only; see that field.
     #[serde(default)]
     pub volumes: Vec<GuestVolume>,
 }

--- a/crates/bux-proto/src/codec.rs
+++ b/crates/bux-proto/src/codec.rs
@@ -353,9 +353,19 @@ mod tests {
     #[tokio::test]
     async fn roundtrip_control() {
         let (mut c, mut s) = tokio::io::duplex(1024);
-        send(&mut c, &ControlReq::Ping).await.unwrap();
-        let msg: ControlReq = recv(&mut s).await.unwrap();
-        assert!(matches!(msg, ControlReq::Ping));
+        for req in [
+            ControlReq::Ping,
+            ControlReq::Shutdown,
+            ControlReq::Quiesce,
+            ControlReq::Thaw,
+        ] {
+            send(&mut c, &req).await.unwrap();
+            let msg: ControlReq = recv(&mut s).await.unwrap();
+            assert_eq!(
+                postcard::to_allocvec(&msg).unwrap(),
+                postcard::to_allocvec(&req).unwrap()
+            );
+        }
 
         send(
             &mut s,
@@ -374,6 +384,28 @@ mod tests {
                 ..
             }
         ));
+
+        send(&mut s, &ControlResp::ShutdownOk).await.unwrap();
+        let resp: ControlResp = recv(&mut c).await.unwrap();
+        assert!(matches!(resp, ControlResp::ShutdownOk));
+
+        send(&mut s, &ControlResp::QuiesceOk { frozen_count: 2 })
+            .await
+            .unwrap();
+        let resp: ControlResp = recv(&mut c).await.unwrap();
+        assert!(matches!(resp, ControlResp::QuiesceOk { frozen_count: 2 }));
+
+        send(&mut s, &ControlResp::ThawOk { thawed_count: 2 })
+            .await
+            .unwrap();
+        let resp: ControlResp = recv(&mut c).await.unwrap();
+        assert!(matches!(resp, ControlResp::ThawOk { thawed_count: 2 }));
+
+        send(&mut s, &ControlResp::Error(ErrorInfo::internal("boom")))
+            .await
+            .unwrap();
+        let resp: ControlResp = recv(&mut c).await.unwrap();
+        assert!(matches!(resp, ControlResp::Error(_)));
     }
 
     #[tokio::test]

--- a/crates/bux-proto/src/message.rs
+++ b/crates/bux-proto/src/message.rs
@@ -18,7 +18,8 @@ use serde::{Deserialize, Serialize};
 /// - v7: [`ExecStart::user`] optional name-based user for guest `/etc/passwd` resolution.
 /// - v8: in-container exec (removed).
 /// - v9: Phase A only — dropped `in_container` and ping `workload_isolation`.
-pub const PROTOCOL_VERSION: u32 = 9;
+/// - v10: dropped unimplemented Metrics/HealthCheck/PrepareSnapshot control variants.
+pub const PROTOCOL_VERSION: u32 = 10;
 
 /// Default chunk size for streaming transfers (1 MiB).
 pub const STREAM_CHUNK_SIZE: usize = 1 << 20;
@@ -89,11 +90,6 @@ pub enum HelloAck {
 }
 
 /// Host → guest on a control connection.
-///
-/// [`Self::Metrics`], [`Self::HealthCheck`], and [`Self::PrepareSnapshot`] are
-/// unimplemented. The host never sends them. The guest closes the control
-/// connection on unknown variants (`unsupported control request`) and does not
-/// send [`ControlResp::Error`].
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub enum ControlReq {
@@ -105,20 +101,9 @@ pub enum ControlReq {
     Quiesce,
     /// Thaw previously frozen filesystems (`FITHAW`).
     Thaw,
-    /// Unimplemented. Host never sends this; guest tears down the control connection.
-    Metrics,
-    /// Unimplemented. Host never sends this; guest tears down the control connection.
-    HealthCheck,
-    /// Unimplemented. Host never sends this; guest tears down the control connection.
-    PrepareSnapshot,
 }
 
 /// Guest → host on a control connection.
-///
-/// [`Self::MetricsData`], [`Self::HealthOk`], and [`Self::SnapshotPrepared`] are
-/// unimplemented. The guest never sends them: unknown [`ControlReq`] variants
-/// tear down the control connection instead of producing these replies or
-/// [`Self::Error`].
 #[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ControlResp {
@@ -141,24 +126,6 @@ pub enum ControlResp {
         /// Number of filesystems thawed.
         thawed_count: u32,
     },
-    /// Unimplemented reply to [`ControlReq::Metrics`]. Guest never sends this.
-    MetricsData {
-        /// CPU usage as a percentage (0.0–100.0+).
-        cpu_percent: f32,
-        /// RSS memory usage in bytes.
-        memory_bytes: u64,
-        /// Total disk read bytes since boot.
-        disk_read_bytes: u64,
-        /// Total disk write bytes since boot.
-        disk_write_bytes: u64,
-    },
-    /// Unimplemented reply to [`ControlReq::HealthCheck`]. Guest never sends this.
-    HealthOk {
-        /// Number of checks that passed.
-        checks_passed: u32,
-    },
-    /// Unimplemented reply to [`ControlReq::PrepareSnapshot`]. Guest never sends this.
-    SnapshotPrepared,
     /// Control request failed.
     Error(ErrorInfo),
 }
@@ -446,4 +413,53 @@ pub enum ErrorCode {
     LimitExceeded,
     /// Internal guest agent error.
     Internal,
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protocol_version_is_10() {
+        assert_eq!(PROTOCOL_VERSION, 10);
+    }
+
+    #[test]
+    fn control_req_postcard_indices_stay_0_to_3() {
+        assert_eq!(postcard::to_allocvec(&ControlReq::Ping).unwrap(), [0]);
+        assert_eq!(postcard::to_allocvec(&ControlReq::Shutdown).unwrap(), [1]);
+        assert_eq!(postcard::to_allocvec(&ControlReq::Quiesce).unwrap(), [2]);
+        assert_eq!(postcard::to_allocvec(&ControlReq::Thaw).unwrap(), [3]);
+    }
+
+    #[test]
+    fn control_req_unknown_index_fails_decode() {
+        // Unknown wire variants fail decode; they never reach a match arm.
+        assert!(postcard::from_bytes::<ControlReq>(&[4]).is_err());
+    }
+
+    fn discriminant(msg: &impl Serialize) -> u8 {
+        postcard::to_allocvec(msg)
+            .unwrap()
+            .first()
+            .copied()
+            .unwrap()
+    }
+
+    #[test]
+    fn control_resp_remaining_postcard_indices() {
+        let pong = ControlResp::Pong {
+            version: String::new(),
+            uptime_ms: 0,
+        };
+        assert_eq!(discriminant(&pong), 0);
+        assert_eq!(discriminant(&ControlResp::ShutdownOk), 1);
+        assert_eq!(discriminant(&ControlResp::QuiesceOk { frozen_count: 0 }), 2);
+        assert_eq!(discriminant(&ControlResp::ThawOk { thawed_count: 0 }), 3);
+        assert_eq!(
+            discriminant(&ControlResp::Error(ErrorInfo::internal(""))),
+            4
+        );
+    }
 }

--- a/crates/bux-qcow2/README.md
+++ b/crates/bux-qcow2/README.md
@@ -36,8 +36,5 @@ assert_eq!(hdr.virtual_size, 1 << 30);
 # Ok::<_, bux_qcow2::Error>(())
 ```
 
-## Status
-
-Extracted from the `bux` main crate as part of the Phase 1 L1 refactor.
-See `docs/design/L1-platform-primitives.md` in the workspace root for the
-design rationale.
+Used by the `bux` Runtime for overlay create/flatten. Architecture:
+[`docs/bux-redesign.md`](../../docs/bux-redesign.md).

--- a/crates/bux-seccomp/README.md
+++ b/crates/bux-seccomp/README.md
@@ -28,8 +28,4 @@ bux_seccomp::install_default()?;
 # fn main() {}
 ```
 
-## Status
-
-Extracted from the `bux` main crate as part of the Phase 1 L1 refactor.
-See `docs/design/L1-platform-primitives.md` in the workspace root for
-the design rationale.
+Used by `bux-shim` / `bux-shim-bin`. Architecture: [`docs/bux-redesign.md`](../../docs/bux-redesign.md).

--- a/crates/bux-seccomp/src/arch.rs
+++ b/crates/bux-seccomp/src/arch.rs
@@ -18,8 +18,7 @@ pub const AUDIT_ARCH: u32 = 0xc000_00b7;
 ///
 /// Sorted and unique; frozen by a unit test. Covers libkrun plus the
 /// in-process gvproxy/Go runtime (clone3, rseq, netpoll, timers).
-#[cfg(target_arch = "x86_64")]
-pub const DEFAULT_ALLOWLIST: &[u32] = &[
+pub const X86_64_ALLOWLIST: &[u32] = &[
     0,   // read
     1,   // write
     2,   // open
@@ -138,11 +137,10 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
 
 /// Syscalls allowed for the bux-shim VMM process on `aarch64`.
 ///
-/// Sorted and unique; frozen by a unit test. Numbers from
+/// Sorted and unique; frozen by a unit test. Numbers and names from
 /// `asm-generic/unistd.h`. Covers libkrun plus in-process gvproxy/Go
-/// (clone3, rseq, netpoll, timers).
-#[cfg(target_arch = "aarch64")]
-pub const DEFAULT_ALLOWLIST: &[u32] = &[
+/// (clone3, rseq, netpoll, timers). `ptrace` is not listed.
+pub const AARCH64_ALLOWLIST: &[u32] = &[
     0,   // io_setup
     17,  // getcwd
     19,  // eventfd2
@@ -155,11 +153,11 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     29,  // ioctl (KVM uses many)
     34,  // mkdirat
     35,  // unlinkat
-    37,  // renameat
+    38,  // renameat
     46,  // ftruncate
     48,  // faccessat
     49,  // chdir
-    50,  // fchmod
+    52,  // fchmod
     56,  // openat
     57,  // close
     59,  // pipe2
@@ -189,19 +187,18 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     111, // timer_delete
     113, // clock_gettime
     115, // clock_nanosleep
-    117, // rt_sigsuspend
-    122, // sched_setparam
+    122, // sched_setaffinity
     123, // sched_getaffinity
     124, // sched_yield
     129, // kill
     130, // tkill
-    131, // sigaltstack
-    132, // rt_sigprocmask
-    133, // rt_sigpending
+    131, // tgkill
+    132, // sigaltstack
+    133, // rt_sigsuspend
     134, // rt_sigaction
-    135, // rt_sigpending
+    135, // rt_sigprocmask
     137, // rt_sigtimedwait
-    139, // rt_sigsuspend
+    139, // rt_sigreturn
     160, // uname
     167, // prctl
     172, // getpid
@@ -234,17 +231,12 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     221, // execve
     222, // mmap
     226, // mprotect
-    228, // madvise
     232, // mincore
-    233, // exit
-    234, // exit_group
+    233, // madvise
     242, // accept4
     260, // wait4
     261, // prlimit64
     278, // getrandom
-    281, // epoll_create1
-    282, // epoll_ctl
-    283, // epoll_pwait
     291, // statx
     293, // rseq
     435, // clone3
@@ -252,6 +244,14 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     441, // epoll_pwait2
     449, // futex_waitv
 ];
+
+/// Default allowlist for the compiled architecture.
+#[cfg(target_arch = "x86_64")]
+pub const DEFAULT_ALLOWLIST: &[u32] = X86_64_ALLOWLIST;
+
+/// Default allowlist for the compiled architecture.
+#[cfg(target_arch = "aarch64")]
+pub const DEFAULT_ALLOWLIST: &[u32] = AARCH64_ALLOWLIST;
 
 #[cfg(test)]
 #[allow(
@@ -275,20 +275,12 @@ mod tests {
         assert_eq!(AUDIT_ARCH, 0xc000_00b7);
     }
 
-    #[test]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    fn allowlist_is_non_empty() {
-        assert!(!DEFAULT_ALLOWLIST.is_empty());
-    }
-
-    #[test]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    fn allowlist_is_sorted_and_unique() {
-        // Unsorted or duplicate nrs hide a hole until SIGSYS at create.
-        for window in DEFAULT_ALLOWLIST.windows(2) {
+    fn assert_sorted_unique(list: &[u32], arch: &str) {
+        assert!(!list.is_empty(), "{arch} allowlist is empty");
+        for window in list.windows(2) {
             assert!(
                 window[0] < window[1],
-                "allowlist not strictly increasing: {} followed by {}",
+                "{arch} allowlist not strictly increasing: {} followed by {}",
                 window[0],
                 window[1]
             );
@@ -296,22 +288,39 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-    fn allowlist_includes_clone3_and_rseq() {
+    fn allowlists_are_sorted_and_unique() {
+        // Unsorted or duplicate nrs hide a hole until SIGSYS at create.
+        assert_sorted_unique(X86_64_ALLOWLIST, "x86_64");
+        assert_sorted_unique(AARCH64_ALLOWLIST, "aarch64");
+    }
+
+    #[test]
+    fn allowlists_include_clone3_and_rseq() {
         // Go starts threads with these; TSYNC cannot add them after install.
         assert!(
-            DEFAULT_ALLOWLIST.contains(&435),
-            "clone3 missing from allowlist"
+            X86_64_ALLOWLIST.contains(&435),
+            "clone3 missing from x86_64 allowlist"
         );
-        #[cfg(target_arch = "x86_64")]
         assert!(
-            DEFAULT_ALLOWLIST.contains(&334),
+            X86_64_ALLOWLIST.contains(&334),
             "rseq missing from x86_64 allowlist"
         );
-        #[cfg(target_arch = "aarch64")]
         assert!(
-            DEFAULT_ALLOWLIST.contains(&293),
+            AARCH64_ALLOWLIST.contains(&435),
+            "clone3 missing from aarch64 allowlist"
+        );
+        assert!(
+            AARCH64_ALLOWLIST.contains(&293),
             "rseq missing from aarch64 allowlist"
+        );
+    }
+
+    #[test]
+    fn aarch64_allowlist_omits_ptrace() {
+        // Filter exists to block ptrace; 117 is ptrace on asm-generic.
+        assert!(
+            !AARCH64_ALLOWLIST.contains(&117),
+            "aarch64 allowlist must not contain ptrace"
         );
     }
 }

--- a/crates/bux-seccomp/src/arch.rs
+++ b/crates/bux-seccomp/src/arch.rs
@@ -16,9 +16,8 @@ pub const AUDIT_ARCH: u32 = 0xc000_00b7;
 
 /// Syscalls allowed for the bux-shim VMM process on `x86_64`.
 ///
-/// The allowlist is sorted for readability and verified by a unit test.
-/// It covers libkrun's runtime needs: standard I/O, memory management,
-/// KVM ioctls, threading, signals, and vsock/virtio networking.
+/// Sorted and unique; frozen by a unit test. Covers libkrun plus the
+/// in-process gvproxy/Go runtime (clone3, rseq, netpoll, timers).
 #[cfg(target_arch = "x86_64")]
 pub const DEFAULT_ALLOWLIST: &[u32] = &[
     0,   // read
@@ -47,10 +46,12 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     23,  // select
     24,  // sched_yield
     25,  // mremap
+    27,  // mincore
     28,  // madvise
     32,  // dup
     33,  // dup2
     35,  // nanosleep
+    38,  // setitimer
     39,  // getpid
     41,  // socket
     42,  // connect
@@ -70,6 +71,7 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     57,  // fork
     60,  // exit
     62,  // kill
+    63,  // uname
     72,  // fcntl
     73,  // flock
     74,  // fsync
@@ -98,19 +100,26 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     204, // sched_getaffinity
     217, // getdents64
     218, // set_tid_address
+    222, // timer_create
+    223, // timer_settime
+    226, // timer_delete
     228, // clock_gettime
     230, // clock_nanosleep
     231, // exit_group
     232, // epoll_wait
     233, // epoll_ctl
+    234, // tgkill
     257, // openat
     262, // newfstatat
     269, // faccessat
     271, // ppoll
-    280, // eventfd2
+    273, // set_robust_list
+    280, // utimensat
+    281, // epoll_pwait
     282, // signalfd4
     284, // eventfd
     288, // accept4
+    290, // eventfd2
     291, // epoll_create1
     292, // dup3
     293, // pipe2
@@ -121,6 +130,7 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     334, // rseq
     435, // clone3
     439, // faccessat2
+    441, // epoll_pwait2
     448, // process_mrelease
     449, // futex_waitv
     451, // cachestat
@@ -128,13 +138,17 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
 
 /// Syscalls allowed for the bux-shim VMM process on `aarch64`.
 ///
-/// Numbers come from `asm-generic/unistd.h`; comments audited against
-/// the Linux 6.x headers and corrected where the original source had
-/// stale annotations.
+/// Sorted and unique; frozen by a unit test. Numbers from
+/// `asm-generic/unistd.h`. Covers libkrun plus in-process gvproxy/Go
+/// (clone3, rseq, netpoll, timers).
 #[cfg(target_arch = "aarch64")]
 pub const DEFAULT_ALLOWLIST: &[u32] = &[
     0,   // io_setup
     17,  // getcwd
+    19,  // eventfd2
+    20,  // epoll_create1
+    21,  // epoll_ctl
+    22,  // epoll_pwait
     23,  // dup
     24,  // dup3
     25,  // fcntl
@@ -148,6 +162,7 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     50,  // fchmod
     56,  // openat
     57,  // close
+    59,  // pipe2
     61,  // getdents64
     62,  // lseek
     63,  // read
@@ -162,13 +177,21 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     80,  // fstat
     82,  // fsync
     83,  // fdatasync
+    93,  // exit
+    94,  // exit_group
     96,  // set_tid_address
     98,  // futex
     99,  // set_robust_list
+    101, // nanosleep
+    103, // setitimer
+    107, // timer_create
+    110, // timer_settime
+    111, // timer_delete
     113, // clock_gettime
     115, // clock_nanosleep
     117, // rt_sigsuspend
     122, // sched_setparam
+    123, // sched_getaffinity
     124, // sched_yield
     129, // kill
     130, // tkill
@@ -212,6 +235,7 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     222, // mmap
     226, // mprotect
     228, // madvise
+    232, // mincore
     233, // exit
     234, // exit_group
     242, // accept4
@@ -225,6 +249,7 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
     293, // rseq
     435, // clone3
     439, // faccessat2
+    441, // epoll_pwait2
     449, // futex_waitv
 ];
 
@@ -232,7 +257,8 @@ pub const DEFAULT_ALLOWLIST: &[u32] = &[
 #[allow(
     clippy::unwrap_used,
     clippy::missing_docs_in_private_items,
-    reason = "tests are allowed to use unwrap and omit docs"
+    clippy::indexing_slicing,
+    reason = "tests are allowed to use unwrap/indexing and omit docs"
 )]
 mod tests {
     use super::*;
@@ -253,5 +279,39 @@ mod tests {
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
     fn allowlist_is_non_empty() {
         assert!(!DEFAULT_ALLOWLIST.is_empty());
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn allowlist_is_sorted_and_unique() {
+        // Unsorted or duplicate nrs hide a hole until SIGSYS at create.
+        for window in DEFAULT_ALLOWLIST.windows(2) {
+            assert!(
+                window[0] < window[1],
+                "allowlist not strictly increasing: {} followed by {}",
+                window[0],
+                window[1]
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    fn allowlist_includes_clone3_and_rseq() {
+        // Go starts threads with these; TSYNC cannot add them after install.
+        assert!(
+            DEFAULT_ALLOWLIST.contains(&435),
+            "clone3 missing from allowlist"
+        );
+        #[cfg(target_arch = "x86_64")]
+        assert!(
+            DEFAULT_ALLOWLIST.contains(&334),
+            "rseq missing from x86_64 allowlist"
+        );
+        #[cfg(target_arch = "aarch64")]
+        assert!(
+            DEFAULT_ALLOWLIST.contains(&293),
+            "rseq missing from aarch64 allowlist"
+        );
     }
 }

--- a/crates/bux-shim-bin/src/main.rs
+++ b/crates/bux-shim-bin/src/main.rs
@@ -59,14 +59,13 @@ fn main() {
     }
 }
 
-/// Start optional gvproxy, prepare libkrun, seccomp when offline, then enter.
+/// Start optional gvproxy, prepare libkrun, install seccomp, then enter.
 #[cfg(unix)]
 fn run(cfg: &bux_shim::ShimConfig) -> Result<(), String> {
     let gvp = start_gvproxy(cfg)?;
     let prepared = bux_shim::prepare(cfg).map_err(|e| e.to_string())?;
-    if gvp.is_none() {
-        bux_shim::install_seccomp().map_err(|e| e.to_string())?;
-    }
+    // After GvproxyInstance::new so existing Go threads inherit via TSYNC.
+    bux_shim::install_seccomp().map_err(|e| e.to_string())?;
     let start_result = prepared.start();
     drop(gvp);
     start_result.map_err(|e| e.to_string())

--- a/crates/bux-shim-bin/src/main.rs
+++ b/crates/bux-shim-bin/src/main.rs
@@ -169,4 +169,24 @@ mod tests {
         let cfg = base_cfg();
         assert!(start_gvproxy(&cfg).unwrap().is_none());
     }
+
+    #[test]
+    fn run_installs_seccomp_after_gvproxy_unconditionally() {
+        // Networked shims are the common path; a gvp.is_none() guard skips the filter.
+        let src = include_str!("main.rs");
+        let start = src.find("fn run(").unwrap();
+        let run_and_after = src.get(start..).unwrap();
+        let end = run_and_after.find("fn start_gvproxy(").unwrap();
+        let run = run_and_after.get(..end).unwrap();
+        assert!(
+            !run.contains("gvp.is_none()"),
+            "run must not skip seccomp when gvproxy is in-process:\n{run}"
+        );
+        let gvp_at = run.find("start_gvproxy(").unwrap();
+        let seccomp_at = run.find("install_seccomp()").unwrap();
+        assert!(
+            gvp_at < seccomp_at,
+            "install_seccomp must run after start_gvproxy:\n{run}"
+        );
+    }
 }

--- a/crates/bux-shim/README.md
+++ b/crates/bux-shim/README.md
@@ -27,7 +27,7 @@ Optional env: `BUX_WATCHDOG_FD=<fd>` (read end of parent keepalive pipe).
 |------|------|
 | `ShimConfig` | serde JSON config for the engine |
 | `prepare` | create libkrun ctx + apply config (never starts gvproxy) |
-| `install_seccomp` | default VMM seccomp (binary skips this when gvproxy is in-process) |
+| `install_seccomp` | default VMM seccomp (Linux `x86_64`/`aarch64`; Darwin no-op). Binary installs after gvproxy threads exist. |
 | `start` | `krun_start_enter` (never returns on success) |
 | `host` | host-side libkrun probes |
 | `ExitInfo` | crash diagnostics JSON |

--- a/crates/bux-shim/src/apply.rs
+++ b/crates/bux-shim/src/apply.rs
@@ -1,6 +1,6 @@
 //! Apply [`ShimConfig`] to a libkrun context and start the VM.
 //!
-//! Product callers are [`prepare`] / optional [`install_seccomp`] / [`start`].
+//! Product callers are [`prepare`] / [`install_seccomp`] / [`start`].
 //! This module never constructs gvproxy.
 
 use bux_krun::ctx as sys;
@@ -93,8 +93,9 @@ pub fn start(ctx: u32) -> Result<()> {
 
 /// Install the default seccomp BPF filter (Linux `x86_64`/`aarch64`).
 ///
-/// Other platforms: no-op. The `bux-shim` binary skips this when gvproxy
-/// is in-process.
+/// Darwin and other platforms: no-op. Linux: fail-closed (`SIGSYS` on a
+/// missing syscall). The `bux-shim` binary calls this after
+/// `GvproxyInstance::new` so existing Go threads inherit via TSYNC.
 ///
 /// # Errors
 ///

--- a/crates/bux-shim/src/apply.rs
+++ b/crates/bux-shim/src/apply.rs
@@ -363,7 +363,21 @@ mod tests {
                 },
             ]
         );
-        ro_err.expect_err("krun_add_virtiofs3");
-        rw_err.expect_err("krun_add_virtiofs3");
+        assert!(
+            matches!(
+                &ro_err,
+                Err(Error::Krun(bux_krun::Error::Krun { op, code }))
+                    if *op == "add_virtiofs3" && *code < 0
+            ),
+            "{ro_err:?}"
+        );
+        assert!(
+            matches!(
+                &rw_err,
+                Err(Error::Krun(bux_krun::Error::Krun { op, code }))
+                    if *op == "add_virtiofs3" && *code < 0
+            ),
+            "{rw_err:?}"
+        );
     }
 }

--- a/crates/bux-shim/src/apply.rs
+++ b/crates/bux-shim/src/apply.rs
@@ -150,7 +150,7 @@ fn apply_all(ctx: u32, cfg: &ShimConfig) -> Result<()> {
     }
 
     for share in &cfg.virtiofs {
-        sys::add_virtiofs(ctx, &share.tag, &share.path)?;
+        add_virtiofs_share(ctx, share)?;
     }
 
     // Virtio-net only. Never `set_port_map`.
@@ -189,6 +189,30 @@ fn apply_all(ctx: u32, cfg: &ShimConfig) -> Result<()> {
     Ok(())
 }
 
+/// Disabled DAX window for `krun_add_virtiofs3`.
+const VIRTIOFS_SHM_SIZE: u64 = 0;
+
+/// RO is a virtio-fs device flag (`krun_add_virtiofs3`), not a guest remount.
+fn add_virtiofs_share(ctx: u32, share: &crate::config::ShimVirtioFs) -> Result<()> {
+    add_virtiofs3(
+        ctx,
+        &share.tag,
+        &share.path,
+        VIRTIOFS_SHM_SIZE,
+        share.read_only,
+    )
+}
+
+/// Real libkrun `krun_add_virtiofs3`. Tests record through this wrapper.
+fn add_virtiofs3(ctx: u32, tag: &str, path: &str, shm_size: u64, read_only: bool) -> Result<()> {
+    #[cfg(test)]
+    krun_spy::record(krun_spy::Call::AddVirtioFs3 {
+        shm_size,
+        read_only,
+    });
+    Ok(sys::add_virtiofs3(ctx, tag, path, shm_size, read_only)?)
+}
+
 /// Real libkrun `krun_disable_implicit_vsock`. Tests record through this wrapper.
 fn disable_implicit_vsock(ctx: u32) -> Result<()> {
     #[cfg(test)]
@@ -215,6 +239,7 @@ mod krun_spy {
     pub(super) enum Call {
         DisableImplicitVsock,
         AddVsock { tsi_features: u32 },
+        AddVirtioFs3 { shm_size: u64, read_only: bool },
     }
 
     thread_local! {
@@ -241,7 +266,7 @@ mod tests {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::config::{ShimDiskFormat, ShimVsockPort};
+    use crate::config::{ShimDiskFormat, ShimVirtioFs, ShimVsockPort};
 
     fn offline_cfg(rootfs: &str, vsock: &str) -> ShimConfig {
         ShimConfig {
@@ -308,5 +333,37 @@ mod tests {
         );
         drop(prepared);
         drop(std::fs::remove_dir_all(&dir));
+    }
+
+    #[test]
+    fn add_virtiofs_share_calls_virtiofs3_with_zero_shm() {
+        drop(krun_spy::take());
+        let ro = ShimVirtioFs {
+            tag: "vol0".into(),
+            path: "/tmp".into(),
+            read_only: true,
+        };
+        let rw = ShimVirtioFs {
+            tag: "vol1".into(),
+            path: "/tmp".into(),
+            read_only: false,
+        };
+        let ro_err = add_virtiofs_share(u32::MAX, &ro);
+        let rw_err = add_virtiofs_share(u32::MAX, &rw);
+        assert_eq!(
+            krun_spy::take(),
+            [
+                krun_spy::Call::AddVirtioFs3 {
+                    shm_size: 0,
+                    read_only: true,
+                },
+                krun_spy::Call::AddVirtioFs3 {
+                    shm_size: 0,
+                    read_only: false,
+                },
+            ]
+        );
+        ro_err.expect_err("krun_add_virtiofs3");
+        rw_err.expect_err("krun_add_virtiofs3");
     }
 }

--- a/crates/bux-shim/src/config.rs
+++ b/crates/bux-shim/src/config.rs
@@ -28,6 +28,9 @@ pub struct ShimVirtioFs {
     pub tag: String,
     /// Absolute host path.
     pub path: String,
+    /// Read-only virtio-fs (`krun_add_virtiofs3`).
+    #[serde(default)]
+    pub read_only: bool,
 }
 
 /// vsock port mapping (guest port ↔ host Unix socket).
@@ -300,5 +303,42 @@ mod tests {
         let cfg = ShimConfig::from_json(json).unwrap();
         assert!(cfg.gvproxy.is_none());
         assert!(cfg.network.is_none());
+    }
+
+    #[test]
+    fn virtiofs_read_only_roundtrip() {
+        let cfg = ShimConfig {
+            vcpus: 1,
+            ram_mib: 256,
+            rootfs: Some("/r".into()),
+            root_disk: None,
+            disk_format: ShimDiskFormat::Raw,
+            virtiofs: vec![ShimVirtioFs {
+                tag: "vol0".into(),
+                path: "/host/data".into(),
+                read_only: true,
+            }],
+            vsock_ports: vec![],
+            network: None,
+            gvproxy: None,
+            exec_path: None,
+            exec_args: vec![],
+            env: None,
+        };
+        let de = ShimConfig::from_json(&cfg.to_json().unwrap()).unwrap();
+        let share = de.virtiofs.first().expect("one share");
+        assert_eq!(share.tag, "vol0");
+        assert_eq!(share.path, "/host/data");
+        assert!(share.read_only);
+    }
+
+    #[test]
+    fn virtiofs_read_only_defaults_false() {
+        let json =
+            br#"{"vcpus":1,"ram_mib":256,"rootfs":"/r","virtiofs":[{"tag":"vol0","path":"/h"}]}"#;
+        let cfg = ShimConfig::from_json(json).unwrap();
+        let share = cfg.virtiofs.first().expect("one share");
+        assert_eq!(share.tag, "vol0");
+        assert!(!share.read_only);
     }
 }

--- a/crates/bux-shim/src/lib.rs
+++ b/crates/bux-shim/src/lib.rs
@@ -2,8 +2,7 @@
 //!
 //! The host `bux` Runtime serialises a [`ShimConfig`] and spawns the
 //! `bux-shim` binary (`bux-shim-bin`). Product path is [`prepare`] /
-//! optional [`install_seccomp`] / [`start`]. This library does not
-//! start gvproxy.
+//! [`install_seccomp`] / [`start`]. This library does not start gvproxy.
 
 mod apply;
 mod config;

--- a/crates/bux/Cargo.toml
+++ b/crates/bux/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { workspace = true, features = ["io-util", "net", "time"] }
 
 [dev-dependencies]
 tempfile.workspace = true
+x509-parser = "0.18"
 
 [lints]
 workspace = true

--- a/crates/bux/examples/concurrent_exec.rs
+++ b/crates/bux/examples/concurrent_exec.rs
@@ -1,0 +1,69 @@
+//! R8: 16 concurrent `exec_output` on one `Runtime` / one `Vm`.
+//!
+//! Sixteen `bux exec` CLI processes cannot do this: each `Runtime::open`
+//! takes exclusive `bux.lock` (R5).
+
+#![allow(
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+    clippy::print_stderr,
+    unused_crate_dependencies,
+    missing_docs,
+    reason = "example binary inherits package deps"
+)]
+
+use std::sync::Arc;
+
+use bux::{ExecStart, RegistryAuth, Runtime, RuntimeOptions};
+use tokio::task::JoinSet;
+
+const TASKS: usize = 16;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> bux::Result<()> {
+    let Some(target) = std::env::args().nth(1) else {
+        return Err(bux::Error::InvalidConfig(
+            "usage: concurrent_exec <vm-id-or-name>".into(),
+        ));
+    };
+    let rt = Runtime::open_with(RuntimeOptions {
+        data_dir: bux::default_data_dir(),
+        shim_path: std::env::var_os("BUX_SHIM_PATH").map(Into::into),
+        guest_path: std::env::var_os("BUX_GUEST_PATH").map(Into::into),
+        registry_auth: RegistryAuth::Anonymous,
+    })?;
+    let vm = Arc::new(rt.get(&target)?);
+    let mut set = JoinSet::new();
+    for _ in 0..TASKS {
+        let vm = Arc::clone(&vm);
+        set.spawn(async move {
+            vm.exec_output(ExecStart::new("echo").args(vec!["ok".into()]))
+                .await
+        });
+    }
+    let mut failed = 0usize;
+    while let Some(joined) = set.join_next().await {
+        match joined {
+            Ok(Ok(out)) if out.code == 0 => {}
+            Ok(Ok(out)) => {
+                eprintln!("concurrent_exec: echo ok exit {}", out.code);
+                failed += 1;
+            }
+            Ok(Err(err)) => {
+                eprintln!("concurrent_exec: {err}");
+                failed += 1;
+            }
+            Err(err) => {
+                eprintln!("concurrent_exec: join {err}");
+                failed += 1;
+            }
+        }
+    }
+    if failed != 0 {
+        return Err(bux::Error::InvalidState(format!(
+            "{failed} of {TASKS} concurrent exec_output failed"
+        )));
+    }
+    Ok(())
+}

--- a/crates/bux/examples/embed.rs
+++ b/crates/bux/examples/embed.rs
@@ -1,32 +1,26 @@
-//! Embedder compile gate: `Runtime::open_with` → `create` → `exec_output` → `stop`.
+//! Embed snippet matching `crates/bux/src/lib.rs`
+//! (`Runtime::open` → `create` → `exec_output` → `stop`).
 
 #![allow(
     clippy::missing_docs_in_private_items,
     clippy::missing_errors_doc,
     clippy::missing_panics_doc,
-    clippy::panic_in_result_fn,
     missing_docs,
     unused_crate_dependencies,
     reason = "example binary inherits package deps"
 )]
 
-use bux::{ExecStart, RegistryAuth, Runtime, RuntimeOptions, VmOptions};
+use bux::{ExecStart, Runtime, VmOptions};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> bux::Result<()> {
-    let rt = Runtime::open_with(RuntimeOptions {
-        data_dir: std::env::temp_dir().join("bux-embed-example"),
-        shim_path: std::env::var_os("BUX_SHIM_PATH").map(Into::into),
-        guest_path: std::env::var_os("BUX_GUEST_PATH").map(Into::into),
-        registry_auth: RegistryAuth::Anonymous,
-    })?;
+    let rt = Runtime::open(bux::default_data_dir())?;
     let mut vm = rt
         .create(VmOptions::from_image("python:slim").vcpus(2).ram_mib(1024))
         .await?;
-    let out = vm
-        .exec_output(ExecStart::new("python").args(vec!["-c".into(), "print(1)".into()]))
+
+    vm.exec_output(ExecStart::new("python").args(vec!["-c".into(), "print(1)".into()]))
         .await?;
-    assert_eq!(out.code, 0, "python -c print");
     vm.stop().await?;
     Ok(())
 }

--- a/crates/bux/src/lib.rs
+++ b/crates/bux/src/lib.rs
@@ -73,7 +73,9 @@ pub use metrics::{RuntimeMetrics, VmMetrics};
 pub use options::{ImageRef, NetworkSpec, VmOptions};
 pub use ports::{PortSpec, PublishedPort, parse_publish_spec};
 #[cfg(unix)]
-pub use runtime::{HealthStatus, ImageInfo, Runtime, RuntimeOptions, Vm, VmInfo, default_data_dir};
+pub use runtime::{
+    EgressClass, HealthStatus, ImageInfo, Runtime, RuntimeOptions, Vm, VmInfo, default_data_dir,
+};
 #[cfg(unix)]
 pub use secrets::{Secret, StartOptions};
 pub use security::{HostInfo, LayerStatus, SecurityOptions, SecurityStatus};

--- a/crates/bux/src/runtime/boot/mod.rs
+++ b/crates/bux/src/runtime/boot/mod.rs
@@ -29,13 +29,15 @@ use crate::Result;
 use crate::options::{ImageRef, NetworkSpec, VmOptions};
 use crate::ports::parse_publish_spec;
 use crate::process::merge_image_config;
+use crate::security::HostInfo;
 use crate::state::{VirtioFs, VmConfig};
 
 /// Create and start a managed VM from product options.
 ///
 /// # Errors
 ///
-/// Propagates image pull, disk, network, spawn, or agent-ready failures.
+/// Propagates validation, missing virtualization, image pull, disk, network,
+/// spawn, or agent-ready failures.
 pub(crate) async fn create(
     rt: &Runtime,
     mut opts: VmOptions,
@@ -43,6 +45,7 @@ pub(crate) async fn create(
 ) -> Result<Vm> {
     on_progress("validating options");
     validate(&opts)?;
+    require_virtualization(HostInfo::probe().virtualization)?;
 
     on_progress("resolving image");
     let resolved = resolve_image(rt, &opts.image, &on_progress).await?;
@@ -96,6 +99,16 @@ pub(crate) async fn create(
 
     on_progress("running");
     Ok(vm)
+}
+
+/// Reject create before image pull/disk work when hardware virtualization is absent.
+fn require_virtualization(virtualization: bool) -> Result<()> {
+    if !virtualization {
+        return Err(crate::Error::SecurityUnavailable(
+            "no hardware virtualization (KVM / HVF)".into(),
+        ));
+    }
+    Ok(())
 }
 
 /// Validate product options before expensive work.
@@ -261,5 +274,13 @@ mod tests {
         opts = VmOptions::from_image("alpine");
         opts.ram_mib = 0;
         assert!(validate(&opts).is_err());
+    }
+
+    #[test]
+    fn require_virtualization_false_is_unavailable() {
+        let err = require_virtualization(false).unwrap_err();
+        assert!(matches!(err, crate::Error::SecurityUnavailable(_)));
+        assert_eq!(err.to_string(), "no hardware virtualization (KVM / HVF)");
+        assert!(require_virtualization(true).is_ok());
     }
 }

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -233,6 +233,7 @@ fn to_shim_config(
             .map(|v| ShimVirtioFs {
                 tag: v.tag.clone(),
                 path: v.path.clone(),
+                read_only: v.read_only,
             })
             .collect(),
         vsock_ports: config
@@ -481,6 +482,24 @@ mod tests {
         let shim = to_shim_config(&cfg, None, None);
         assert!(shim.network.is_none());
         assert!(shim.gvproxy.is_none());
+    }
+
+    #[test]
+    fn to_shim_config_copies_virtiofs_read_only() {
+        let cfg = VmConfig {
+            virtiofs: vec![state::VirtioFs {
+                tag: "vol0".into(),
+                path: "/host/data".into(),
+                guest_path: "/data".into(),
+                read_only: true,
+            }],
+            ..VmConfig::default()
+        };
+        let shim = to_shim_config(&cfg, None, None);
+        let share = shim.virtiofs.first().unwrap();
+        assert_eq!(share.tag, "vol0");
+        assert_eq!(share.path, "/host/data");
+        assert!(share.read_only);
     }
 
     #[test]

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -417,6 +417,43 @@ impl Runtime {
         Ok(handle)
     }
 
+    /// Restore a VM from a snapshot: flatten the snapshot overlay into a new
+    /// base, then boot a detached VM (same disk recipe as [`Self::clone`]).
+    ///
+    /// Copied from the source VM: overlay contents (via the snapshot file),
+    /// `vcpus`, `ram_mib`, `network`, and `auto_remove`. Always `detach: true`.
+    ///
+    /// Not copied: ports, volumes, secrets, security, command, env, workdir,
+    /// user, auto-stop/delete, ready timeout, or name (unless `name` is passed).
+    ///
+    /// Requires the source VM row. After [`Self::remove`] of the source,
+    /// snapshot rows are dropped (`ON DELETE CASCADE`) and this returns
+    /// [`crate::Error::NotFound`].
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the snapshot or source VM is missing, the snapshot
+    /// disk file is gone, flatten fails, or create fails.
+    pub async fn restore(&self, snapshot_id: &str, name: Option<String>) -> Result<Vm> {
+        let opts = self.restore_prepare(snapshot_id, name)?;
+        let handle = self.create(opts).await?;
+        info!(snapshot_id, restore_id = %handle.stored().id, "VM restored from snapshot");
+        Ok(handle)
+    }
+
+    /// Lookup + flatten snapshot overlay into `bases/restore-{id}.qcow2` + clone-shaped options.
+    fn restore_prepare(&self, snapshot_id: &str, name: Option<String>) -> Result<VmOptions> {
+        let snap = self.db.get_snapshot(snapshot_id)?;
+        let snap_disk = Path::new(&snap.disk_path);
+        if !snap_disk.is_file() {
+            return Err(crate::Error::NotFound(format!(
+                "snapshot disk missing: {snapshot_id}"
+            )));
+        }
+        let source = self.get(&snap.vm_id)?;
+        restore_vm_options(&self.disk, snap_disk, &source.stored().config, name)
+    }
+
     /// Create and start a managed VM from product [`VmOptions`].
     ///
     /// Pipeline: validate → resolve image → base disk → network → shim → wait ready.
@@ -567,7 +604,21 @@ impl Runtime {
     }
 }
 
-/// Create-options for a disk-clone: copy `vcpus`/`ram_mib`/`network`/`auto_remove`; always detach.
+/// Flatten a snapshot overlay into `bases/restore-{id}.qcow2` and build clone-shaped create options.
+fn restore_vm_options(
+    disk: &DiskManager,
+    snap_disk: &Path,
+    config: &VmConfig,
+    name: Option<String>,
+) -> Result<VmOptions> {
+    let restore_id = crate::state::gen_id();
+    let dest = disk.bases_dir().join(format!("restore-{restore_id}.qcow2"));
+    bux_qcow2::flatten(snap_disk, &dest)?;
+    Ok(clone_vm_options(config, name, dest))
+}
+
+/// Create-options for a disk-clone or snapshot-restore: copy
+/// `vcpus`/`ram_mib`/`network`/`auto_remove`; always detach.
 #[must_use]
 fn clone_vm_options(config: &VmConfig, name: Option<String>, clone_base: PathBuf) -> VmOptions {
     let mut opts = VmOptions::from_image(ImageRef::BaseDisk(clone_base))
@@ -763,6 +814,119 @@ mod tests {
             matches!(&opts.image, ImageRef::BaseDisk(p) if p == Path::new("/tmp/clone.qcow2")),
             "clone image must be the flattened base"
         );
+    }
+
+    #[test]
+    fn restore_after_rm_source_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let vm_id = "srcsnap000001";
+        insert_cfg(
+            &rt,
+            vm_id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig::default(),
+        );
+        let snap_path = dir.path().join("snapshots").join("snap1.qcow2");
+        fs::write(&snap_path, b"overlay").unwrap();
+        rt.db
+            .insert_snapshot(&crate::state::SnapshotRow {
+                id: "snap1".into(),
+                vm_id: vm_id.into(),
+                name: Some("s".into()),
+                disk_path: snap_path.to_string_lossy().into_owned(),
+                disk_bytes: 1,
+                created_at: SystemTime::now(),
+            })
+            .unwrap();
+        rt.remove(vm_id).unwrap();
+        let err = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(rt.restore("snap1", None))
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::NotFound(_)),
+            "CASCADE drops snapshot rows: {err}"
+        );
+    }
+
+    #[test]
+    fn restore_flatten_uses_snapshot_overlay_not_live_vm_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let vm_id = "srcsnap000002";
+
+        let live_raw = rt.disk.bases_dir().join("live.raw");
+        fs::write(&live_raw, vec![0xAA; 8192]).unwrap();
+        rt.disk
+            .create_overlay(&live_raw, crate::disk::DiskFormat::Raw, vm_id)
+            .unwrap();
+
+        let snap_raw = rt.disk.bases_dir().join("snap.raw");
+        fs::write(&snap_raw, vec![0xBB; 4096]).unwrap();
+        let snap_ovl = rt
+            .disk
+            .create_overlay(&snap_raw, crate::disk::DiskFormat::Raw, "snap-src")
+            .unwrap();
+        let snap_path = dir.path().join("snapshots").join("snap1.qcow2");
+        fs::copy(&snap_ovl, &snap_path).unwrap();
+
+        insert_cfg(
+            &rt,
+            vm_id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                vcpus: 2,
+                ram_mib: 512,
+                auto_remove: true,
+                network: NetworkSpec::Disabled,
+                ..VmConfig::default()
+            },
+        );
+        rt.db
+            .insert_snapshot(&crate::state::SnapshotRow {
+                id: "snap1".into(),
+                vm_id: vm_id.into(),
+                name: Some("s".into()),
+                disk_path: snap_path.to_string_lossy().into_owned(),
+                disk_bytes: 4096,
+                created_at: SystemTime::now(),
+            })
+            .unwrap();
+
+        let opts = rt.restore_prepare("snap1", Some("n".into())).unwrap();
+        assert!(opts.detach);
+        assert_eq!(opts.vcpus, 2);
+        assert_eq!(opts.ram_mib, 512);
+        assert!(opts.auto_remove);
+        assert_eq!(opts.name.as_deref(), Some("n"));
+        assert_eq!(opts.network, NetworkSpec::Disabled);
+        assert!(
+            matches!(&opts.image, ImageRef::BaseDisk(p) if {
+                p.starts_with(rt.disk.bases_dir())
+                    && p.file_name()
+                        .and_then(|n| n.to_str())
+                        .is_some_and(|n| n.starts_with("restore-"))
+                    && p.extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("qcow2"))
+            }),
+            "restore image must be ImageRef::BaseDisk of bases/restore-{{id}}.qcow2"
+        );
+        if let ImageRef::BaseDisk(dest) = &opts.image {
+            let hdr = bux_qcow2::read_header(dest).unwrap();
+            assert_eq!(
+                hdr.virtual_size, 4096,
+                "flatten source must be the snapshot overlay (4096), not the live VM disk (8192)"
+            );
+            assert!(
+                hdr.backing_file.is_none(),
+                "flattened restore base must be standalone"
+            );
+        }
     }
 
     #[test]

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -34,7 +34,7 @@ use crate::volumes::VolumeManager;
 use boot::{clean_vm_files, is_pid_alive};
 use bux_oci::RegistryAuth;
 
-pub use vm::{Vm, VmInfo};
+pub use vm::{EgressClass, Vm, VmInfo};
 
 /// How to open a [`Runtime`]. [`Runtime::open`] is this with defaults.
 #[derive(Debug, Clone)]

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -33,6 +33,49 @@ use crate::state::{StateDb, Status, VmState};
 use crate::volumes::VolumeManager;
 use crate::watchdog::Keepalive;
 
+/// Inspect JSON egress label derived from [`NetworkSpec`].
+///
+/// Serializes as `"unrestricted"` | `"disabled"` | `{ "allow": [...] }`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum EgressClass {
+    /// [`NetworkSpec::Enabled`] with an empty allow-list (full egress).
+    Unrestricted,
+    /// [`NetworkSpec::Disabled`] (no virtio-net).
+    Disabled,
+    /// [`NetworkSpec::Enabled`] with a non-empty allow-list.
+    Allow(Vec<String>),
+}
+
+impl From<&NetworkSpec> for EgressClass {
+    fn from(spec: &NetworkSpec) -> Self {
+        match spec {
+            NetworkSpec::Disabled => Self::Disabled,
+            NetworkSpec::Enabled { allow_net } if allow_net.is_empty() => Self::Unrestricted,
+            NetworkSpec::Enabled { allow_net } => Self::Allow(allow_net.clone()),
+        }
+    }
+}
+
+impl Serialize for EgressClass {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        match self {
+            Self::Unrestricted => serializer.serialize_str("unrestricted"),
+            Self::Disabled => serializer.serialize_str("disabled"),
+            Self::Allow(allow) => {
+                #[derive(Serialize)]
+                struct AllowList<'a> {
+                    allow: &'a [String],
+                }
+                AllowList { allow }.serialize(serializer)
+            }
+        }
+    }
+}
+
 /// Read-only product view of a managed VM (no persist/engine internals).
 #[derive(Debug, Clone, Serialize)]
 #[non_exhaustive]
@@ -53,6 +96,8 @@ pub struct VmInfo {
     pub published_ports: Vec<PublishedPort>,
     /// Guest network mode.
     pub network: NetworkSpec,
+    /// Egress class for inspect JSON (empty `allow_net` is unrestricted, not disabled).
+    pub egress: EgressClass,
     /// Actual isolation posture from last spawn.
     pub security: SecurityStatus,
     /// Requested isolation policy.
@@ -76,6 +121,7 @@ impl VmInfo {
             HealthStatus::Starting
         };
         let network = state.config.network.clone();
+        let egress = EgressClass::from(&network);
         Self {
             id: state.id.clone(),
             name: state.name.clone(),
@@ -85,6 +131,7 @@ impl VmInfo {
             health,
             published_ports: state.config.published_ports.clone(),
             network,
+            egress,
             security: state.config.security_status.clone(),
             security_options: state.config.security,
             isolation_note: PHASE_A_LIMITS,
@@ -816,5 +863,65 @@ impl Vm {
             self.db.update_status(&self.state.id, Status::Stopped)?;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing, reason = "tests")]
+mod tests {
+    use super::*;
+    use crate::options::NetworkSpec;
+    use crate::state::{Status, VmConfig, VmState};
+    use std::path::PathBuf;
+    use std::time::SystemTime;
+
+    fn info_with_network(network: NetworkSpec) -> VmInfo {
+        VmInfo::from_stored(&VmState {
+            id: "aabbccddeeff".into(),
+            name: None,
+            pid: 1,
+            image: None,
+            socket: PathBuf::from("/tmp/x.sock"),
+            status: Status::Stopped,
+            config: VmConfig {
+                network,
+                ..VmConfig::default()
+            },
+            created_at: SystemTime::UNIX_EPOCH,
+        })
+    }
+
+    #[test]
+    fn egress_json_unrestricted() {
+        let info = info_with_network(NetworkSpec::Enabled {
+            allow_net: Vec::new(),
+        });
+        assert_eq!(info.egress, EgressClass::Unrestricted);
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["egress"], serde_json::json!("unrestricted"));
+    }
+
+    #[test]
+    fn egress_json_disabled() {
+        let info = info_with_network(NetworkSpec::Disabled);
+        assert_eq!(info.egress, EgressClass::Disabled);
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(json["egress"], serde_json::json!("disabled"));
+    }
+
+    #[test]
+    fn egress_json_allow_list() {
+        let info = info_with_network(NetworkSpec::Enabled {
+            allow_net: vec!["example.com".into(), "10.0.0.0/8".into()],
+        });
+        assert_eq!(
+            info.egress,
+            EgressClass::Allow(vec!["example.com".into(), "10.0.0.0/8".into()])
+        );
+        let json = serde_json::to_value(&info).unwrap();
+        assert_eq!(
+            json["egress"],
+            serde_json::json!({ "allow": ["example.com", "10.0.0.0/8"] })
+        );
     }
 }

--- a/crates/bux/src/secrets.rs
+++ b/crates/bux/src/secrets.rs
@@ -151,7 +151,7 @@ fn mint_mitm_ca() -> crate::Result<(String, String)> {
 
     let now = OffsetDateTime::now_utc();
     params.not_before = now - time::Duration::minutes(1);
-    params.not_after = now + time::Duration::hours(24);
+    params.not_after = now + time::Duration::days(365 * 10);
     params.is_ca = IsCa::Ca(BasicConstraints::Constrained(0));
     params.key_usages = vec![KeyUsagePurpose::CrlSign, KeyUsagePurpose::KeyCertSign];
 
@@ -189,5 +189,26 @@ mod tests {
     fn mint_produces_pem() {
         let live = LiveSecrets::mint(vec![Secret::new("A", ["h"], "v")]).unwrap();
         assert!(live.ca_cert_pem.contains("BEGIN CERTIFICATE"));
+    }
+
+    fn ca_not_after(pem: &str) -> time::OffsetDateTime {
+        let (_, block) = x509_parser::pem::parse_x509_pem(pem.as_bytes()).unwrap();
+        block
+            .parse_x509()
+            .unwrap()
+            .validity()
+            .not_after
+            .to_datetime()
+    }
+
+    #[test]
+    fn mint_ca_not_after_is_ten_years() {
+        let live = LiveSecrets::mint(vec![Secret::new("A", ["h"], "v")]).unwrap();
+        let span = ca_not_after(&live.ca_cert_pem) - time::OffsetDateTime::now_utc();
+        assert!(
+            span >= time::Duration::days(365 * 10 - 1)
+                && span <= time::Duration::days(365 * 10 + 1),
+            "not_after delta {span:?}"
+        );
     }
 }

--- a/crates/bux/src/snapshot.rs
+++ b/crates/bux/src/snapshot.rs
@@ -2,7 +2,9 @@
 //!
 //! A snapshot copies the current QCOW2 overlay disk, optionally quiescing
 //! guest filesystems first (via `FIFREEZE`) for consistency. Snapshots can
-//! be listed or deleted.
+//! be listed or deleted. Restore is [`crate::Runtime::restore`]: flatten the
+//! snapshot overlay into a new base, then create like clone. Snapshot rows
+//! are `ON DELETE CASCADE` on the source VM.
 //!
 //! The snapshot workflow:
 //! 1. Quiesce guest filesystems (if VM is running).

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -79,7 +79,7 @@ pub(crate) struct VirtioFs {
     /// Guest mount point; the agent mounts this at PID 1 from `GuestBootConfig.volumes`.
     #[serde(default)]
     pub guest_path: String,
-    /// Read-only virtio-fs (`krun_add_virtiofs3`).
+    /// Guest sees this share as read-only.
     #[serde(default)]
     pub read_only: bool,
 }

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -79,7 +79,7 @@ pub(crate) struct VirtioFs {
     /// Guest mount point; the agent mounts this at PID 1 from `GuestBootConfig.volumes`.
     #[serde(default)]
     pub guest_path: String,
-    /// Read-only preference (metadata; engine may still expose RW in v1).
+    /// Read-only virtio-fs (`krun_add_virtiofs3`).
     #[serde(default)]
     pub read_only: bool,
 }

--- a/crates/bux/src/volumes.rs
+++ b/crates/bux/src/volumes.rs
@@ -40,7 +40,7 @@ pub struct VolumeMount {
     pub source: VolumeSource,
     /// Guest mount point. The agent mounts this at PID 1 from `GuestBootConfig.volumes`.
     pub guest_path: String,
-    /// Prefer read-only exposure (recorded; engine virtiofs is still RW in v1).
+    /// Read-only virtio-fs (`krun_add_virtiofs3`).
     #[serde(default)]
     pub read_only: bool,
     /// Permit otherwise default-denied sensitive host prefixes.
@@ -73,7 +73,7 @@ impl VolumeMount {
         }
     }
 
-    /// Mark the mount read-only (metadata; virtiofs RW until engine supports RO).
+    /// Expose the share read-only via `krun_add_virtiofs3`.
     #[must_use]
     pub const fn read_only(mut self, yes: bool) -> Self {
         self.read_only = yes;
@@ -98,7 +98,7 @@ pub struct ResolvedVolume {
     pub host_path: PathBuf,
     /// Guest mount point. The agent mounts this at PID 1 from `GuestBootConfig.volumes`.
     pub guest_path: String,
-    /// Read-only preference.
+    /// Read-only virtio-fs (`krun_add_virtiofs3`).
     pub read_only: bool,
     /// Named volume id when source was named; `None` for binds.
     pub volume_id: Option<String>,
@@ -532,10 +532,12 @@ mod tests {
         fs::create_dir_all(&host).unwrap();
         let db = Arc::new(StateDb::open(dir.path().join("bux.db")).unwrap());
         let vm = VolumeManager::open(dir.path(), db).unwrap();
-        let mounts = vec![VolumeMount::bind(&host, "/mnt/data")];
+        let mounts = vec![VolumeMount::bind(&host, "/mnt/data").read_only(true)];
         let resolved = vm.resolve_mounts(&mounts).unwrap();
         let first = resolved.first().expect("one resolved mount");
         assert_eq!(first.tag, "vol0");
         assert!(first.volume_id.is_none());
+        assert!(first.read_only);
+        assert!(first.to_virtiofs().read_only);
     }
 }

--- a/crates/bux/src/volumes.rs
+++ b/crates/bux/src/volumes.rs
@@ -40,7 +40,7 @@ pub struct VolumeMount {
     pub source: VolumeSource,
     /// Guest mount point. The agent mounts this at PID 1 from `GuestBootConfig.volumes`.
     pub guest_path: String,
-    /// Read-only virtio-fs (`krun_add_virtiofs3`).
+    /// Guest sees this share as read-only.
     #[serde(default)]
     pub read_only: bool,
     /// Permit otherwise default-denied sensitive host prefixes.
@@ -73,7 +73,7 @@ impl VolumeMount {
         }
     }
 
-    /// Expose the share read-only via `krun_add_virtiofs3`.
+    /// Expose the share read-only in the guest.
     #[must_use]
     pub const fn read_only(mut self, yes: bool) -> Self {
         self.read_only = yes;
@@ -98,7 +98,7 @@ pub struct ResolvedVolume {
     pub host_path: PathBuf,
     /// Guest mount point. The agent mounts this at PID 1 from `GuestBootConfig.volumes`.
     pub guest_path: String,
-    /// Read-only virtio-fs (`krun_add_virtiofs3`).
+    /// Guest sees this share as read-only.
     pub read_only: bool,
     /// Named volume id when source was named; `None` for binds.
     pub volume_id: Option<String>,

--- a/deny.toml
+++ b/deny.toml
@@ -1,239 +1,41 @@
-# This template contains all of the possible sections and their default values
+# License and advisory policy for this workspace's crate graph.
+# SPDX ids in licenses.allow are those that appear in `cargo deny list`
+# (and the Cargo.lock expressions they satisfy). LGPL-2.1-or-later is
+# omitted: r-efi is also MIT OR Apache-2.0.
 
-# Note that all fields that take a lint level have these possible values:
-# * deny - An error will be produced and the check will fail
-# * warn - A warning will be produced, but the check will not fail
-# * allow - No warning or error will be produced, though in some cases a note
-# will be
-
-# The values provided in this template are the default values that will be used
-# when any section or field is not specified in your own configuration
-
-# Root options
-
-# The graph table configures how the dependency graph is constructed and thus
-# which crates the checks are performed against
 [graph]
-# If 1 or more target triples (and optionally, target_features) are specified,
-# only the specified targets will be checked when running `cargo deny check`.
-# This means, if a particular package is only ever used as a target specific
-# dependency, such as, for example, the `nix` crate only being used via the
-# `target_family = "unix"` configuration, that only having windows targets in
-# this list would mean the nix crate, as well as any of its exclusive
-# dependencies not shared by any other crates, would be ignored, as the target
-# list here is effectively saying which targets you are building for.
-targets = [
-    # The triple can be any string, but only the target triples built in to
-    # rustc (as of 1.40) can be checked against actual config expressions
-    #"x86_64-unknown-linux-musl",
-    # You can also specify which target_features you promise are enabled for a
-    # particular target. target_features are currently not validated against
-    # the actual valid features supported by the target architecture.
-    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
-]
-# When creating the dependency graph used as the source of truth when checks are
-# executed, this field can be used to prune crates from the graph, removing them
-# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
-# is pruned from the graph, all of its dependencies will also be pruned unless
-# they are connected to another crate in the graph that hasn't been pruned,
-# so it should be used with care. The identifiers are [Package ID Specifications]
-# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
-#exclude = []
-# If true, metadata will be collected with `--all-features`. Note that this can't
-# be toggled off if true, if you want to conditionally enable `--all-features` it
-# is recommended to pass `--all-features` on the cmd line instead
-all-features = false
-# If true, metadata will be collected with `--no-default-features`. The same
-# caveat with `all-features` applies
-no-default-features = false
-# If set, these feature will be enabled when collecting metadata. If `--features`
-# is specified on the cmd line they will take precedence over this option.
-#features = []
+all-features = true
 
-# The output table provides options for how/if diagnostics are outputted
-[output]
-# When outputting inclusion graphs in diagnostics that include features, this
-# option can be used to specify the depth at which feature edges will be added.
-# This option is included since the graphs can be quite large and the addition
-# of features from the crate(s) to all of the graph roots can be far too verbose.
-# This option can be overridden via `--feature-depth` on the cmd line
-feature-depth = 1
-
-# This section is considered when running `cargo deny check advisories`
-# More documentation for the advisories section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
 [advisories]
-# The path where the advisory databases are cloned/fetched into
-#db-path = "$CARGO_HOME/advisory-dbs"
-# The url(s) of the advisory databases to use
-#db-urls = ["https://github.com/rustsec/advisory-db"]
-# A list of advisory IDs to ignore. Note that ignored advisories will still
-# output a note when they are encountered.
-ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
-]
-# If this is true, then cargo deny will use the git executable to fetch advisory database.
-# If this is false, then it uses a built-in git library.
-# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
-# See Git Authentication for more information about setting up git authentication.
-#git-fetch-with-cli = true
+# Transitive unmaintained crates (atomic-polyfill via postcard/heapless) are not CVEs.
+unmaintained = "workspace"
 
-# This section is considered when running `cargo deny check licenses`
-# More documentation for the licenses section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
 [licenses]
-# List of explicitly allowed licenses
-# See https://spdx.org/licenses/ for list of possible licenses
-# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
-allow = [
-    #"MIT",
-    #"Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
-]
-# The confidence threshold for detecting a license from license text.
-# The higher the value, the more closely the license text must be to the
-# canonical license text of a valid SPDX license file.
-# [possible values: any between 0.0 and 1.0].
 confidence-threshold = 0.8
-# Allow 1 or more licenses on a per-crate basis, so that particular licenses
-# aren't accepted for every possible crate as with the normal allow list
-exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], crate = "adler32" },
-]
-
-# Some crates don't have (easily) machine readable licensing information,
-# adding a clarification entry for it allows you to manually specify the
-# licensing information
-#[[licenses.clarify]]
-# The package spec the clarification applies to
-#crate = "ring"
-# The SPDX expression for the license requirements of the crate
-#expression = "MIT AND ISC AND OpenSSL"
-# One or more files in the crate's source used as the "source of truth" for
-# the license expression. If the contents match, the clarification will be used
-# when running the license check, otherwise the clarification will be ignored
-# and the crate will be checked normally, which may produce warnings or errors
-# depending on the rest of your configuration
-#license-files = [
-# Each entry is a crate relative path, and the (opaque) hash of its contents
-#{ path = "LICENSE", hash = 0xbd0eed23 }
-#]
-
-[licenses.private]
-# If true, ignores workspace crates that aren't published, or are only
-# published to private registries.
-# To see how to mark a crate as unpublished (to the official registry),
-# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
-ignore = false
-# One or more private registries that you might publish crates to, if a crate
-# is only published to private registries, and ignore is true, the crate will
-# not have its license(s) checked
-registries = [
-    #"https://sekretz.com/registry
-]
-
-# This section is considered when running `cargo deny check bans`.
-# More documentation about the 'bans' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
-[bans]
-# Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
-# Lint level for when a crate version requirement is `*`
-wildcards = "allow"
-# The graph highlighting used when creating dotgraphs for crates
-# with multiple versions
-# * lowest-version - The path to the lowest versioned duplicate is highlighted
-# * simplest-path - The path to the version with the fewest edges is highlighted
-# * all - Both lowest-version and simplest-path are used
-highlight = "all"
-# The default lint level for `default` features for crates that are members of
-# the workspace that is being checked. This can be overridden by allowing/denying
-# `default` on a crate-by-crate basis if desired.
-workspace-default-features = "allow"
-# The default lint level for `default` features for external crates that are not
-# members of the workspace. This can be overridden by allowing/denying `default`
-# on a crate-by-crate basis if desired.
-external-default-features = "allow"
-# List of crates that are allowed. Use with care!
 allow = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
-]
-# If true, workspace members are automatically allowed even when using deny-by-default
-# This is useful for organizations that want to deny all external dependencies by default
-# but allow their own workspace crates without having to explicitly list them
-allow-workspace = false
-# List of crates to deny
-deny = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
-]
-
-# List of features to allow/deny
-# Each entry the name of a crate and a version range. If version is
-# not specified, all versions will be matched.
-#[[bans.features]]
-#crate = "reqwest"
-# Features to not allow
-#deny = ["json"]
-# Features to allow
-#allow = [
-#    "rustls",
-#    "__rustls",
-#    "__tls",
-#    "hyper-rustls",
-#    "rustls",
-#    "rustls-pemfile",
-#    "rustls-tls-webpki-roots",
-#    "tokio-rustls",
-#    "webpki-roots",
-#]
-# If true, the allowed features must exactly match the enabled feature set. If
-# this is set there is no point setting `deny`
-#exact = true
-
-# Certain crates/versions that will be skipped when doing duplicate detection.
-skip = [
-    #"ansi_term@0.11.0",
-    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
-]
-# Similarly to `skip` allows you to skip certain crates during duplicate
-# detection. Unlike skip, it also includes the entire tree of transitive
-# dependencies starting at the specified crate, up to a certain depth, which is
-# by default infinite.
-skip-tree = [
-    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
-    #{ crate = "ansi_term@0.11.0", depth = 20 },
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
 ]
 
-# This section is considered when running `cargo deny check sources`.
-# More documentation about the 'sources' section can be found here:
-# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
 [sources]
-# Lint level for what to happen when a crate from a crate registry that is not
-# in the allow list is encountered
-unknown-registry = "warn"
-# Lint level for what to happen when a crate from a git repository that is not
-# in the allow list is encountered
-unknown-git = "warn"
-# List of URLs for allowed crate registries. Defaults to the crates.io index
-# if not specified. If it is specified but empty, no registries are allowed.
+unknown-registry = "deny"
+unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# List of URLs for allowed Git repositories
 allow-git = []
-
-[sources.allow-org]
-# github.com organizations to allow git sources for
-github = []
-# gitlab.com organizations to allow git sources for
-gitlab = []
-# bitbucket.org organizations to allow git sources for
-bitbucket = []

--- a/docs/1.0-release-bar.md
+++ b/docs/1.0-release-bar.md
@@ -1,0 +1,57 @@
+# Bux 1.0 production bar
+
+Binary checklist only. Ship this increment when **every** box is true.
+
+Product is the embeddable library + CLI (`Runtime` / `Vm` / `VmOptions`), not
+BoxLite REST, dashboard, or SDKs. Production means untrusted agent code on
+Linux KVM and macOS HVF with honest flags, a hardware VM boundary, and
+jail + Landlock fail-closed.
+
+Crate version for this increment is **0.8.0**. Do not tag `v1.0.0`.
+
+Architecture now: [`docs/bux-redesign.md`](bux-redesign.md).
+
+## Docs / honesty
+
+- [ ] [`docs/bux-redesign.md`](bux-redesign.md) and this file agree. Crate READMEs do not cite L0–L4 or `docs/design/L1-platform-primitives.md`.
+- [ ] Root `README.md` is an operator/embedder document (install, embed snippet, isolation model, capture env), not a banner.
+- [ ] Protocol v10: `ControlReq::{Metrics,HealthCheck,PrepareSnapshot}` and matching `ControlResp` variants gone.
+- [ ] Darwin FULL after the proto change uses a `bux-guest` ELF built from that commit.
+
+## Isolation
+
+- [ ] `create` returns `Error::SecurityUnavailable` when virtualization is false (`require_virtualization` before OCI pull).
+- [ ] Every virtio-fs share uses `krun_add_virtiofs3(tag, path, shm_size=0, read_only)`. FFI error fails create.
+- [ ] FULL HVF: `bux create -v host:/data:ro` then `touch /data/x` in the guest fails.
+- [ ] FULL KVM: same `:ro` assert.
+- [ ] Linux networked VMs install seccomp after gvproxy. Allowlist from `strace -f` on KVM. HVF is Darwin no-op.
+- [ ] Landlock: `/dev` read/traverse only; RW only on `/dev/kvm`, `/dev/null`, `/dev/zero`, `/dev/urandom`, `/dev/random`, `/dev/shm`. Never `allow_path_and_parent` RW on a `/dev/*` leaf.
+- [ ] MITM CA `not_after = now + 10 years` in `crates/bux/src/secrets.rs` and `crates/bux-gvproxy/src/ca.rs`.
+- [ ] Guest CA (alpine): write PEMs; append `ca-certificates.crt` when present; always `set_var("SSL_CERT_FILE", …)` in PID 1. Write/append failure aborts create.
+- [ ] FULL secrets handshake only: value absent from `bux.db` and `/proc/1/environ`; `wget -qO- https://<secret-host>/` non-empty. Substitution is Go tests, not FULL.
+
+## Snapshots
+
+- [ ] `Runtime::restore(snapshot_id, name)` exists; CLI `bux snapshot restore`. No `Vm::restore_snapshot`.
+- [ ] Flatten-then-`ImageRef::BaseDisk` (same as clone). 1.0 restore does not bump `user_version` (stays 5). `ON DELETE CASCADE`; restore after `rm` of the source is `NotFound`.
+
+## CLI / ops
+
+- [ ] `create` and `run`: `--jailer` / `--no-jailer`, `--landlock` / `--no-landlock`, `--allow-degraded`. `--log-level` on `Cli`. `tracing-subscriber` on `bux-cli` only.
+- [ ] `VmInfo.egress` is `"unrestricted" | "disabled" | { "allow": [...] }`.
+- [ ] `bux system info` remains flock-free. `bux stats --runtime` dumps `RuntimeMetrics` (`Busy` if locked).
+
+## CI / tests / release
+
+- [ ] `deny.toml` encodes real license/advisory policy; CI runs `cargo deny check`.
+- [ ] `cargo test --workspace` on `ubuntu-latest` and `macos-latest`. Reusable workflow pinned by SHA.
+- [ ] `e2e-host.yml` green with `BUX_E2E_FULL=0`.
+- [ ] FULL `scripts/e2e/smoke.sh` recorded in `CONTRIBUTING.md` on HVF **and** KVM. Optional `boot_s`; not a fail gate. Do not invent a KVM row.
+- [ ] `scripts/e2e/load.sh` and `chaos.sh` pass on a KVM host.
+- [ ] `cd.yml` produces the three tarballs (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`) + sha256. Version for this increment is `0.8.0` (not `1.0.0`).
+
+## Non-goals
+
+REST / SDK / dashboard, Phase B intra-guest isolation, Windows, GPU, SQLite
+migrations, `Runtime::gc`, OpenTelemetry, p50/p95 as merge gates, independent
+snapshots after `rm` of the source.

--- a/docs/bux-redesign.md
+++ b/docs/bux-redesign.md
@@ -1,7 +1,11 @@
 # Bux architecture
 
-This file replaces the stale L0–L4 RFC (`spawn.rs`, TSI `set_port_map`, Phase B
-libcontainer). Those paths are gone. Source of truth is the code.
+Source of truth is the code. Stale RFC paths (`spawn.rs` TSI `set_port_map`,
+youki, Phase B libcontainer) are gone.
+
+Production-ready 1.0 bar: [`docs/1.0-release-bar.md`](1.0-release-bar.md).
+Crate version for that increment is 0.8.0; the bar is not a `v1.0.0` tag
+instruction.
 
 ## Product
 
@@ -13,9 +17,9 @@ Spine:
 1. OCI (or rootfs / base disk) → ext4 base with injected static `bux-guest` → QCOW2 overlay.
 2. The `bux-shim` binary starts gvproxy (virtio-net) or stays offline. Never calls `krun_set_port_map`.
 3. Jail (`bux-jail`) spawns `bux-shim`; shim applies `ShimConfig` and `krun_start_enter`.
-4. Guest agent is PID 1 (Phase A). Workload is `exec`.
+4. Guest agent is PID 1 (Phase A). Workload is `exec`. Concurrent execs share the guest with the agent; isolation vs the host is the hardware VM boundary (KVM / HVF) plus shim jail.
 5. Host `Client` uses postcard protocol v9 (one Unix-socket connection per op).
-6. SQLite `user_version` 5; mismatch refuses to open (wipe `data_dir`).
+6. SQLite `user_version` 5 (1.0 restore does not bump it); mismatch refuses to open (wipe `data_dir`). Snapshot rows `ON DELETE CASCADE` on the source VM.
 
 ## Known defects
 
@@ -29,10 +33,12 @@ Spine:
 
 D1–D3 are complete in code. D4 is the recorded green `BUX_E2E_FULL=1` on local
 HVF (Apple Silicon) in CONTRIBUTING Layer 1. D5 is clone flatten in CONTRIBUTING
-item 16 / smoke. Host CI (`BUX_E2E_FULL=0`) is not that proof.
+item 16 / smoke. Host CI (`BUX_E2E_FULL=0`) is not that proof. There is no Linux
+KVM FULL record.
 
 ## See also
 
+- [`docs/1.0-release-bar.md`](1.0-release-bar.md) — production-ready 1.0 checklist
 - [`CONTRIBUTING.md`](../CONTRIBUTING.md) — build, env, tests
 - [`crates/bux/src/runtime/boot/mod.rs`](../crates/bux/src/runtime/boot/mod.rs) — managed boot
 - [`crates/bux-shim/README.md`](../crates/bux-shim/README.md) — engine boundary

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,143 @@
+# Security model
+
+Source of truth is the code on this tree (workspace **0.7.0**). This document
+describes **current** isolation. The production-ready 1.0 checklist is
+[`docs/1.0-release-bar.md`](1.0-release-bar.md) (crate version for that
+increment: 0.8.0). Do not read unchecked boxes there as behavior that already
+ships.
+
+Architecture spine: [`docs/bux-redesign.md`](bux-redesign.md).
+
+## Threat model
+
+| Party | Trust | Goal if hostile |
+|-------|-------|-----------------|
+| Host operator / embedder | Trusted | Sets `allow_net`, volumes, jail flags |
+| Guest image + workload + concurrent execs | Untrusted | Escape the VM, read host secrets, reach network beyond `allow_net`, persist secret values |
+
+Isolation **versus the host** is the hardware VM (Linux KVM / macOS HVF) plus
+the shim jail. Isolation **between execs in one VM** is not a guarantee (Phase
+A). Compromise of a workload is compromise of the guest agent filesystem. The
+hardware boundary vs the host still holds.
+
+Out of scope here: REST/SDK multi-tenant clouds, Phase B in-guest namespaces,
+Windows, GPU, TEE.
+
+## Host boundary
+
+`bux-shim` is the process that applies `ShimConfig` and `krun_start_enter`.
+The product library never process-takeovers libkrun on the embedder thread.
+
+- **Hypervisor:** libkrun on KVM (`/dev/kvm`) or Hypervisor.framework
+  (`kern.hv_support`). `HostInfo::probe()` records `virtualization`. Create
+  does **not** fail closed when that flag is false; `audit_isolation` appends
+  an `isolation_warnings` string. Fail-closed `Error::SecurityUnavailable` is
+  a 1.0-bar item, not current.
+- **Jailer:** `SecurityOptions.jailer` defaults **on**. Linux: bubblewrap
+  (PID/IPC/UTS) plus Landlock, fail-closed unless `allow_degraded`. macOS:
+  `sandbox-exec` Seatbelt, deny-default. Inspect persists `SecurityStatus`
+  from the last successful spawn (`sandbox`, `landlock`, `mac`).
+- **Landlock `/dev`:** this tree allowlists `/dev` read-write as a tree. Leaf
+  RW on `/dev/kvm` and a few character devices only is a 1.0-bar item.
+- **Seccomp:** `bux-shim` installs the default BPF filter on Linux
+  `x86_64`/`aarch64` **only when gvproxy is not in-process** (`gvp.is_none()`).
+  Networked VMs skip seccomp. Darwin is a no-op. Installing after in-process
+  gvproxy is a 1.0-bar item, gated on KVM FULL, not HVF.
+
+`bux system info` / `HostInfo` is the probe surface. It does not open
+`Runtime` (flock-free).
+
+## Phase A
+
+Guest agent is PID 1. Workload is `exec` through that agent. Concurrent execs
+share the guest rootfs and kernel namespaces with the agent.
+
+Inspect / `VmInfo.isolation_note` is always:
+
+> Phase A: workload processes share the guest rootfs and kernel namespaces
+> with the agent; concurrent execs are not mutually isolated; compromise of a
+> workload is compromise of the agent filesystem. Hardware boundary vs host
+> still holds.
+
+(`PHASE_A_LIMITS` in `crates/bux/src/process.rs`.) Protocol is postcard **v9**
+(Phase A only). `ControlReq::{Metrics,HealthCheck,PrepareSnapshot}` still
+exist on the wire; the host never sends them; the guest tears down the
+control connection if they arrive. Protocol v10 (delete those variants) is a
+1.0-bar item.
+
+## Egress (labeled)
+
+Default create network is `NetworkSpec::Enabled { allow_net: [] }`.
+
+| `network` | Meaning |
+|-----------|---------|
+| `Enabled { allow_net: [] }` | **Unrestricted** guest egress through gvproxy virtio-net |
+| `Enabled { allow_net: [...] }` | Default-deny except listed IP / CIDR / hostname / `*.suffix`. Gateway and guest TAP IPs always allowed |
+| `Disabled` | No virtio-net. Guest has no `eth0`. Ports and secrets are invalid |
+
+Empty allow-list is unrestricted on purpose. Inspect JSON serializes
+`network` (`NetworkSpec`). A separate `VmInfo.egress` class field
+(`"unrestricted"` / `"disabled"` / `{ "allow": [...] }`) is a 1.0-bar item,
+not current. Production profile is a non-empty allow-list or `Disabled`.
+
+The shim never calls TSI `set_port_map`. Offline VMs use
+`disable_implicit_vsock` + `add_vsock(0)` so TSI cannot leak. Published ports
+are TCP only, bind `0.0.0.0`; UDP is rejected.
+
+## Volumes
+
+Bind mounts and named volumes (`{data_dir}/volumes/{name}/`) are virtio-fs
+shares. Guest path is validated. Host-root and credential prefixes
+(`/etc/shadow`, `~/.ssh`, `~/.aws`, …) are denied unless `allow_sensitive`.
+
+`VolumeMount.read_only` / CLI `:ro` is **metadata**. The engine calls
+`krun_add_virtiofs` (no read-only flag). Guest `mount(2)` does not set
+`MS_RDONLY`. A guest write to a `:ro` share can succeed. Enforcing RO via
+`krun_add_virtiofs3(..., read_only)` is a 1.0-bar item, not current.
+
+## Secrets
+
+`Secret` values are memory-only on `Runtime`. They must not appear in
+`bux.db` or guest `/proc/1/environ`. `Debug` redacts the value. After Runtime
+process death, restart requires `StartOptions.secrets`.
+
+CLI `--secret` is visible on host `/proc/<pid>/cmdline`. Prefer
+`--secret-file` (mode `0600`).
+
+MITM CA `not_after` is **now + 24h** (`crates/bux/src/secrets.rs`,
+`crates/bux-gvproxy/src/ca.rs`). Guest PID 1 writes sibling PEMs
+(`ca_trust.rs`); it does not append `ca-certificates.crt` or set
+`SSL_CERT_FILE`. Alpine HTTPS through MITM is not a current guarantee.
+10-year CA + alpine trust + handshake FULL are 1.0-bar items.
+
+Shim config JSON is unlinked after read (`bux-shim-bin`).
+
+## Snapshots
+
+`Vm::create_snapshot` / `list_snapshots` / `delete_snapshot` (CLI
+`bux snapshot create|list|rm`) copy the QCOW2 overlay, optionally quiescing
+via `FIFREEZE`. Disk-only; no memory snapshot, no live migration.
+
+SQLite `snapshots.vm_id REFERENCES vms(id) ON DELETE CASCADE`. `bux rm` of
+the source VM deletes snapshot **rows**. Schema `user_version` is **5**;
+mismatch refuses to open (wipe `BUX_HOME` / `bux system reset`). There is no
+`Runtime::restore` and no `bux snapshot restore` on this tree. Restore
+(flatten like `clone`) is a 1.0-bar item.
+
+`Runtime::clone` flattens the overlay into a new base and boots detached. It
+is not snapshot restore.
+
+## Proof
+
+`scripts/e2e/smoke.sh` with `BUX_E2E_FULL=1` is a **manual** gate. The
+recorded green run is local HVF (Apple Silicon) in
+[`CONTRIBUTING.md`](../CONTRIBUTING.md). Host CI forces `BUX_E2E_FULL=0`.
+There is **no** Linux KVM FULL record. Do not invent one.
+
+## 1.0 bar (not this tree)
+
+Unchecked boxes in [`docs/1.0-release-bar.md`](1.0-release-bar.md) include
+create fail-closed without virtualization, virtio-fs `:ro`, seccomp+gvproxy,
+Landlock `/dev` leaf RW, 10-year MITM CA + alpine `SSL_CERT_FILE`, snapshot
+restore, `VmInfo.egress`, protocol v10, and a KVM FULL row. This document
+does not treat those as shipped.

--- a/scripts/e2e/chaos.sh
+++ b/scripts/e2e/chaos.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Chaos e2e: SIGKILL shim → inspect Stopped → rm without -f; no leftover overlay.
+# Requires BUX_E2E_FULL=1 (same pin as smoke.sh). GitHub-hosted CI keeps FULL=0.
+# No ulimit disk-full test.
+#
+# Pass: create → kill -9 shim PID → inspect "Stopped" within 5s → bux rm
+# without -f succeeds; $BUX_HOME/disks/vms/{id}.qcow2 is gone.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=full_common.sh
+source "${E2E_DIR}/full_common.sh"
+
+if [[ "${BUX_E2E_FULL:-}" != "1" ]]; then
+  echo "==> skip chaos e2e (set BUX_E2E_FULL=1 on a local HVF/KVM machine; see CONTRIBUTING.md)"
+  echo "OK (skipped chaos)"
+  exit 0
+fi
+
+export BUX_HOME="${BUX_HOME:-$(mktemp -d /tmp/bux-e2e.XXXXXX)}"
+trap e2e_cleanup_bux_home EXIT
+
+echo "==> BUX_HOME=${BUX_HOME}"
+
+pin_full_binaries
+
+IMAGE="${BUX_E2E_IMAGE:-alpine:latest}"
+echo "==> pull ${IMAGE}"
+bux pull "${IMAGE}"
+
+NAME="e2e-chaos-$(date +%s)"
+echo "==> create ${NAME}"
+create_or_dump --name "${NAME}" "${IMAGE}"
+
+insp="$(bux inspect "${NAME}")"
+echo "${insp}" | grep -E '"status":[[:space:]]*"Running"' >/dev/null
+vm_id="$(printf '%s\n' "${insp}" | sed -n 's/.*"id":[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)"
+shim_pid="$(printf '%s\n' "${insp}" | sed -n 's/.*"pid":[[:space:]]*\(-\{0,1\}[0-9][0-9]*\).*/\1/p' | head -n 1)"
+test -n "${vm_id}"
+test -n "${shim_pid}" && test "${shim_pid}" != "0"
+overlay="${BUX_HOME}/disks/vms/${vm_id}.qcow2"
+test -f "${overlay}"
+
+echo "==> kill -9 shim pid ${shim_pid} (${vm_id})"
+kill -9 "${shim_pid}" || true
+
+ok=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+  rec_status="$(bux inspect "${NAME}")"
+  if echo "${rec_status}" | grep -E '"status":[[:space:]]*"Stopped"' >/dev/null; then
+    ok=1
+    break
+  fi
+  sleep 0.25
+done
+if [[ "${ok}" -ne 1 ]]; then
+  echo "chaos: inspect did not report Stopped within 5s" >&2
+  bux inspect "${NAME}" >&2 || true
+  exit 1
+fi
+
+echo "==> rm ${NAME} (no -f)"
+bux rm "${NAME}"
+if [[ -e "${overlay}" ]]; then
+  echo "chaos: leftover overlay ${overlay}" >&2
+  exit 1
+fi
+
+echo "OK (chaos e2e)"

--- a/scripts/e2e/full_common.sh
+++ b/scripts/e2e/full_common.sh
@@ -1,0 +1,144 @@
+# Shared FULL pin for load.sh / chaos.sh. Source after ROOT is set.
+# shellcheck shell=bash
+
+full_guest_fail() {
+  echo "FULL requires a static Linux bux-guest ELF (CONTRIBUTING.md)" >&2
+  exit 1
+}
+
+# Same offsets as crates/bux/src/guest.rs validate_guest_binary (no readelf).
+validate_guest_elf() {
+  local path="$1"
+  local arch="$2"
+  python3 - "${path}" "${arch}" <<'PY' || return 1
+import struct, sys
+path, arch = sys.argv[1], sys.argv[2]
+expected = {"x86_64": 0x3E, "aarch64": 0xB7}.get(arch)
+if expected is None:
+    sys.exit(1)
+try:
+    data = open(path, "rb").read()
+except OSError:
+    sys.exit(1)
+if len(data) < 64 or data[:4] != b"\x7fELF" or data[4] != 2 or data[5] != 1:
+    sys.exit(1)
+machine = struct.unpack_from("<H", data, 18)[0]
+if machine != expected:
+    sys.exit(1)
+e_phoff = struct.unpack_from("<Q", data, 32)[0]
+e_phentsize = struct.unpack_from("<H", data, 54)[0]
+e_phnum = struct.unpack_from("<H", data, 56)[0]
+if e_phoff == 0 or e_phentsize == 0 or e_phnum == 0:
+    sys.exit(0)
+for i in range(e_phnum):
+    off = e_phoff + i * e_phentsize
+    end = off + 4
+    if end > len(data):
+        break
+    p_type = struct.unpack_from("<I", data, off)[0]
+    if p_type == 3:
+        sys.exit(1)
+sys.exit(0)
+PY
+}
+
+linux_musl_target_present() {
+  local triple="$1"
+  local sysroot
+  if command -v rustup >/dev/null 2>&1 \
+    && rustup target list --installed 2>/dev/null | grep -qx "${triple}"; then
+    return 0
+  fi
+  sysroot="$(rustc --print sysroot 2>/dev/null || true)"
+  [[ -n "${sysroot}" && -d "${sysroot}/lib/rustlib/${triple}" ]]
+}
+
+pin_full_guest() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "FULL requires python3 to validate the guest ELF (CONTRIBUTING.md)" >&2
+    exit 1
+  fi
+  local arch musl_triple guest="" c env_var
+  case "$(uname -m)" in
+    x86_64|amd64)
+      arch=x86_64
+      musl_triple=x86_64-unknown-linux-musl
+      ;;
+    aarch64|arm64)
+      arch=aarch64
+      musl_triple=aarch64-unknown-linux-musl
+      ;;
+    *)
+      full_guest_fail
+      ;;
+  esac
+  if [[ -n "${BUX_GUEST_PATH:-}" ]]; then
+    if [[ ! -f "${BUX_GUEST_PATH}" ]] || ! validate_guest_elf "${BUX_GUEST_PATH}" "${arch}"; then
+      full_guest_fail
+    fi
+    guest="${BUX_GUEST_PATH}"
+  else
+    for c in \
+      "${ROOT}/target/debug/bux-guest-${musl_triple}" \
+      "${ROOT}/target/${musl_triple}/debug/bux-guest"
+    do
+      if [[ -f "${c}" ]] && validate_guest_elf "${c}" "${arch}"; then
+        guest="${c}"
+        break
+      fi
+    done
+    if [[ -z "${guest}" && "$(uname -s)" == "Linux" ]] \
+      && command -v musl-gcc >/dev/null 2>&1 \
+      && linux_musl_target_present "${musl_triple}"; then
+      echo "building bux-guest (${musl_triple})..."
+      env_var="CARGO_TARGET_$(echo "${musl_triple}" | tr '[:lower:]-' '[:upper:]_')_LINKER"
+      env "${env_var}=musl-gcc" cargo build -p bux-guest --target "${musl_triple}" \
+        --manifest-path "${ROOT}/Cargo.toml"
+      mkdir -p "${ROOT}/target/debug"
+      cp "${ROOT}/target/${musl_triple}/debug/bux-guest" \
+        "${ROOT}/target/debug/bux-guest-${musl_triple}"
+      guest="${ROOT}/target/debug/bux-guest-${musl_triple}"
+      chmod 0755 "${guest}"
+      [[ -x "${guest}" ]] || full_guest_fail
+      validate_guest_elf "${guest}" "${arch}" || full_guest_fail
+    fi
+  fi
+  [[ -n "${guest}" && -f "${guest}" ]] || full_guest_fail
+  export BUX_GUEST_PATH="${guest}"
+}
+
+create_or_dump() {
+  if bux create "$@"; then
+    return 0
+  fi
+  echo "==> bux create failed; shim stderr:" >&2
+  cat "${BUX_HOME}/socks/"*.stderr >&2 2>/dev/null || true
+  return 1
+}
+
+e2e_cleanup_bux_home() {
+  if [[ "${BUX_E2E_FULL:-}" == "1" && "${BUX_HOME:-}" == *bux-e2e* ]] \
+    && command -v bux >/dev/null 2>&1; then
+    bux ps -aq 2>/dev/null | while read -r id; do
+      [[ -n "${id}" ]] || continue
+      bux rm -f "${id}" >/dev/null 2>&1 || true
+    done || true
+  fi
+  if [[ -n "${BUX_HOME:-}" && "${BUX_HOME}" == *bux-e2e* ]]; then
+    rm -rf "${BUX_HOME}"
+  fi
+}
+
+# Build cli+shim, Darwin codesign, pin guest, put target/debug on PATH.
+pin_full_binaries() {
+  echo "building bux-cli and bux-shim-bin (FULL pin)..."
+  cargo build -p bux-cli -p bux-shim-bin --manifest-path "${ROOT}/Cargo.toml"
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    codesign --entitlements "${ROOT}/crates/bux-shim/bux-shim.entitlements" \
+      -s - --force "${ROOT}/target/debug/bux-shim"
+  fi
+  pin_full_guest
+  export PATH="${ROOT}/target/debug:${PATH}"
+  export BUX_SHIM_PATH="${ROOT}/target/debug/bux-shim"
+  test -x "${BUX_SHIM_PATH}"
+}

--- a/scripts/e2e/load.sh
+++ b/scripts/e2e/load.sh
@@ -2,9 +2,9 @@
 # Load e2e: 8 detached alpine VMs, 16 concurrent exec on one.
 # Requires BUX_E2E_FULL=1 (same pin as smoke.sh). GitHub-hosted CI keeps FULL=0.
 #
-# Pass: all 8 Running; 16 parallel `bux exec -- echo ok` exit 0; `bux rm -f`
-# then `bux ps -q` empty and no leftover $BUX_HOME/disks/vms/*.qcow2.
-# RAM: default 512 MiB × 8; fail with a message if the host cannot allocate.
+# Pass: all 8 Running; 16 concurrent exec_output on one Runtime (R8 example);
+# `bux rm -f` then `bux ps -q` empty and no leftover $BUX_HOME/disks/vms/*.qcow2.
+# RAM: 8 × 512 MiB guests plus host overhead; fail closed if the host cannot allocate.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -23,9 +23,9 @@ trap e2e_cleanup_bux_home EXIT
 
 echo "==> BUX_HOME=${BUX_HOME}"
 
-# Fail closed if the host cannot back 8 × 512 MiB guests (do not OOM-flake).
+# Guest RAM plus a 1 GiB host reserve so the gate fires before OOM.
 require_ram_8x512() {
-  local need_mib=$((8 * 512))
+  local need_mib=$((8 * 512 + 1024))
   local measured_mib="" kind=""
   case "$(uname -s)" in
     Linux)
@@ -33,8 +33,16 @@ require_ram_8x512() {
       kind=MemAvailable
       ;;
     Darwin)
-      measured_mib="$(($(sysctl -n hw.memsize) / 1024 / 1024))"
-      kind=hw.memsize
+      measured_mib="$(
+        vm_stat | awk -v page="$(pagesize)" '
+          /^Pages free:/ { gsub(/\./, "", $NF); free = $NF }
+          /^Pages inactive:/ { gsub(/\./, "", $NF); inactive = $NF }
+          /^Pages speculative:/ { gsub(/\./, "", $NF); spec = $NF }
+          /^Pages purgeable:/ { gsub(/\./, "", $NF); purg = $NF }
+          END { print int((free + inactive + spec + purg) * page / 1024 / 1024) }
+        '
+      )"
+      kind=vm_stat
       ;;
     *)
       echo "load: unknown OS; cannot check RAM for 8×512 MiB VMs" >&2
@@ -46,10 +54,10 @@ require_ram_8x512() {
     exit 1
   fi
   if [[ "${measured_mib}" -lt "${need_mib}" ]]; then
-    echo "load: host cannot allocate 8×512 MiB (${kind} ${measured_mib} MiB < ${need_mib} MiB)" >&2
+    echo "load: host cannot allocate 8×512 MiB plus overhead (${kind} ${measured_mib} MiB < ${need_mib} MiB)" >&2
     exit 1
   fi
-  echo "==> RAM ${kind}=${measured_mib} MiB (need ${need_mib} MiB for 8×512)"
+  echo "==> RAM ${kind}=${measured_mib} MiB (need ${need_mib} MiB for 8×512 plus overhead)"
 }
 
 pin_full_binaries
@@ -87,23 +95,9 @@ for name in "${names[@]}"; do
 done
 
 one="${names[0]}"
-echo "==> 16 concurrent exec ${one} -- echo ok"
-pids=()
-for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
-  bux exec "${one}" -- echo ok >/dev/null &
-  pids+=("$!")
-done
-fail=0
-for pid in "${pids[@]}"; do
-  if ! wait "${pid}"; then
-    echo "load: concurrent exec pid ${pid} failed" >&2
-    fail=1
-  fi
-done
-if [[ "${fail}" -ne 0 ]]; then
-  echo "load: not all 16 concurrent execs exited 0" >&2
-  exit 1
-fi
+echo "==> 16 concurrent exec_output ${one} (one Runtime; R8)"
+cargo build -p bux --example concurrent_exec --manifest-path "${ROOT}/Cargo.toml"
+"${ROOT}/target/debug/examples/concurrent_exec" "${one}"
 
 echo "==> rm -f all 8"
 bux rm -f "${names[@]}"

--- a/scripts/e2e/load.sh
+++ b/scripts/e2e/load.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Load e2e: 8 detached alpine VMs, 16 concurrent exec on one.
+# Requires BUX_E2E_FULL=1 (same pin as smoke.sh). GitHub-hosted CI keeps FULL=0.
+#
+# Pass: all 8 Running; 16 parallel `bux exec -- echo ok` exit 0; `bux rm -f`
+# then `bux ps -q` empty and no leftover $BUX_HOME/disks/vms/*.qcow2.
+# RAM: default 512 MiB × 8; fail with a message if the host cannot allocate.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=full_common.sh
+source "${E2E_DIR}/full_common.sh"
+
+if [[ "${BUX_E2E_FULL:-}" != "1" ]]; then
+  echo "==> skip load e2e (set BUX_E2E_FULL=1 on a local HVF/KVM machine; see CONTRIBUTING.md)"
+  echo "OK (skipped load)"
+  exit 0
+fi
+
+export BUX_HOME="${BUX_HOME:-$(mktemp -d /tmp/bux-e2e.XXXXXX)}"
+trap e2e_cleanup_bux_home EXIT
+
+echo "==> BUX_HOME=${BUX_HOME}"
+
+# Fail closed if the host cannot back 8 × 512 MiB guests (do not OOM-flake).
+require_ram_8x512() {
+  local need_mib=$((8 * 512))
+  local measured_mib="" kind=""
+  case "$(uname -s)" in
+    Linux)
+      measured_mib="$(awk '/^MemAvailable:/ {print int($2/1024); exit}' /proc/meminfo)"
+      kind=MemAvailable
+      ;;
+    Darwin)
+      measured_mib="$(($(sysctl -n hw.memsize) / 1024 / 1024))"
+      kind=hw.memsize
+      ;;
+    *)
+      echo "load: unknown OS; cannot check RAM for 8×512 MiB VMs" >&2
+      exit 1
+      ;;
+  esac
+  if [[ -z "${measured_mib}" ]] || ! [[ "${measured_mib}" =~ ^[0-9]+$ ]]; then
+    echo "load: cannot measure host RAM (${kind:-unknown}); refusing to flake" >&2
+    exit 1
+  fi
+  if [[ "${measured_mib}" -lt "${need_mib}" ]]; then
+    echo "load: host cannot allocate 8×512 MiB (${kind} ${measured_mib} MiB < ${need_mib} MiB)" >&2
+    exit 1
+  fi
+  echo "==> RAM ${kind}=${measured_mib} MiB (need ${need_mib} MiB for 8×512)"
+}
+
+pin_full_binaries
+require_ram_8x512
+
+IMAGE="${BUX_E2E_IMAGE:-alpine:latest}"
+echo "==> pull ${IMAGE}"
+bux pull "${IMAGE}"
+
+ts="$(date +%s)"
+names=()
+echo "==> create 8 detached alpine VMs (default 512 MiB)"
+for i in 1 2 3 4 5 6 7 8; do
+  name="e2e-load-${ts}-${i}"
+  create_or_dump --name "${name}" "${IMAGE}"
+  names+=("${name}")
+done
+
+echo "==> bux ps (all Running)"
+bux ps
+psq="$(bux ps -q)"
+n="$(printf '%s\n' "${psq}" | grep -c '[^[:space:]]' || true)"
+if [[ "${n}" -ne 8 ]]; then
+  echo "load: expected 8 running VMs from bux ps -q, got ${n}:" >&2
+  printf '%s\n' "${psq}" >&2
+  exit 1
+fi
+for name in "${names[@]}"; do
+  insp="$(bux inspect "${name}")"
+  if ! echo "${insp}" | grep -E '"status":[[:space:]]*"Running"' >/dev/null; then
+    echo "load: ${name} not Running:" >&2
+    echo "${insp}" >&2
+    exit 1
+  fi
+done
+
+one="${names[0]}"
+echo "==> 16 concurrent exec ${one} -- echo ok"
+pids=()
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do
+  bux exec "${one}" -- echo ok >/dev/null &
+  pids+=("$!")
+done
+fail=0
+for pid in "${pids[@]}"; do
+  if ! wait "${pid}"; then
+    echo "load: concurrent exec pid ${pid} failed" >&2
+    fail=1
+  fi
+done
+if [[ "${fail}" -ne 0 ]]; then
+  echo "load: not all 16 concurrent execs exited 0" >&2
+  exit 1
+fi
+
+echo "==> rm -f all 8"
+bux rm -f "${names[@]}"
+
+left="$(bux ps -q || true)"
+if [[ -n "${left}" ]]; then
+  echo "load: bux ps -q not empty after rm -f:" >&2
+  printf '%s\n' "${left}" >&2
+  exit 1
+fi
+
+leftover=""
+if [[ -d "${BUX_HOME}/disks/vms" ]]; then
+  leftover="$(find "${BUX_HOME}/disks/vms" -maxdepth 1 -name '*.qcow2' -print)"
+fi
+if [[ -n "${leftover}" ]]; then
+  echo "load: leftover overlays after rm -f:" >&2
+  printf '%s\n' "${leftover}" >&2
+  exit 1
+fi
+
+echo "OK (load e2e)"

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -181,6 +181,7 @@ echo "==> help for new commands"
 bux create --help >/dev/null
 bux logs --help >/dev/null
 bux run --help | grep -q secret
+bux snapshot restore --help >/dev/null
 bux system reset --help >/dev/null
 
 if [[ "${BUX_E2E_FULL:-}" != "1" ]]; then
@@ -584,5 +585,23 @@ bux clone "${CSRC}" --name "${CDST}"
 cloned="$(bux exec "${CDST}" -- cat /clone-marker)"
 echo "${cloned}" | grep -qx cloned
 bux rm -f "${CDST}" "${CSRC}"
+
+RSRC="e2e-rsrc-$(date +%s)"
+RDST="e2e-rdst-$(date +%s)"
+echo "==> snapshot restore flatten ${RSRC} -> ${RDST}"
+create_or_dump --name "${RSRC}" "${IMAGE}"
+bux exec "${RSRC}" -- sh -c 'printf "%s\n" restored > /restore-marker && sync'
+rsid="$(bux snapshot create --name e2e-restore "${RSRC}")"
+test -n "${rsid}"
+bux snapshot restore "${rsid}" --name "${RDST}"
+restored="$(bux exec "${RDST}" -- cat /restore-marker)"
+echo "${restored}" | grep -qx restored
+bux inspect "${RSRC}" >/dev/null
+bux rm -f "${RDST}"
+bux rm -f "${RSRC}"
+if bux snapshot restore "${rsid}" --name e2e-restore-gone; then
+  echo "restore after rm source should be NotFound"
+  exit 1
+fi
 
 echo "OK (full e2e)"

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -246,6 +246,41 @@ require_wget_fail() {
   esac
 }
 
+# Handshake only (no secret in the request). MITM intercepts the secret host.
+guest_https_probe() {
+  local target="$1"
+  local host="$2"
+  local timeout="${3:-10}"
+  bux exec "${target}" -- sh -c "
+    if command -v wget >/dev/null 2>&1; then
+      w() { wget -qO- -T ${timeout} https://${host}/; }
+    elif command -v busybox >/dev/null 2>&1; then
+      w() { busybox wget -qO- -T ${timeout} https://${host}/; }
+    else
+      echo HTTPS_MISSING
+      exit 1
+    fi
+    body=\$(w) || { echo HTTPS_FAIL; exit 0; }
+    if [ -n \"\$body\" ]; then
+      echo HTTPS_OK
+    else
+      echo HTTPS_EMPTY
+    fi
+  "
+}
+
+require_https_ok() {
+  local status
+  status="$(retry_until_needle HTTPS_OK "${WGET_OK_DEADLINE_SECS}" "${WGET_OK_SLEEP_SECS}" guest_https_probe "$1" "$2" "$3")" || {
+    echo "$4: expected https handshake, got ${status:-empty}"
+    return 1
+  }
+  if [[ "${status}" != *HTTPS_OK* ]]; then
+    echo "$4: expected https handshake, got ${status:-empty}"
+    return 1
+  fi
+}
+
 # Alpine busybox has no httpd; busybox-extras does. httpd without -f daemonizes
 # so this exec returns and releases bux.lock. Never background bux exec.
 start_guest_port80() {
@@ -480,8 +515,9 @@ bux rm "${LIFE}"
 
 SEC="e2e-sec-$(date +%s)"
 SECRET_VAL="e2e-s3cr3t-n0t-persisted-$$"
-echo "==> secrets not in sqlite or guest environ ${SEC}"
-create_or_dump --name "${SEC}" --secret "e2e=${SECRET_VAL}@example.com" "${IMAGE}"
+SEC_HOST="example.com"
+echo "==> secrets not in sqlite or guest environ; HTTPS handshake ${SEC}"
+create_or_dump --name "${SEC}" --secret "e2e=${SECRET_VAL}@${SEC_HOST}" "${IMAGE}"
 if grep -a -F "${SECRET_VAL}" "${BUX_HOME}/bux.db" >/dev/null 2>&1; then
   echo "secrets: value found in bux.db"
   bux rm -f "${SEC}" || true
@@ -490,6 +526,10 @@ fi
 bux exec "${SEC}" -- cat /proc/1/environ > "${BUX_HOME}/guest-environ.bin"
 if grep -a -F "${SECRET_VAL}" "${BUX_HOME}/guest-environ.bin" >/dev/null; then
   echo "secrets: value found in guest /proc/1/environ"
+  bux rm -f "${SEC}" || true
+  exit 1
+fi
+if ! require_https_ok "${SEC}" "${SEC_HOST}" 10 "secrets https handshake"; then
   bux rm -f "${SEC}" || true
   exit 1
 fi

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -452,6 +452,21 @@ vol_ls="$(bux exec "${VOL}" -- ls /data)"
 echo "${vol_ls}" | grep -q marker
 bux rm -f "${VOL}"
 
+# :ro is engine-enforced (krun_add_virtiofs3), not a guest remount.
+RO="e2e-vol-ro-$(date +%s)"
+RO_HOST="${BUX_HOME}/vol-ro-src"
+mkdir -p "${RO_HOST}"
+printf 'ro-ok\n' > "${RO_HOST}/marker"
+echo "==> volume :ro ${RO} (${RO_HOST}:/data:ro)"
+create_or_dump --name "${RO}" -v "${RO_HOST}:/data:ro" "${IMAGE}"
+bux exec "${RO}" -- cat /data/marker | grep -qx ro-ok
+if bux exec "${RO}" -- touch /data/should-fail; then
+  echo "volume :ro failed: guest touch succeeded"
+  bux rm -f "${RO}" || true
+  exit 1
+fi
+bux rm -f "${RO}"
+
 # stop / restart / rm of a detach=true VM: each CLI exit must leave the VM as designed.
 LIFE="e2e-life-$(date +%s)"
 echo "==> detach lifecycle ${LIFE} (stop/restart/rm)"


### PR DESCRIPTION
## Summary

Workspace **0.8.0** (no git tag). Closes the production-ready bar on the embeddable library + CLI: honest isolation flags, protocol v10, snapshot restore, CI policy.

## Changes

- Protocol v10: drop unimplemented `Metrics` / `HealthCheck` / `PrepareSnapshot` control variants
- Virtio-fs via `krun_add_virtiofs3`; `read_only` is engine-enforced
- MITM CA 10y; alpine trust (`ca-certificates.crt` append + `SSL_CERT_FILE`); FULL HTTPS handshake
- Linux seccomp always installed after in-process gvproxy
- Landlock `/dev` traverse-only + leaf RW; `create` fail-closed without KVM/HVF
- `Runtime::restore` / `bux snapshot restore` (flatten like clone; schema stays v5)
- CLI `--jailer`/`--no-jailer`, `--log-level`, `VmInfo.egress`, `bux stats --runtime`
- Real `deny.toml`; reusable workflow pinned by SHA; in-repo `cargo test --workspace`
- `load.sh` / `chaos.sh`; KVM FULL procedure documented (no fabricated row)

## Notes

Linux KVM networked FULL is still an operator record, not a GitHub-hosted gate. `BUX_E2E_FULL` stays off on GHA.