### PR TITLE
fix(guest): stamp bux-guest-protocol-v10; smoke.sh sources full_common.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ bux system info --format json
 - Product entry: `Runtime` + `Vm` + `VmOptions` (`crates/bux`).
 - Engine boundary: product `VmConfig` → `ShimConfig` → `bux-shim` → libkrun.
 - Managed network: gvproxy virtio-net in the `bux-shim` process (`bux-shim-bin`); no TSI `set_port_map`.
-- Guest agent: postcard protocol v9; Phase A process identity only.
+- Guest agent: postcard protocol v10; Phase A process identity only.
 - Schema: SQLite `user_version` 5 — **no migrations**; wipe `BUX_HOME` on mismatch.
 
 ## Tests
@@ -116,12 +116,17 @@ The first green FULL is recorded below on **local HVF (Apple Silicon)**.
 Host CI (`BUX_E2E_FULL=0`) is not that proof. Linux KVM has **no** Layer 1
 row in this tree (procedure under **Linux KVM FULL record**).
 
+The HVF captures below (`42f02b0`, `f4ff20f`, `04fca66`) ran against pre-v10
+guests. They are **not ship proof**. Do not invent a new uname or ELF sha256
+to update this table. Linux KVM stays empty until an operator records a v10
+run.
+
 ### Layer 1 FULL record
 
 Operator FULL 2026-08-28 local HVF (smoke START 2026-08-27T19:48:37Z UTC,
 `SMOKE_EXIT=0`, `OK (full e2e)`). Capture binary `./target/debug/bux` (not
 PATH `bux`). `$BUX_HOME` was `/Users/xu/bux-full-hvf-119` (no `bux-e2e`
-substring).
+substring). **Pre-v10; not ship proof.**
 
 | Field | Value |
 | ----- | ----- |
@@ -176,18 +181,27 @@ data dir on exit). Darwin guest ELF: `scripts/e2e/fetch-guest.sh`.
 
 FULL always builds `target/debug/bux` and `target/debug/bux-shim` and ignores a
 PATH `bux`. On Darwin the script ad-hoc codesigns the shim with
-`crates/bux-shim/bux-shim.entitlements`. Darwin HVF needs that codesign plus a
-guest ELF via `BUX_GUEST_PATH` from `scripts/e2e/fetch-guest.sh` (not a cwd
-`gh run download` that leaves the ELF nested). Darwin does not compile the guest
-and does not use zig cc. Linux FULL may `cargo build -p bux-guest --target
-$ARCH-unknown-linux-musl` only when `musl-gcc` and that rustc target are already
-present; the ELF must still pass validation (64-bit LE, host guest arch
-x86_64/aarch64, no `PT_INTERP`). Missing or dynamic ELF exits before `bux
-create`. FULL needs python3 for the guest ELF validator and Go for
-`bux-shim-bin`; Darwin FULL still needs `BUX_GUEST_PATH` and `gh` authenticated
-to `qntx/bux` with `workflow` if they must dispatch; `gh release download
-guest-<sha>` is enough when that Release exists; `gh run download` is enough
-when a matching run already exists.
+`crates/bux-shim/bux-shim.entitlements`. Darwin FULL **requires**
+`BUX_GUEST_PATH` from `scripts/e2e/fetch-guest.sh` of this HEAD (not a cwd
+`gh run download` that leaves the ELF nested). There is no leftover
+`target/debug/bux-guest-*` fall-through: unset `BUX_GUEST_PATH` plus a leftover
+ELF must fail before `bux create`. Before fetch, unset `BUX_GUEST_PATH` **and**
+delete leftover `target/debug/bux-guest-*`. Darwin does not compile the guest
+and does not use zig cc.
+
+Linux FULL when `BUX_GUEST_PATH` is unset: musl-gcc build of this tree (when
+`musl-gcc` and that rustc target are already present) **or**
+`scripts/e2e/fetch-guest.sh`. Do not silently accept a leftover v9 ELF. After
+musl-build/fetch, the ELF must still contain the literal bytes
+`bux-guest-protocol-v10`. Missing stamp, missing ELF, or a dynamic ELF exits
+before `bux create`. Validation is 64-bit LE, host guest arch x86_64/aarch64,
+no `PT_INTERP`, plus that stamp.
+
+FULL needs python3 for the guest ELF validator and Go for `bux-shim-bin`;
+Darwin FULL still needs `BUX_GUEST_PATH` and `gh` authenticated to `qntx/bux`
+with `workflow` if they must dispatch; `gh release download guest-<sha>` is
+enough when that Release exists; `gh run download` is enough when a matching
+run already exists.
 
 CD `cd.yml` musl guest:
 
