### PR TITLE
fix(ci): clippy PathBeneath rustdoc and macOS Go for workspace tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.1
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: crates/bux-gvproxy/gvproxy-bridge/go.mod
       - uses: Swatinem/rust-cache@v2
       # Guest unit tests (reaper, ca_no_command, sig_ign_waitpid) are cfg(linux).
+      # macos-latest has no Go; workspace tests compile bux-gvproxy (libgvproxy).
       # Never BUX_E2E_FULL=1 on GitHub-hosted runners.
       - name: Workspace tests
         run: cargo test --workspace

--- a/crates/bux-jail/src/landlock_setup.rs
+++ b/crates/bux-jail/src/landlock_setup.rs
@@ -20,7 +20,7 @@ pub(crate) fn build_fd(
     restrictions.build().map_err(|e| e.to_string())
 }
 
-/// Writable `/dev` leaves. `/dev` itself stays read-only because PathBeneath is recursive.
+/// Writable `/dev` leaves. `/dev` itself stays read-only because `PathBeneath` is recursive.
 const DEV_RW_LEAVES: &[&str] = &[
     "/dev/kvm",
     "/dev/null",
@@ -91,7 +91,7 @@ fn path_restrictions(jail: &JailConfig, shim: &Path, config_path: &Path) -> Path
 
 /// Grant `/dev` read/traverse and RW only on listed leaves that exist.
 ///
-/// PathBeneath is recursive, so `/dev` itself must not be RW.
+/// `PathBeneath` is recursive, so `/dev` itself must not be RW.
 fn allow_dev(mut r: PathRestrictions, exists: impl Fn(&Path) -> bool) -> PathRestrictions {
     if exists(Path::new("/dev")) {
         r = r.allow_read("/dev");


### PR DESCRIPTION
## Summary

CI on #126 failed two jobs:

- **ci / build**: `clippy::doc_markdown` on `PathBeneath` in `bux-jail` rustdoc
- **test (macos-latest)**: `cargo test --workspace` builds `bux-gvproxy`; macos-latest has no `go`

## Changes

- Backtick `PathBeneath` in landlock rustdoc
- `actions/setup-go` on the in-repo workspace-test job, version from `gvproxy-bridge/go.mod`