### PR TITLE
ci: pin qntx/workflows @v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
-  # SHA is qntx/workflows main at 2026-08-28 (cb94c5b5b8b4c22587840a7db6d2db503c17369c).
-  # That revision's ci-rust.yml runs fmt/clippy/build/`cargo test --workspace --verbose --all-features` on ubuntu-latest only.
   ci:
-    uses: qntx/workflows/.github/workflows/ci-rust.yml@cb94c5b5b8b4c22587840a7db6d2db503c17369c
+    uses: qntx/workflows/.github/workflows/ci-rust.yml@v2
+    permissions:
+      contents: read
     with:
       submodules: true
-      toolchain: "1.97.1"
+      rust-version: "1.97.1"
 
   deny:
     runs-on: ubuntu-latest
@@ -35,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.97.1
+          rust-version: 1.97.1
       - uses: actions/setup-go@v5
         with:
           go-version-file: crates/bux-gvproxy/gvproxy-bridge/go.mod

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,20 @@
+# Caller owns on:. Pin at @v2.
+# Enable "Allow auto-merge" on the repository. This workflow does not approve.
+# If branch protection requires reviews, add a ruleset bypass for dependabot
+# or pass TOKEN (a PAT/App) that can enable auto-merge. Do not checkout the PR.
+name: Dependabot
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: qntx/workflows/.github/workflows/ops-dependabot.yml@v2

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,6 +5,13 @@ on:
     - cron: "30 1 * * *"
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
-    uses: qntx/workflows/.github/workflows/repo-stale.yml@main
+    uses: qntx/workflows/.github/workflows/ops-stale.yml@v2
+    permissions:
+      issues: write
+      pull-requests: write


### PR DESCRIPTION
Mechanical cutover to qntx/workflows @v2 / @v2.0.0. Pin reusable callers; leave local extra jobs untouched.