@@ -196,6 +210,14 @@ CD `cd.yml` musl guest:
 - GHA artifact **name**: `guest-<triple>` (never `bux-guest-*`)
 - **file** inside the artifact: `bux-guest-<triple>`
 - sibling after fetch: `target/debug/bux-guest-<triple>`
+
+After this PR and PR 1 (combined CAfile) are both on `main`:
+
+```bash
+git fetch origin
+git tag "guest-$(git rev-parse origin/main)" "$(git rev-parse origin/main)"
+git push origin "guest-$(git rev-parse origin/main)"
+```
 
 Do not vendor the ELF in git. Do not fill the FULL record above from a
 Release download.
@@ -222,13 +244,18 @@ OCI (`bux pull` / `bux create IMAGE`).
    `bind_addr=0.0.0.0`, host TCP to that port **reaches the guest**
 7. **`offline-no-eth0`:** `bux create --network=disabled`, wget fails (no TSI),
    `/sys/class/net/eth0` absent (do not also assert dummy-nic)
-8. volume: `bux create -v host:/data` then `bux exec -- ls /data`
+8. volume: `bux create -v host:/data` then `bux exec -- ls /data`; `:ro`
+   write-fail (guest can read; `touch` on the volume fails)
 9. `bux stop` / `bux restart` / `bux rm` of a `detach=true` VM (no `bux start`;
    restart must still survive CLI exit)
-10. secrets: value not in `bux.db` or guest `/proc/1/environ`
+10. secrets: value not in `bux.db` or guest `/proc/1/environ`; HTTPS MITM
+    handshake returns a **non-empty body**
 
-The Layer 1 record above is that green local HVF run. Host CI
-(`BUX_E2E_FULL=0`) is not that proof. Linux KVM FULL remains empty.
+The Layer 1 record above is that green local HVF run (**pre-v10, not ship
+proof**). Host CI (`BUX_E2E_FULL=0`) is not that proof. Linux KVM FULL remains
+empty. HEAD `smoke.sh` asserts `:ro` write-fail, HTTPS MITM non-empty body,
+clone flatten, restore flatten + CASCADE; `load.sh` / `chaos.sh` are the same
+FULL pin.
 
 Items 11–15 are not in the `42f02b0` Layer 1 row.
 
@@ -241,6 +268,7 @@ Items 11–15 are not in the `42f02b0` Layer 1 row.
 Operator FULL 2026-08-28 on `f4ff20ffaabfde6aedb30d9e2e23d5916405765f`
 (capture binary `./target/debug/bux`, `$BUX_HOME=/Users/xu/bux-full-hvf-addenda3`)
 exited 0 including items 11–15 (`SMOKE_EXIT=0`, `OK (full e2e)`).
+**Pre-v10; not ship proof.**
 
 Item 16 is not in the `42f02b0` Layer 1 row.
 
@@ -249,12 +277,15 @@ Item 16 is not in the `42f02b0` Layer 1 row.
 Operator FULL 2026-08-28 on `04fca66945fe24fc16fda5aff113c8e4782cbc68`
 (capture binary `./target/debug/bux`, `$BUX_HOME=/Users/xu/bux-full-hvf-clone`)
 exited 0 including clone flatten (`SMOKE_EXIT=0`, `OK (full e2e)`).
+**Pre-v10; not ship proof.**
 
 Item 17 is not in the Layer 1 or clone FULL rows.
 
 17. snapshot restore flatten: write `/restore-marker` → `bux snapshot create` →
     `bux snapshot restore` → `exec` cat marker; source still listed; `rm`
     restore; `rm` source drops snapshot rows (`ON DELETE CASCADE`)
