### PR TITLE
ci: restore dtolnay rust-toolchain input name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@master
         with:
-          rust-version: 1.97.1
+          toolchain: 1.97.1
       - uses: actions/setup-go@v5
         with:
           go-version-file: crates/bux-gvproxy/gvproxy-bridge/go.mod


### PR DESCRIPTION
Follow-up to the v2 workflows cutover.

The mechanical rewrite replaced `toolchain:` with `rust-version:` for the reusable `ci-rust.yml` / `publish-crates.yml` inputs. The same substitution hit a **local** `dtolnay/rust-toolchain@master` step in this file. That action only accepts `toolchain`; the bad key made the step fail before tests/publish ran.

This restores `toolchain` on the local step. Reusable-workflow pins stay `@v2` / `@v2.0.0`.