### PR TITLE
fix(ci): run Dependabot merge sweep on a schedule

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,11 +1,15 @@
 # Caller owns on:. Pin at @v2.
-# Enable "Allow auto-merge" on the repository. This workflow does not approve.
-# If branch protection requires reviews, add a ruleset bypass for dependabot
-# or pass TOKEN (a PAT/App) that can enable auto-merge. Do not checkout the PR.
+# pull_request: try to queue GitHub auto-merge (no-op without required checks).
+# schedule: squash-merge Dependabot PRs whose checks are green.
+# Do not checkout the PR. This workflow does not approve.
+# If rulesets require reviews, add a bypass for Dependabot or pass TOKEN.
 name: Dependabot
 
 on:
   pull_request:
+  schedule:
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -13,7 +17,9 @@ permissions:
 
 jobs:
   merge:
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    if: >-
+      github.event_name != 'pull_request'
+      || github.event.pull_request.user.login == 'dependabot[bot]'
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
Platform `ops-dependabot` now squash-merges green Dependabot PRs on `schedule` (`qntx/workflows#34`, `@v2` moved).

This caller must fire on `schedule` / `workflow_dispatch` or the sweep never runs. `pull_request` still only arms auto-merge (no-op without required checks, no longer fails UNSTABLE).