+18. load.sh (below)
+19. chaos.sh (below)
 
 `scripts/e2e/load.sh` (`BUX_E2E_FULL=1`, dedicated `$BUX_HOME`):
 

--- a/crates/bux-cli/README.md
+++ b/crates/bux-cli/README.md
@@ -20,8 +20,8 @@ and FULL procedure: [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 | `wait` | Block until VMs stop |
 | `prune` | Remove all stopped VMs |
 | `rename` / `restart` | Rename; restart a stopped or running VM |
-| `stats` | VM identity, status, and health |
-| `snapshot create` / `list` / `rm` | Disk overlay snapshots |
+| `stats` | VM identity, status, and health; `--runtime` dumps `RuntimeMetrics` |
+| `snapshot create` / `list` / `rm` / `restore` | Disk overlay snapshots |
 | `clone` | Disk-clone (overlay flatten); always boots detached |
 | `export` | Export a VM disk as standalone QCOW2 |
 | `pull` / `images` / `rmi` | OCI images |

--- a/crates/bux-guest/src/server.rs
+++ b/crates/bux-guest/src/server.rs
@@ -16,6 +16,13 @@ use crate::mounts;
 use crate::network;
 use crate::reaper::Reaper;
 
+/// Contiguous ELF bytes so pin scripts can reject leftover v9 guests.
+const ELF_PROTOCOL_STAMP: &str = "bux-guest-protocol-v10";
+const _: () = assert!(
+    PROTOCOL_VERSION == 10,
+    "ELF_PROTOCOL_STAMP must match PROTOCOL_VERSION"
+);
+
 /// Boot timestamp, set once at agent startup.
 pub static BOOT_T0: OnceLock<Instant> = OnceLock::new();
 
@@ -32,7 +39,7 @@ pub fn uptime_ms() -> u64 {
 /// Returns an error if boot, network, MITM CA install, virtiofs, reaper start, or vsock listen fails.
 pub async fn run() -> io::Result<()> {
     BOOT_T0.set(Instant::now()).ok();
-    eprintln!("[bux-guest] T+0ms: starting");
+    eprintln!("[bux-guest] T+0ms: starting {ELF_PROTOCOL_STAMP}");
 
     mounts::mount_essential_tmpfs();
     eprintln!("[bux-guest] T+{}ms: tmpfs mounted", uptime_ms());
@@ -119,7 +126,7 @@ async fn session(stream: tokio_vsock::VsockStream, reaper: Reaper) -> io::Result
         Hello::Control { version } => {
             if version != PROTOCOL_VERSION {
                 let err = bux_proto::ErrorInfo::version_mismatch(format!(
-                    "host protocol v{version}, guest protocol v{PROTOCOL_VERSION}"
+                    "host protocol v{version}, guest protocol v{PROTOCOL_VERSION} ({ELF_PROTOCOL_STAMP})"
                 ));
                 bux_proto::send(&mut w, &HelloAck::Error(err)).await?;
                 return w.flush().await;

--- a/crates/bux-landlock/src/lib.rs
+++ b/crates/bux-landlock/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! Landlock is a best-effort defence-in-depth layer, so "kernel does
 //! not support Landlock" is signalled by `Ok(None)`, not an error.
-//! Callers log a warning and continue without Landlock.
+//! Product callers fail-close (`map_jail_error` → `SecurityUnavailable`).
 //!
 //! # Example — parent/child split
 //!

--- a/crates/bux/src/events.rs
+++ b/crates/bux/src/events.rs
@@ -65,6 +65,13 @@ pub enum AuditEventKind {
         /// Snapshot identifier.
         snapshot_id: String,
     },
+    /// A VM was restored from a snapshot.
+    SnapshotRestored {
+        /// VM identifier.
+        vm_id: String,
+        /// Snapshot identifier.
+        snapshot_id: String,
+    },
     /// A file was copied into or out of a VM.
     FileCopied {
         /// VM identifier.
@@ -326,6 +333,21 @@ mod tests {
                 direction: CopyDirection::In,
                 ref path,
             } if vm_id == "vm1" && path == "/tmp/x"
+        ));
+    }
+
+    #[test]
+    fn snapshot_restored_variant_round_trip() {
+        let event = AuditEvent::now(AuditEventKind::SnapshotRestored {
+            vm_id: "vm1".into(),
+            snapshot_id: "snap1".into(),
+        });
+        assert!(matches!(
+            event.kind,
+            AuditEventKind::SnapshotRestored {
+                ref vm_id,
+                ref snapshot_id,
+            } if vm_id == "vm1" && snapshot_id == "snap1"
         ));
     }
 

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -437,7 +437,13 @@ impl Runtime {
     pub async fn restore(&self, snapshot_id: &str, name: Option<String>) -> Result<Vm> {
         let opts = self.restore_prepare(snapshot_id, name)?;
         let handle = self.create(opts).await?;
-        info!(snapshot_id, restore_id = %handle.stored().id, "VM restored from snapshot");
+        let vm_id = handle.stored().id.clone();
+        info!(snapshot_id, restore_id = %vm_id, "VM restored from snapshot");
+        self.events
+            .emit(AuditEvent::now(AuditEventKind::SnapshotRestored {
+                vm_id,
+                snapshot_id: snapshot_id.to_owned(),
+            }));
         Ok(handle)
     }
 

--- a/scripts/e2e/full_common.sh
+++ b/scripts/e2e/full_common.sh
@@ -1,4 +1,4 @@
-# Shared FULL pin for load.sh / chaos.sh. Source after ROOT is set.
+# Shared FULL pin for smoke.sh / load.sh / chaos.sh. Source after ROOT is set.
 # shellcheck shell=bash
 
 full_guest_fail() {
@@ -28,16 +28,17 @@ if machine != expected:
 e_phoff = struct.unpack_from("<Q", data, 32)[0]
 e_phentsize = struct.unpack_from("<H", data, 54)[0]
 e_phnum = struct.unpack_from("<H", data, 56)[0]
-if e_phoff == 0 or e_phentsize == 0 or e_phnum == 0:
-    sys.exit(0)
-for i in range(e_phnum):
-    off = e_phoff + i * e_phentsize
-    end = off + 4
-    if end > len(data):
-        break
-    p_type = struct.unpack_from("<I", data, off)[0]
-    if p_type == 3:
-        sys.exit(1)
+if e_phoff != 0 and e_phentsize != 0 and e_phnum != 0:
+    for i in range(e_phnum):
+        off = e_phoff + i * e_phentsize
+        end = off + 4
+        if end > len(data):
+            break
+        p_type = struct.unpack_from("<I", data, off)[0]
+        if p_type == 3:
+            sys.exit(1)
+if b"bux-guest-protocol-v10" not in data:
+    sys.exit(1)
 sys.exit(0)
 PY
 }
@@ -58,7 +59,7 @@ pin_full_guest() {
     echo "FULL requires python3 to validate the guest ELF (CONTRIBUTING.md)" >&2
     exit 1
   fi
-  local arch musl_triple guest="" c env_var
+  local arch musl_triple guest="" env_var
   case "$(uname -m)" in
     x86_64|amd64)
       arch=x86_64
@@ -77,30 +78,29 @@ pin_full_guest() {
       full_guest_fail
     fi
     guest="${BUX_GUEST_PATH}"
+  elif [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "Darwin FULL requires BUX_GUEST_PATH from fetch-guest.sh of this HEAD (CONTRIBUTING.md)" >&2
+    echo "unset BUX_GUEST_PATH and delete leftover target/debug/bux-guest-* before fetch" >&2
+    exit 1
+  elif command -v musl-gcc >/dev/null 2>&1 \
+    && linux_musl_target_present "${musl_triple}"; then
+    echo "building bux-guest (${musl_triple})..."
+    env_var="CARGO_TARGET_$(echo "${musl_triple}" | tr '[:lower:]-' '[:upper:]_')_LINKER"
+    env "${env_var}=musl-gcc" cargo build -p bux-guest --target "${musl_triple}" \
+      --manifest-path "${ROOT}/Cargo.toml"
+    mkdir -p "${ROOT}/target/debug"
+    cp "${ROOT}/target/${musl_triple}/debug/bux-guest" \
+      "${ROOT}/target/debug/bux-guest-${musl_triple}"
+    guest="${ROOT}/target/debug/bux-guest-${musl_triple}"
+    chmod 0755 "${guest}"
+    [[ -x "${guest}" ]] || full_guest_fail
+    validate_guest_elf "${guest}" "${arch}" || full_guest_fail
   else
-    for c in \
-      "${ROOT}/target/debug/bux-guest-${musl_triple}" \
-      "${ROOT}/target/${musl_triple}/debug/bux-guest"
-    do
-      if [[ -f "${c}" ]] && validate_guest_elf "${c}" "${arch}"; then
-        guest="${c}"
-        break
-      fi
-    done
-    if [[ -z "${guest}" && "$(uname -s)" == "Linux" ]] \
-      && command -v musl-gcc >/dev/null 2>&1 \
-      && linux_musl_target_present "${musl_triple}"; then
-      echo "building bux-guest (${musl_triple})..."
-      env_var="CARGO_TARGET_$(echo "${musl_triple}" | tr '[:lower:]-' '[:upper:]_')_LINKER"
-      env "${env_var}=musl-gcc" cargo build -p bux-guest --target "${musl_triple}" \
-        --manifest-path "${ROOT}/Cargo.toml"
-      mkdir -p "${ROOT}/target/debug"
-      cp "${ROOT}/target/${musl_triple}/debug/bux-guest" \
-        "${ROOT}/target/debug/bux-guest-${musl_triple}"
-      guest="${ROOT}/target/debug/bux-guest-${musl_triple}"
-      chmod 0755 "${guest}"
-      [[ -x "${guest}" ]] || full_guest_fail
-      validate_guest_elf "${guest}" "${arch}" || full_guest_fail
+    echo "fetching bux-guest via fetch-guest.sh..."
+    bash "${ROOT}/scripts/e2e/fetch-guest.sh"
+    guest="${ROOT}/target/debug/bux-guest-${musl_triple}"
+    if [[ ! -f "${guest}" ]] || ! validate_guest_elf "${guest}" "${arch}"; then
+      full_guest_fail
     fi
   fi
   [[ -n "${guest}" && -f "${guest}" ]] || full_guest_fail

--- a/scripts/e2e/full_common_test.sh
+++ b/scripts/e2e/full_common_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Host-only tests for full_common.sh guest ELF stamp. No hypervisor.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=full_common.sh
+source "${E2E_DIR}/full_common.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "python3 required to build fixture ELFs"
+fi
+
+case "$(uname -m)" in
+  x86_64|amd64)
+    arch=x86_64
+    musl_triple=x86_64-unknown-linux-musl
+    ;;
+  aarch64|arm64)
+    arch=aarch64
+    musl_triple=aarch64-unknown-linux-musl
+    ;;
+  *)
+    fail "unsupported machine: $(uname -m)"
+    ;;
+esac
+
+T="$(mktemp -d)"
+trap 'rm -rf "${T}"' EXIT
+
+write_fixture() {
+  local dest="$1" stamped="$2"
+  python3 - "${dest}" "${arch}" "${stamped}" <<'PY'
+import struct, sys
+
+path, arch, stamped = sys.argv[1], sys.argv[2], sys.argv[3]
+machine = {"x86_64": 0x3E, "aarch64": 0xB7}[arch]
+ident = bytes([0x7F, 0x45, 0x4C, 0x46, 2, 1, 1] + [0] * 9)
+rest = struct.pack(
+    "<HHIQQQIHHHHHH",
+    2,  # e_type ET_EXEC
+    machine,
+    1,  # e_version
+    0,  # e_entry
+    0,  # e_phoff
+    0,  # e_shoff
+    0,  # e_flags
+    64,  # e_ehsize
+    0,  # e_phentsize
+    0,  # e_phnum
+    0,  # e_shentsize
+    0,  # e_shnum
+    0,  # e_shstrndx
+)
+data = ident + rest
+if stamped == "1":
+    data += b"bux-guest-protocol-v10"
+open(path, "wb").write(data)
+PY
+}
+
+write_fixture "${T}/unstamped" 0
+if validate_guest_elf "${T}/unstamped" "${arch}"; then
+  fail "unstamped structurally-valid ELF must fail validate_guest_elf"
+fi
+
+write_fixture "${T}/stamped" 1
+if ! validate_guest_elf "${T}/stamped" "${arch}"; then
+  fail "stamped structurally-valid ELF must pass validate_guest_elf"
+fi
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  leftover_root="${T}/leftover"
+  leftover="${leftover_root}/target/debug/bux-guest-${musl_triple}"
+  mkdir -p "$(dirname "${leftover}")"
+  write_fixture "${leftover}" 1
+  rc=0
+  (
+    ROOT="${leftover_root}"
+    unset BUX_GUEST_PATH
+    pin_full_guest
+  ) && rc=0 || rc=$?
+  [[ "${rc}" -ne 0 ]] || fail "Darwin leftover ELF must not pin without BUX_GUEST_PATH"
+fi
+
+echo OK

--- a/scripts/e2e/smoke.sh
+++ b/scripts/e2e/smoke.sh
@@ -11,6 +11,9 @@ E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=wget_probe.sh
 source "${E2E_DIR}/wget_probe.sh"
 bash "${E2E_DIR}/wget_probe_test.sh"
+# shellcheck source=full_common.sh
+source "${E2E_DIR}/full_common.sh"
+bash "${E2E_DIR}/full_common_test.sh"
 
 export BUX_HOME="${BUX_HOME:-$(mktemp -d /tmp/bux-e2e.XXXXXX)}"
 cleanup() {
@@ -30,132 +33,8 @@ trap cleanup EXIT
 
 echo "==> BUX_HOME=${BUX_HOME}"
 
-full_guest_fail() {
-  echo "FULL requires a static Linux bux-guest ELF (CONTRIBUTING.md)" >&2
-  exit 1
-}
-
-# Same offsets as crates/bux/src/guest.rs validate_guest_binary (no readelf).
-validate_guest_elf() {
-  local path="$1"
-  local arch="$2"
-  python3 - "${path}" "${arch}" <<'PY' || return 1
-import struct, sys
-path, arch = sys.argv[1], sys.argv[2]
-expected = {"x86_64": 0x3E, "aarch64": 0xB7}.get(arch)
-if expected is None:
-    sys.exit(1)
-try:
-    data = open(path, "rb").read()
-except OSError:
-    sys.exit(1)
-if len(data) < 64 or data[:4] != b"\x7fELF" or data[4] != 2 or data[5] != 1:
-    sys.exit(1)
-machine = struct.unpack_from("<H", data, 18)[0]
-if machine != expected:
-    sys.exit(1)
-e_phoff = struct.unpack_from("<Q", data, 32)[0]
-e_phentsize = struct.unpack_from("<H", data, 54)[0]
-e_phnum = struct.unpack_from("<H", data, 56)[0]
-if e_phoff == 0 or e_phentsize == 0 or e_phnum == 0:
-    sys.exit(0)
-for i in range(e_phnum):
-    off = e_phoff + i * e_phentsize
-    end = off + 4
-    if end > len(data):
-        break
-    p_type = struct.unpack_from("<I", data, off)[0]
-    if p_type == 3:
-        sys.exit(1)
-sys.exit(0)
-PY
-}
-
-linux_musl_target_present() {
-  local triple="$1"
-  local sysroot
-  if command -v rustup >/dev/null 2>&1 \
-    && rustup target list --installed 2>/dev/null | grep -qx "${triple}"; then
-    return 0
-  fi
-  sysroot="$(rustc --print sysroot 2>/dev/null || true)"
-  [[ -n "${sysroot}" && -d "${sysroot}/lib/rustlib/${triple}" ]]
-}
-
-pin_full_guest() {
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "FULL requires python3 to validate the guest ELF (CONTRIBUTING.md)" >&2
-    exit 1
-  fi
-  local arch musl_triple guest="" c env_var
-  case "$(uname -m)" in
-    x86_64|amd64)
-      arch=x86_64
-      musl_triple=x86_64-unknown-linux-musl
-      ;;
-    aarch64|arm64)
-      arch=aarch64
-      musl_triple=aarch64-unknown-linux-musl
-      ;;
-    *)
-      full_guest_fail
-      ;;
-  esac
-  if [[ -n "${BUX_GUEST_PATH:-}" ]]; then
-    if [[ ! -f "${BUX_GUEST_PATH}" ]] || ! validate_guest_elf "${BUX_GUEST_PATH}" "${arch}"; then
-      full_guest_fail
-    fi
-    guest="${BUX_GUEST_PATH}"
-  else
-    for c in \
-      "${ROOT}/target/debug/bux-guest-${musl_triple}" \
-      "${ROOT}/target/${musl_triple}/debug/bux-guest"
-    do
-      if [[ -f "${c}" ]] && validate_guest_elf "${c}" "${arch}"; then
-        guest="${c}"
-        break
-      fi
-    done
-    if [[ -z "${guest}" && "$(uname -s)" == "Linux" ]] \
-      && command -v musl-gcc >/dev/null 2>&1 \
-      && linux_musl_target_present "${musl_triple}"; then
-      echo "building bux-guest (${musl_triple})..."
-      env_var="CARGO_TARGET_$(echo "${musl_triple}" | tr '[:lower:]-' '[:upper:]_')_LINKER"
-      env "${env_var}=musl-gcc" cargo build -p bux-guest --target "${musl_triple}" \
-        --manifest-path "${ROOT}/Cargo.toml"
-      mkdir -p "${ROOT}/target/debug"
-      cp "${ROOT}/target/${musl_triple}/debug/bux-guest" \
-        "${ROOT}/target/debug/bux-guest-${musl_triple}"
-      guest="${ROOT}/target/debug/bux-guest-${musl_triple}"
-      chmod 0755 "${guest}"
-      [[ -x "${guest}" ]] || full_guest_fail
-      validate_guest_elf "${guest}" "${arch}" || full_guest_fail
-    fi
-  fi
-  [[ -n "${guest}" && -f "${guest}" ]] || full_guest_fail
-  export BUX_GUEST_PATH="${guest}"
-}
-
-create_or_dump() {
-  if bux create "$@"; then
-    return 0
-  fi
-  echo "==> bux create failed; shim stderr:" >&2
-  cat "${BUX_HOME}/socks/"*.stderr >&2 2>/dev/null || true
-  return 1
-}
-
 if [[ "${BUX_E2E_FULL:-}" == "1" ]]; then
-  echo "building bux-cli and bux-shim-bin (FULL pin)..."
-  cargo build -p bux-cli -p bux-shim-bin --manifest-path "${ROOT}/Cargo.toml"
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    codesign --entitlements "${ROOT}/crates/bux-shim/bux-shim.entitlements" \
-      -s - --force "${ROOT}/target/debug/bux-shim"
-  fi
-  pin_full_guest
-  export PATH="${ROOT}/target/debug:${PATH}"
-  export BUX_SHIM_PATH="${ROOT}/target/debug/bux-shim"
-  test -x "${BUX_SHIM_PATH}"
+  pin_full_binaries
 elif ! command -v bux >/dev/null 2>&1; then
   echo "building bux-cli..."
   cargo build -q -p bux-cli --manifest-path "${ROOT}/Cargo.toml"


### PR DESCRIPTION
## Summary

Follow-on to #128 (combined CAfile), retargeted onto `main` after that merge deleted the stack base branch. Same commit as closed #129 (`810d8ab`).

- Compile-time stamp `bux-guest-protocol-v10` used in boot log and version-mismatch `ErrorInfo` (not a `format!` fragment grep)
- `smoke.sh` sources `full_common.sh`; Darwin FULL requires `BUX_GUEST_PATH` (no leftover `target/debug` fall-through)
- Host-only `full_common_test.sh`: unstamped fixture ELF fails before `bux create`
- CONTRIBUTING: protocol v10; existing Layer 1 rows marked pre-v10, not ship proof
- `AuditEventKind::SnapshotRestored`; CLI README snapshot restore + `stats --runtime`

Supersedes closed #129.

## Test plan

- [x] Independent review of this commit (same as #129): no issues
- [ ] GitHub-hosted CI on `main`
- Darwin/KVM FULL records are **not** in this PR