### PR TITLE
feat: hosted bux serve worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   ci:
-    uses: qntx/workflows/.github/workflows/ci-rust.yml@v2
+    # v2 (6fae2077275e4a757a294c90cbab4f481847b45a)
+    uses: qntx/workflows/.github/workflows/ci-rust.yml@6fae2077275e4a757a294c90cbab4f481847b45a
     permissions:
       contents: read
     with:
-      submodules: true
       rust-version: "1.97.1"
 
   deny:

--- a/.github/workflows/e2e-host.yml
+++ b/.github/workflows/e2e-host.yml
@@ -31,3 +31,7 @@ jobs:
         env:
           BUX_E2E_FULL: "0"
         run: ./scripts/e2e/smoke.sh
+      - name: Host-only serve smoke
+        env:
+          BUX_E2E_FULL: "0"
+        run: ./scripts/e2e/serve.sh

--- a/.gitignore
+++ b/.gitignore
@@ -27,4 +27,3 @@ target
 .claude
 .bux-tmp
 .DS_Store
-docs/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,12 +239,15 @@ CD `cd.yml` musl guest:
 - **file** inside the artifact: `bux-guest-<triple>`
 - sibling after fetch: `target/debug/bux-guest-<triple>`
 
-After this PR and PR 1 (combined CAfile) are both on `main`:
+After this merge is on `main`, tag the guest of that commit:
 
 ```bash
 git fetch origin
-git tag "guest-$(git rev-parse origin/main)" "$(git rev-parse origin/main)"
-git push origin "guest-$(git rev-parse origin/main)"
+git checkout main
+git pull --ff-only origin main
+SHA="$(git rev-parse HEAD)"
+git tag "guest-${SHA}" "${SHA}"
+git push origin "guest-${SHA}"
 ```
 
 Do not vendor the ELF in git. Do not fill the FULL record above from a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,14 @@
 # Contributing to bux
 
+The product is a hosted per-agent sandbox (`bux serve`). The engine
+(`Runtime` / `Vm` / `VmOptions`) is the substrate. **1.0 is hosted + FULL
+proof** (HVF v10 guest from that commit, Linux `/dev/kvm` FULL, load/chaos),
+not library-only. Do not tag `v1.0.0` until that bar is true. Do not invent
+FULL sha256 rows.
+
+Operator docs: root `README.md`, `docs/architecture.md`,
+`docs/security-model.md`, `docs/serve.md`.
+
 ## Build
 
 ```bash
@@ -84,11 +93,19 @@ bux system info --format json
 
 ## Architecture notes
 
-- Product entry: `Runtime` + `Vm` + `VmOptions` (`crates/bux`).
+- Product: hosted per-agent sandbox (`bux serve`). HTTP is a client of
+  `Runtime`; it does not live in `crates/bux`. 1.0 is that worker plus
+  recorded FULL proof, not library-only.
+- Engine: `Runtime` + `Vm` + `VmOptions` (`crates/bux`). Exclusive flock;
+  one process owns `BUX_HOME`. Second serve (or CLI Runtime) on the same
+  dir is `Busy`.
 - Engine boundary: product `VmConfig` → `ShimConfig` → `bux-shim` → libkrun.
 - Managed network: gvproxy virtio-net in the `bux-shim` process (`bux-shim-bin`); no TSI `set_port_map`.
 - Guest agent: postcard protocol v10; Phase A process identity only.
 - Schema: SQLite `user_version` 5 — **no migrations**; wipe `BUX_HOME` on mismatch.
+- Isolation vs host: hardware VM. Isolation vs other agents: one VM per agent.
+- `create` fail-closed: `require_virtualization` before image resolve
+  (`Error::SecurityUnavailable`; HTTP 412).
 
 ## Tests
 
@@ -308,4 +325,4 @@ Schema mismatches require `bux system reset` (or wiping `$BUX_HOME`).
 
 ## Lints
 
-Workspace clippy is strict (`unsafe_code = deny` with crate exceptions). Prefer small, modular PRs along the redesign plan spine.
+Workspace clippy is strict (`unsafe_code = deny` with crate exceptions). Prefer small, modular PRs. Hosted worker and engine stay separate crates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -209,6 +209,14 @@ ELF must fail before `bux create`. Before fetch, unset `BUX_GUEST_PATH` **and**
 delete leftover `target/debug/bux-guest-*`. Darwin does not compile the guest
 and does not use zig cc.
 
+Before any FULL `bux create`, `pin_full_binaries` calls
+`refuse_fake_ip_example_com`: Python `getaddrinfo("example.com", 443,
+type=SOCK_STREAM)`, log every record, fail if any address's IPv4 form is in
+`198.18.0.0/15` (IPv4; else `ipv4_mapped`; else last 4 bytes of the AAAA
+packed form — macOS translated `::ffff:0:c612:a0` is not
+`::ffff:198.18.0.0/111`). Fake-ip / MacPacket is hygiene, not a recorded 502.
+Disable fake-ip for the HVF v10 record. Do not invent FULL sha256.
+
 Linux FULL when `BUX_GUEST_PATH` is unset: musl-gcc build of this tree (when
 `musl-gcc` and that rustc target are already present) **or**
 `scripts/e2e/fetch-guest.sh`. Do not silently accept a leftover v9 ELF. After
@@ -245,7 +253,9 @@ Release download.
 `scripts/e2e/fetch-guest.sh` prefers the `guest-<sha>` Release asset, else
 polls the `guest-<triple>` workflow artifact for this `HEAD`, and copies the
 file next to `target/debug/bux`. Dest is `chmod 0755` after copy; the script
-exits 1 if not `-x`. Do not `gh run download -n bux-guest-*`.
+exits 1 if not `-x`. The same `bux-guest-protocol-v10` bytes check as
+`full_common.sh` applies: a v9 ELF is rejected even if `guest-<sha>` exists.
+Do not `gh run download -n bux-guest-*`.
 
 Pin `$BUX_E2E_IMAGE` if alpine wget/httpd is missing. There is no in-repo
 custom e2e image.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,20 +114,23 @@ cargo test -p bux --lib
 cargo test -p bux-proto --lib
 # Host-only smoke (no hypervisor). This is the GitHub-hosted CI gate:
 ./scripts/e2e/smoke.sh
+./scripts/e2e/serve.sh
 # Full VM e2e — documented **manual** gate (HVF recorded; KVM needs /dev/kvm).
 # Never set BUX_E2E_FULL=1 on GitHub-hosted runners.
 BUX_E2E_FULL=1 ./scripts/e2e/smoke.sh
-# Load / chaos — same FULL pin as smoke (cli+shim, guest ELF). Manual HVF/KVM.
+# Load / chaos / serve — same FULL pin as smoke (cli+shim, guest ELF). Manual HVF/KVM.
 # GitHub-hosted CI does not run these; e2e-host.yml stays BUX_E2E_FULL=0.
 BUX_E2E_FULL=1 ./scripts/e2e/load.sh
 BUX_E2E_FULL=1 ./scripts/e2e/chaos.sh
+BUX_E2E_FULL=1 ./scripts/e2e/serve.sh
 ```
 
 `.github/workflows/e2e-host.yml` forces `BUX_E2E_FULL=0` on `ubuntu-latest` and
-`macos-latest`. Host-only is not production proof. `BUX_E2E_FULL=1` is not a CI
-job. GitHub-hosted runners must not set `BUX_E2E_FULL=1`. Self-hosted runners
-can take it later without redesign. `load.sh` and `chaos.sh` are the same
-manual gate, not GitHub-hosted jobs.
+`macos-latest` (`smoke.sh` and `serve.sh` help/openapi). Host-only is not
+production proof. `BUX_E2E_FULL=1` is not a CI job. GitHub-hosted runners must
+not set `BUX_E2E_FULL=1`. Self-hosted runners can take it later without
+redesign. `load.sh`, `chaos.sh`, and `serve.sh` FULL are the same manual gate,
+not GitHub-hosted jobs.
 
 The first green FULL is recorded below on **local HVF (Apple Silicon)**.
 Host CI (`BUX_E2E_FULL=0`) is not that proof. Linux KVM has **no** Layer 1
@@ -320,6 +323,39 @@ Item 17 is not in the Layer 1 or clone FULL rows.
   without `-f`
 - no leftover overlay `$BUX_HOME/disks/vms/{id}.qcow2` for that id
 - no `ulimit` disk-full test
+
+`scripts/e2e/serve.sh` host-only (`BUX_E2E_FULL=0`, GitHub-hosted `e2e-host.yml`):
+
+- `bux serve start --help`
+- `bux serve openapi` (JSON document including `/v1/health` and sandbox routes)
+- no hypervisor, no `bux-shim-bin` / guest ELF
+
+`BUX_E2E_FULL=1 ./scripts/e2e/serve.sh` is the same cli+shim+guest pin as
+`smoke.sh` (Darwin: `BUX_GUEST_PATH` from `scripts/e2e/fetch-guest.sh` of this
+HEAD; Linux: musl-gcc or fetch). Skip FULL when `host.virtualization` is not
+true. Capture binary `./target/debug/bux`. Pin `$BUX_HOME` without substring
+`bux-e2e` if the data dir must survive script exit. Do not invent an HVF/KVM
+sha256 row here — record a real run in a later docs PR.
+
+FULL loop (HTTP, two API keys `t1` / `t2`):
+
+1. `POST /v1/images/pull` alpine (or `$BUX_E2E_IMAGE`)
+2. `POST /v1/sandboxes` twice with the same `agent_id` / image → same exact
+   12-char id (201 then 200)
+3. `POST .../exec` `echo` (stdout `e2e-ok`, code 0)
+4. `PUT`/`GET .../files?path=/workspace/x`
+5. `allow_net: ["127.0.0.1"]` then guest wget example.com **fails**
+6. stop/start: `auto_stop_secs=1` + sweep then `POST .../start`; workspace
+   file persists (HTTP has no stop route; idle sweep is the stop)
+7. `DELETE` removes `{BUX_HOME}/volumes/ws-{tenant}-{agent}`
+8. second tenant GET `{id}` → 404 (same envelope as missing)
+9. SIGTERM the serve process, start again, exec still works (R3 reattach)
+10. after auto-stop, `POST /v1/sandboxes` resume then GET is still `running`
+    (`start_with` idle clock; do not wait a sweep tick with `auto_stop_secs=1`)
+11. `curl --unix-socket` `GET /v1/health` (worker also binds TCP loopback)
+12. snapshot create → restore `{agent_id}` → exec overlay marker
+13. clone `{agent_id}` → exec overlay marker
+14. other tenant 404 on snapshot GET/POST
 
 Schema mismatches require `bux system reset` (or wiping `$BUX_HOME`).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +318,7 @@ dependencies = [
  "anyhow",
  "bux",
  "bux-proto",
+ "bux-serve",
  "clap",
  "clap_complete",
  "libc",
@@ -392,6 +441,21 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "thiserror",
+]
+
+[[package]]
+name = "bux-serve"
+version = "0.8.0"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -1158,6 +1222,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1179,6 +1249,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1582,6 +1653,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1672,12 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -2393,6 +2476,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,10 +2889,12 @@ dependencies = [
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,7 @@ name = "bux-serve"
 version = "0.8.0"
 dependencies = [
  "axum",
+ "bux",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -189,6 +190,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
@@ -413,6 +415,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "tempfile",
  "thiserror",
  "tokio",
 ]
@@ -449,6 +452,7 @@ version = "0.8.0"
 dependencies = [
  "axum",
  "bux",
+ "bux-proto",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "utoipa",
 ]
 
 [[package]]
@@ -903,6 +904,12 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
@@ -1433,6 +1440,18 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3087,6 +3106,29 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ version = "0.8.0"
 dependencies = [
  "axum",
  "bux",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "axum",
  "bux",
  "bux-proto",
+ "libc",
  "rusqlite",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/qntx/bux"
 bux = { version = "0.8", path = "crates/bux" }
 bux-oci = { version = "0.8", path = "crates/bux-oci" }
 bux-proto = { version = "0.8", path = "crates/bux-proto" }
+bux-serve = { version = "0.8", path = "crates/bux-serve" }
 
 bux-bwrap = { version = "0.2", path = "crates/bux-bwrap" }
 bux-jail = { version = "0.1", path = "crates/bux-jail" }
@@ -25,6 +26,7 @@ bux-qcow2 = { version = "0.1", path = "crates/bux-qcow2" }
 bux-seccomp = { version = "0.1", path = "crates/bux-seccomp" }
 
 anyhow = "1.0.104"
+axum = { version = "0.8.9", default-features = false, features = ["http1", "json", "tokio"] }
 clap = { version = "4.6.6", features = ["derive"] }
 clap_complete = "4.6.9"
 colored = "3.1.1"
@@ -39,6 +41,8 @@ postcard = { version = "1.1.3", features = ["alloc"] }
 tempfile = "3.27.0"
 thiserror = "2.0.20"
 tokio = { version = "1.53.1", features = ["macros", "rt", "io-util", "net", "time", "sync", "signal"] }
+tower = { version = "0.5.2", features = ["util"] }
+tower-http = { version = "0.6.6", features = ["limit", "trace"] }
 rusqlite = { version = "0.40.2", features = ["bundled"] }
 tokio-vsock = "0.7.2"
 bindgen = "0.72.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ tar = "0.4.46"
 ureq = "3.4.0"
 signal-hook = "0.4.4"
 tracing = "0.1.44"
+utoipa = "5.5.0"
 
 [profile.release]
 codegen-units = 1

--- a/README.md
+++ b/README.md
@@ -1,17 +1,139 @@
-<!-- markdownlint-disable MD033 MD041 MD036 -->
-
 # Bux
 
-Embedded micro-VM sandbox for running AI agents, powered by [libkrun](https://github.com/containers/libkrun) with KVM (Linux) or Hypervisor.framework (macOS).
+Hosted per-agent sandbox. Every agent gets its own hardware-isolated micro-VM
+(libkrun on KVM or Hypervisor.framework), addressable over HTTP (`bux serve`)
+or by embedding [`Runtime`](crates/bux/src/lib.rs). Isolation versus the host
+is the VM. Isolation versus other agents is **one VM per agent** — never share
+a guest across agents.
 
----
+The engine (`Runtime` / `Vm` / `VmOptions`) is the substrate. It is not a
+library-only 1.0. **1.0 is the hosted worker plus recorded FULL proof** (HVF
+v10 guest, Linux `/dev/kvm` FULL, load/chaos). Workspace version is **0.8.0**.
+Do not tag `v1.0.0` until that bar is true. Recorded HVF rows in
+[CONTRIBUTING.md](CONTRIBUTING.md) are pre-v10 and are **not ship proof**.
+Linux KVM FULL is empty.
 
-<div align="center">
+## Isolation
 
-A **[QuantX](https://qntx.org)** open-source project.
+```text
+                    untrusted (one agent)
+┌─────────────────────────────────────────────┐
+│ guest kernel (libkrunfw)                    │
+│  bux-guest PID 1 + that agent's execs       │
+│  /workspace ← named volume                  │
+└──────────────────┬──────────────────────────┘
+                   │ virtio blk, fs, vsock, net
+┌──────────────────▼──────────────────────────┐
+│ bux-shim + optional gvproxy                 │
+│  seccomp (Linux) · Landlock · bwrap/seatbelt│
+└──────────────────┬──────────────────────────┘
+                   │ Unix sockets, overlay, volumes
+┌──────────────────▼──────────────────────────┐
+│ bux serve / Runtime (trusted)               │
+│  SQLite, OCI cache, API keys                │
+└─────────────────────────────────────────────┘
+```
 
-<a href="https://qntx.org"><img alt="QuantX" width="369" src="https://raw.githubusercontent.com/qntx/.github/main/profile/qntx.svg" /></a>
+Phase A: concurrent execs in one VM share the guest rootfs and namespaces.
+That is acceptable because one agent owns the guest. Inspect JSON includes
+`PHASE_A_LIMITS` and `egress`.
 
-Code is law. We write both.
+`create` calls `require_virtualization` before image resolve. Missing KVM/HVF
+is `Error::SecurityUnavailable` (HTTP **412**). GitHub-hosted CI does not
+provide `/dev/kvm`; it is not Linux production proof.
 
-</div>
+CLI default network is unrestricted (`NetworkSpec::Enabled { allow_net: [] }`).
+HTTP default is deny. Two entry points, one engine type.
+
+## Install
+
+Product artifact is the GitHub Release tarball (`v*` tags), not crates.io.
+
+| Host | Asset |
+|------|--------|
+| Linux x86_64 | `bux-<ver>-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux aarch64 | `bux-<ver>-aarch64-unknown-linux-gnu.tar.gz` |
+| macOS aarch64 | `bux-<ver>-aarch64-apple-darwin.tar.gz` |
+
+```bash
+tar xf bux-*-x86_64-unknown-linux-gnu.tar.gz
+cd bux-*-x86_64-unknown-linux-gnu
+./bux system info
+```
+
+Extracted layout (Linux `.so` / Darwin `.dylib`; keep `libkrun*` next to `bux`):
+
+```text
+bux
+bux-shim
+bux-guest-<linux-musl-triple>
+libkrun*
+libkrunfw*
+LICENSE-MIT
+LICENSE-APACHE
+```
+
+Linux binaries stamp `DT_RPATH` `$ORIGIN` (this repo’s `.cargo/config.toml`).
+Downstream Linux embedders must set the same rustflag. Darwin uses
+`@loader_path`; embedders do not need rpath rustflags.
+
+Operator path, 412, Busy flock, data-dir sizing, rollback:
+[docs/serve.md](docs/serve.md).
+
+## Serve
+
+One process owns one data dir. `Runtime::open` takes an exclusive flock;
+a second `bux serve start` (or `bux create`) on the same `BUX_HOME` is `Busy`.
+
+```bash
+./bux serve start \
+  --api-key-file /etc/bux/keys \
+  --listen 127.0.0.1:8080 \
+  --listen unix://${XDG_RUNTIME_DIR:-/tmp}/bux.sock
+```
+
+At least one API key is required to start, including loopback and Unix.
+`--public` is required to bind a non-loopback TCP address. Terminate TLS in a
+reverse proxy; the worker does not.
+
+Flags, keys, listeners, proxy, disk: [docs/serve.md](docs/serve.md).
+
+## Embed
+
+`crates/bux` stays daemonless. HTTP does not live in this crate.
+
+```rust
+use bux::{ExecStart, Runtime, VmOptions};
+
+let rt = Runtime::open(bux::default_data_dir())?;
+let mut vm = rt
+    .create(VmOptions::from_image("python:slim").vcpus(2).ram_mib(1024))
+    .await?;
+vm.exec_output(ExecStart::new("python").args(vec!["-c".into(), "print(1)".into()]))
+    .await?;
+vm.stop().await?;
+```
+
+The CLI (`bux create` / `exec` / `cp` / …) is a client of the same methods.
+Local CLI cannot run **during** serve (same flock). After serve stops, CLI
+verbs on that `BUX_HOME` work.
+
+## Capture env
+
+| Variable | Purpose |
+|----------|---------|
+| `BUX_HOME` | Runtime data directory (lock, SQLite, disks, volumes, socks) |
+| `BUX_SHIM_PATH` | Absolute path to `bux-shim` |
+| `BUX_GUEST_PATH` | Absolute path to a static Linux `bux-guest` ELF |
+| `BUX_GUEST_DIR` | Build-time directory of a prebuilt Linux guest ELF |
+
+`bux system info --format json` is flock-free.
+
+## Docs
+
+| Doc | Contents |
+|-----|----------|
+| [docs/architecture.md](docs/architecture.md) | Crate map, worker process, isolation layers, native/guest/product tags |
+| [docs/security-model.md](docs/security-model.md) | Current engine isolation + hosted threat model |
+| [docs/serve.md](docs/serve.md) | Tarball, `/dev/kvm`, rpath, flags, data dir, rollback |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Build, capture env, FULL procedure, recorded runs |

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ Product artifact is the GitHub Release tarball (`v*` tags), not crates.io.
 
 ```bash
 tar xf bux-*-x86_64-unknown-linux-gnu.tar.gz
-cd bux-*-x86_64-unknown-linux-gnu
 ./bux system info
 ```
+
+Members are at archive root (`tar czf … -C "$staging" .`). Run `./bux` from
+the directory that received the extract.
 
 Extracted layout (Linux `.so` / Darwin `.dylib`; keep `libkrun*` next to `bux`):
 
@@ -86,15 +88,14 @@ One process owns one data dir. `Runtime::open` takes an exclusive flock;
 a second `bux serve start` (or `bux create`) on the same `BUX_HOME` is `Busy`.
 
 ```bash
-./bux serve start \
-  --api-key-file /etc/bux/keys \
-  --listen 127.0.0.1:8080 \
-  --listen unix://${XDG_RUNTIME_DIR:-/tmp}/bux.sock
+./bux serve start --api-key-file /etc/bux/keys
 ```
 
-At least one API key is required to start, including loopback and Unix.
-`--public` is required to bind a non-loopback TCP address. Terminate TLS in a
-reverse proxy; the worker does not.
+Omitted `--listen` is `127.0.0.1:8080` and
+`unix://$XDG_RUNTIME_DIR/bux.sock` (fallback `/tmp/bux-$UID.sock`). At least
+one API key is required to start, including loopback and Unix. `--public` is
+required to bind a non-loopback TCP address. Terminate TLS in a reverse
+proxy; the worker does not.
 
 Flags, keys, listeners, proxy, disk: [docs/serve.md](docs/serve.md).
 

--- a/crates/bux-cli/Cargo.toml
+++ b/crates/bux-cli/Cargo.toml
@@ -16,13 +16,14 @@ path = "src/main.rs"
 [dependencies]
 bux.workspace = true
 bux-proto.workspace = true
+bux-serve.workspace = true
 anyhow.workspace = true
-clap.workspace = true
+clap = { workspace = true, features = ["env"] }
 clap_complete.workspace = true
 libc.workspace = true
 serde_json.workspace = true
 tar.workspace = true
-tokio = { workspace = true, features = ["io-std"] }
+tokio = { workspace = true, features = ["io-std", "rt-multi-thread"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]

--- a/crates/bux-cli/README.md
+++ b/crates/bux-cli/README.md
@@ -1,6 +1,11 @@
 # bux-cli
 
-CLI client of the `bux` `Runtime` / `Vm` / `VmOptions` API. Binary name: `bux`.
+Operator CLI and hosted worker binary (`bux`). Local verbs (`create` / `exec`
+/ …) are a client of the `bux` `Runtime` / `Vm` / `VmOptions` API. `bux serve`
+is the product surface: one process, one Runtime, many per-agent VMs.
+
+1.0 is **hosted + FULL proof**, not library-only. See
+[`docs/serve.md`](../../docs/serve.md) and the root [`README.md`](../../README.md).
 
 Build: `cargo build -p bux-cli -p bux-shim-bin`. Capture env, tarball layout,
 and FULL procedure: [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
@@ -31,11 +36,18 @@ and FULL procedure: [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 | `system info` | Host capabilities, data dir, capture env (flock-free) |
 | `system reset` | Delete the runtime data directory (requires flock) |
 | `info` | Alias of `system info` |
+| `serve start` | HTTP worker: exclusive flock on `BUX_HOME`, Bearer keys, per-agent VMs |
+| `serve openapi` | OpenAPI JSON to stdout, exit 0 |
 
 List/info commands take `--format table|json` where present.
 
 `create` is always detach (CLI exits; VM survives). Equivalent to
 `bux run -d IMAGE` with no command override.
+
+Local Runtime verbs cannot run during `bux serve start` on the same
+`BUX_HOME` (exclusive flock → `Busy`). `system info` is flock-free. HTTP
+default network is deny; CLI default remains unrestricted
+(`Enabled { allow_net: [] }`).
 
 ## Capture env
 

--- a/crates/bux-cli/README.md
+++ b/crates/bux-cli/README.md
@@ -1,8 +1,8 @@
 # bux-cli
 
-Operator CLI and hosted worker binary (`bux`). Local verbs (`create` / `exec`
-/ …) are a client of the `bux` `Runtime` / `Vm` / `VmOptions` API. `bux serve`
-is the product surface: one process, one Runtime, many per-agent VMs.
+CLI client of the `bux` `Runtime` / `Vm` / `VmOptions` API. Binary name: `bux`.
+`bux serve` is the product surface (one process, one Runtime, many per-agent
+VMs) and is 1.0, not in this 0.8.0 clap.
 
 1.0 is **hosted + FULL proof**, not library-only. See
 [`docs/serve.md`](../../docs/serve.md) and the root [`README.md`](../../README.md).
@@ -36,18 +36,17 @@ and FULL procedure: [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 | `system info` | Host capabilities, data dir, capture env (flock-free) |
 | `system reset` | Delete the runtime data directory (requires flock) |
 | `info` | Alias of `system info` |
-| `serve start` | HTTP worker: exclusive flock on `BUX_HOME`, Bearer keys, per-agent VMs |
-| `serve openapi` | OpenAPI JSON to stdout, exit 0 |
 
 List/info commands take `--format table|json` where present.
 
 `create` is always detach (CLI exits; VM survives). Equivalent to
 `bux run -d IMAGE` with no command override.
 
-Local Runtime verbs cannot run during `bux serve start` on the same
-`BUX_HOME` (exclusive flock → `Busy`). `system info` is flock-free. HTTP
-default network is deny; CLI default remains unrestricted
-(`Enabled { allow_net: [] }`).
+`serve start` / `serve openapi` are 1.0 (not in 0.8.0 clap). Spec:
+[`docs/serve.md`](../../docs/serve.md). Local Runtime verbs cannot run
+during serve on the same `BUX_HOME` (exclusive flock → `Busy`).
+`system info` is flock-free. HTTP default network is deny; CLI default
+remains unrestricted (`Enabled { allow_net: [] }`).
 
 ## Capture env
 

--- a/crates/bux-cli/README.md
+++ b/crates/bux-cli/README.md
@@ -2,7 +2,7 @@
 
 CLI client of the `bux` `Runtime` / `Vm` / `VmOptions` API. Binary name: `bux`.
 `bux serve` is the product surface (one process, one Runtime, many per-agent
-VMs) and is 1.0, not in this 0.8.0 clap.
+VMs). Serve is in this 0.8.0 workspace clap; the product tag is not 1.0.
 
 1.0 is **hosted + FULL proof**, not library-only. See
 [`docs/serve.md`](../../docs/serve.md) and the root [`README.md`](../../README.md).
@@ -42,7 +42,8 @@ List/info commands take `--format table|json` where present.
 `create` is always detach (CLI exits; VM survives). Equivalent to
 `bux run -d IMAGE` with no command override.
 
-`serve start` / `serve openapi` are 1.0 (not in 0.8.0 clap). Spec:
+`serve start` / `serve openapi` are in this 0.8.0 workspace clap; the product
+tag is not 1.0. Spec:
 [`docs/serve.md`](../../docs/serve.md). Local Runtime verbs cannot run
 during serve on the same `BUX_HOME` (exclusive flock → `Busy`).
 `system info` is flock-free. HTTP default network is deny; CLI default

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -240,6 +240,18 @@ struct ServeStartArgs {
     #[arg(long, default_value_t = 32_u64 * 1024 * 1024 * 1024)]
     max_disk_bytes: u64,
 
+    /// Maximum compressed image pull size in bytes (`Runtime::manifest_compressed_bytes`).
+    #[arg(long, default_value_t = 4_u64 * 1024 * 1024 * 1024)]
+    max_pull_bytes: u64,
+
+    /// Maximum collected stdout or stderr per exec, in bytes.
+    #[arg(long, default_value_t = 1024 * 1024)]
+    max_exec_output_bytes: u64,
+
+    /// Registry pull deadline in seconds.
+    #[arg(long, default_value_t = 300)]
+    pull_timeout_secs: u64,
+
     /// Default `ram_mib` when omitted on create.
     #[arg(long, default_value_t = 512)]
     default_ram_mib: u32,
@@ -264,6 +276,9 @@ impl ServeStartArgs {
             max_vcpus: self.max_vcpus,
             max_running_ram_mib: self.max_running_ram_mib,
             max_disk_bytes: self.max_disk_bytes,
+            max_pull_bytes: self.max_pull_bytes,
+            max_exec_output_bytes: self.max_exec_output_bytes,
+            pull_timeout_secs: self.pull_timeout_secs,
             default_ram_mib: self.default_ram_mib,
             default_vcpus: self.default_vcpus,
         };
@@ -744,6 +759,9 @@ mod log_level_tests {
         assert!(help.contains("--max-ram-mib"), "{help}");
         assert!(help.contains("--max-running-ram-mib"), "{help}");
         assert!(help.contains("--max-disk-bytes"), "{help}");
+        assert!(help.contains("--max-pull-bytes"), "{help}");
+        assert!(help.contains("--max-exec-output-bytes"), "{help}");
+        assert!(help.contains("--pull-timeout-secs"), "{help}");
     }
 
     #[test]

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -18,6 +18,8 @@ mod run;
 mod vm;
 mod volume;
 
+use std::path::PathBuf;
+
 use anyhow::Result;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
@@ -170,6 +172,10 @@ enum Command {
     /// Policies default off; set `auto_stop_secs` / `auto_delete_secs` on create.
     Sweep,
 
+    /// Hosted HTTP worker.
+    #[command(subcommand)]
+    Serve(Serve),
+
     /// Manage ext4 disk images.
     Disk {
         #[command(subcommand)]
@@ -182,6 +188,44 @@ enum Command {
         /// Target shell.
         shell: Shell,
     },
+}
+
+/// `bux serve` subcommands.
+#[derive(Subcommand)]
+enum Serve {
+    /// Run the HTTP worker.
+    Start(ServeStartArgs),
+    /// Print the OpenAPI document as JSON and exit.
+    Openapi,
+}
+
+/// Flags for `bux serve start`.
+#[derive(clap::Args)]
+struct ServeStartArgs {
+    /// TCP listen address (`IP:PORT`).
+    #[arg(long, env = "BUX_LISTEN", default_value = "127.0.0.1:8080")]
+    listen: String,
+
+    /// API key as `id:secret`. Repeatable. `id` is the tenant id (`[A-Za-z0-9._]`).
+    #[arg(long = "api-key")]
+    api_key: Vec<String>,
+
+    /// File of `id=secret` lines. Blank lines and `#` comments are skipped.
+    #[arg(long, env = "BUX_API_KEY_FILE")]
+    api_key_file: Option<PathBuf>,
+}
+
+impl ServeStartArgs {
+    fn run(self) -> std::result::Result<(), bux_serve::Error> {
+        let env_keys = std::env::var("BUX_API_KEYS").ok();
+        let keys = bux_serve::load_api_keys(
+            &self.api_key,
+            self.api_key_file.as_deref(),
+            env_keys.as_deref().filter(|s| !s.is_empty()),
+        )?;
+        let config = bux_serve::ServeConfig::new(&self.listen, keys)?;
+        bux_serve::run(config)
+    }
 }
 
 /// Subcommands for `bux system`.
@@ -263,13 +307,42 @@ pub(crate) enum OutputFormat {
     Json,
 }
 
-#[tokio::main(flavor = "current_thread")]
-async fn main() {
+fn main() {
     let cli = Cli::parse();
     init_tracing(cli.log_level);
-    if let Err(e) = cli.dispatch().await {
-        eprintln!("bux: {e:#}");
-        std::process::exit(1);
+    match cli.command {
+        Command::Serve(cmd) => {
+            if let Err(e) = run_serve(cmd) {
+                eprintln!("bux: {e}");
+                std::process::exit(e.exit_code());
+            }
+        }
+        command => {
+            let rt = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    eprintln!("bux: {e:#}");
+                    std::process::exit(1);
+                }
+            };
+            if let Err(e) = rt.block_on(dispatch(command)) {
+                eprintln!("bux: {e:#}");
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+fn run_serve(cmd: Serve) -> std::result::Result<(), bux_serve::Error> {
+    match cmd {
+        Serve::Start(args) => args.run(),
+        Serve::Openapi => {
+            println!("{}", bux_serve::openapi_json());
+            Ok(())
+        }
     }
 }
 
@@ -287,42 +360,41 @@ fn init_tracing(log_level: Option<LogLevel>) {
         .init();
 }
 
-impl Cli {
-    async fn dispatch(self) -> Result<()> {
-        match self.command {
-            Command::Run(args) => args.run().await,
-            Command::Create(args) => args.run().await,
-            Command::Exec(args) => vm::exec(args).await,
-            Command::Logs(ref args) => logs::logs(args),
-            Command::Ps(ref args) => vm::ps(args),
-            Command::Stop(args) => vm::stop(args).await,
-            Command::Kill(ref args) => vm::kill(args),
-            Command::Rm(ref args) => vm::rm(args),
-            Command::Inspect(ref args) => vm::inspect(args),
-            Command::Cp(args) => vm::cp(args).await,
-            Command::Wait(args) => vm::wait(args).await,
-            Command::Prune => vm::prune(),
-            Command::Rename(ref args) => vm::rename(args),
-            Command::Restart(args) => vm::restart(args).await,
-            Command::Stats(ref args) => vm::stats(args).await,
-            Command::Snapshot { action } => snapshot_cmd(action).await,
-            Command::Clone(args) => vm::clone_box(args).await,
-            Command::Export(ref args) => vm::export(args),
-            Command::Pull { image } => pull(&image).await,
-            Command::Images { format } => images(format),
-            Command::Rmi { images } => rmi(&images),
-            Command::Info { format } => system_info(format),
-            Command::System { action } => match action {
-                SystemAction::Info { format } => system_info(format),
-                SystemAction::Reset => system_reset(),
-            },
-            Command::Volume { action } => volume::dispatch(action),
-            Command::Sweep => sweep_cmd(),
-            Command::Disk { action } => disk_cmd(action),
-            Command::Completion { shell } => {
-                clap_complete::generate(shell, &mut Self::command(), "bux", &mut std::io::stdout());
-                Ok(())
-            }
+async fn dispatch(command: Command) -> Result<()> {
+    match command {
+        Command::Run(args) => args.run().await,
+        Command::Create(args) => args.run().await,
+        Command::Exec(args) => vm::exec(args).await,
+        Command::Logs(ref args) => logs::logs(args),
+        Command::Ps(ref args) => vm::ps(args),
+        Command::Stop(args) => vm::stop(args).await,
+        Command::Kill(ref args) => vm::kill(args),
+        Command::Rm(ref args) => vm::rm(args),
+        Command::Inspect(ref args) => vm::inspect(args),
+        Command::Cp(args) => vm::cp(args).await,
+        Command::Wait(args) => vm::wait(args).await,
+        Command::Prune => vm::prune(),
+        Command::Rename(ref args) => vm::rename(args),
+        Command::Restart(args) => vm::restart(args).await,
+        Command::Stats(ref args) => vm::stats(args).await,
+        Command::Snapshot { action } => snapshot_cmd(action).await,
+        Command::Clone(args) => vm::clone_box(args).await,
+        Command::Export(ref args) => vm::export(args),
+        Command::Pull { image } => pull(&image).await,
+        Command::Images { format } => images(format),
+        Command::Rmi { images } => rmi(&images),
+        Command::Info { format } => system_info(format),
+        Command::System { action } => match action {
+            SystemAction::Info { format } => system_info(format),
+            SystemAction::Reset => system_reset(),
+        },
+        Command::Volume { action } => volume::dispatch(action),
+        Command::Sweep => sweep_cmd(),
+        Command::Serve(_) => anyhow::bail!("serve does not run on the current_thread runtime"),
+        Command::Disk { action } => disk_cmd(action),
+        Command::Completion { shell } => {
+            clap_complete::generate(shell, &mut Cli::command(), "bux", &mut std::io::stdout());
+            Ok(())
         }
     }
 }
@@ -596,6 +668,31 @@ mod log_level_tests {
     #[test]
     fn rejects_invalid_level() {
         assert!(Cli::try_parse_from(["bux", "--log-level", "verbose", "images"]).is_err());
+    }
+
+    #[test]
+    fn serve_start_and_openapi_are_subcommands() {
+        let start = parse(&["serve", "start", "--api-key", "t1:s"]);
+        assert!(
+            matches!(start.command, Command::Serve(Serve::Start(_))),
+            "start"
+        );
+        let openapi = parse(&["serve", "openapi"]);
+        assert!(
+            matches!(openapi.command, Command::Serve(Serve::Openapi)),
+            "openapi"
+        );
+    }
+
+    #[test]
+    fn serve_start_help_mentions_keys() {
+        let help = match Cli::try_parse_from(["bux", "serve", "start", "--help"]) {
+            Ok(_) => panic!("--help should abort parse"),
+            Err(e) => e.to_string(),
+        };
+        assert!(help.contains("--api-key"), "{help}");
+        assert!(help.contains("--api-key-file"), "{help}");
+        assert!(help.contains("--listen"), "{help}");
     }
 
     #[test]

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -259,6 +259,14 @@ struct ServeStartArgs {
     /// Default `vcpus` when omitted on create.
     #[arg(long, default_value_t = 1)]
     default_vcpus: u8,
+
+    /// Required to bind a non-loopback TCP address.
+    #[arg(long)]
+    public: bool,
+
+    /// Allow `"unrestricted": true` on create (`Enabled { allow_net: [] }`).
+    #[arg(long)]
+    allow_unrestricted_net: bool,
 }
 
 impl ServeStartArgs {
@@ -282,9 +290,10 @@ impl ServeStartArgs {
             default_ram_mib: self.default_ram_mib,
             default_vcpus: self.default_vcpus,
         };
-        let config = bux_serve::ServeConfig::new(&self.listen, keys)?
+        let config = bux_serve::ServeConfig::bind(&self.listen, keys, self.public)?
             .data_dir(bux::default_data_dir())
-            .limits(limits);
+            .limits(limits)
+            .allow_unrestricted_net(self.allow_unrestricted_net);
         bux_serve::run(config)
     }
 }
@@ -762,6 +771,27 @@ mod log_level_tests {
         assert!(help.contains("--max-pull-bytes"), "{help}");
         assert!(help.contains("--max-exec-output-bytes"), "{help}");
         assert!(help.contains("--pull-timeout-secs"), "{help}");
+        assert!(help.contains("--public"), "{help}");
+        assert!(help.contains("--allow-unrestricted-net"), "{help}");
+    }
+
+    #[test]
+    fn serve_start_public_and_unrestricted_flags() {
+        let cli = parse(&[
+            "serve",
+            "start",
+            "--api-key",
+            "t1:s",
+            "--public",
+            "--allow-unrestricted-net",
+        ]);
+        match cli.command {
+            Command::Serve(Serve::Start(args)) => {
+                assert!(args.public, "public");
+                assert!(args.allow_unrestricted_net, "unrestricted");
+            }
+            _ => panic!("expected serve start"),
+        }
     }
 
     #[test]

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -207,6 +207,8 @@ struct ServeStartArgs {
     listen: String,
 
     /// API key as `id:secret`. Repeatable. `id` is the tenant id (`[A-Za-z0-9._]`).
+    ///
+    /// Also `BUX_API_KEYS=id:secret,id2:secret2` (comma-separated, merged with this flag).
     #[arg(long = "api-key")]
     api_key: Vec<String>,
 
@@ -693,6 +695,7 @@ mod log_level_tests {
         assert!(help.contains("--api-key"), "{help}");
         assert!(help.contains("--api-key-file"), "{help}");
         assert!(help.contains("--listen"), "{help}");
+        assert!(help.contains("BUX_API_KEYS"), "{help}");
     }
 
     #[test]

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -202,9 +202,13 @@ enum Serve {
 /// Flags for `bux serve start`.
 #[derive(clap::Args)]
 struct ServeStartArgs {
-    /// TCP listen address (`IP:PORT`).
-    #[arg(long, env = "BUX_LISTEN", default_value = "127.0.0.1:8080")]
-    listen: String,
+    /// Listen spec. Repeatable. `HOST:PORT` or `unix://PATH` (a path starting with `/` is Unix).
+    ///
+    /// When omitted: `127.0.0.1:8080` and `unix://$XDG_RUNTIME_DIR/bux.sock`
+    /// (fallback `/tmp/bux-$UID.sock`). `BUX_LISTEN` is comma-separated using the
+    /// same grammar.
+    #[arg(long, value_name = "ADDR")]
+    listen: Vec<String>,
 
     /// API key as `id:secret`. Repeatable. `id` is the tenant id (`[A-Za-z0-9._]`).
     ///
@@ -260,7 +264,8 @@ struct ServeStartArgs {
     #[arg(long, default_value_t = 1)]
     default_vcpus: u8,
 
-    /// Required to bind a non-loopback TCP address.
+    /// Required to bind a non-loopback TCP address. Unix sockets ignore this.
+    /// Invalid when every `--listen` is a Unix socket.
     #[arg(long)]
     public: bool,
 
@@ -290,7 +295,9 @@ impl ServeStartArgs {
             default_ram_mib: self.default_ram_mib,
             default_vcpus: self.default_vcpus,
         };
-        let config = bux_serve::ServeConfig::bind(&self.listen, keys, self.public)?
+        let env_listen = std::env::var("BUX_LISTEN").ok();
+        let listen = bux_serve::listen_specs(&self.listen, env_listen.as_deref());
+        let config = bux_serve::ServeConfig::bind(listen, keys, self.public)?
             .data_dir(bux::default_data_dir())
             .limits(limits)
             .allow_unrestricted_net(self.allow_unrestricted_net);
@@ -763,6 +770,8 @@ mod log_level_tests {
         assert!(help.contains("--api-key"), "{help}");
         assert!(help.contains("--api-key-file"), "{help}");
         assert!(help.contains("--listen"), "{help}");
+        assert!(help.contains("unix://"), "{help}");
+        assert!(help.contains("BUX_LISTEN"), "{help}");
         assert!(help.contains("BUX_API_KEYS"), "{help}");
         assert!(help.contains("--max-sandboxes"), "{help}");
         assert!(help.contains("--max-ram-mib"), "{help}");
@@ -773,6 +782,30 @@ mod log_level_tests {
         assert!(help.contains("--pull-timeout-secs"), "{help}");
         assert!(help.contains("--public"), "{help}");
         assert!(help.contains("--allow-unrestricted-net"), "{help}");
+    }
+
+    #[test]
+    fn serve_start_listen_repeatable() {
+        let cli = parse(&[
+            "serve",
+            "start",
+            "--api-key",
+            "t1:s",
+            "--listen",
+            "127.0.0.1:8080",
+            "--listen",
+            "unix:///tmp/bux.sock",
+        ]);
+        match cli.command {
+            Command::Serve(Serve::Start(args)) => {
+                assert_eq!(
+                    args.listen,
+                    vec!["127.0.0.1:8080", "unix:///tmp/bux.sock"],
+                    "listen"
+                );
+            }
+            _ => panic!("expected serve start"),
+        }
     }
 
     #[test]

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -750,10 +750,15 @@ mod log_level_tests {
     #[test]
     fn serve_start_and_openapi_are_subcommands() {
         let start = parse(&["serve", "start", "--api-key", "t1:s"]);
-        assert!(
-            matches!(start.command, Command::Serve(Serve::Start(_))),
-            "start"
-        );
+        match start.command {
+            Command::Serve(Serve::Start(args)) => {
+                assert!(
+                    args.listen.is_empty(),
+                    "omitted --listen stays empty so ServeConfig applies TCP+unix defaults"
+                );
+            }
+            _ => panic!("start"),
+        }
         let openapi = parse(&["serve", "openapi"]);
         assert!(
             matches!(openapi.command, Command::Serve(Serve::Openapi)),

--- a/crates/bux-cli/src/main.rs
+++ b/crates/bux-cli/src/main.rs
@@ -215,6 +215,38 @@ struct ServeStartArgs {
     /// File of `id=secret` lines. Blank lines and `#` comments are skipped.
     #[arg(long, env = "BUX_API_KEY_FILE")]
     api_key_file: Option<PathBuf>,
+
+    /// Maximum sandboxes per tenant.
+    #[arg(long, default_value_t = 32)]
+    max_sandboxes: u32,
+
+    /// Maximum sandboxes on this worker (all tenants).
+    #[arg(long, default_value_t = 32)]
+    max_sandboxes_global: u32,
+
+    /// Maximum RAM per sandbox (MiB).
+    #[arg(long, default_value_t = 2048)]
+    max_ram_mib: u32,
+
+    /// Maximum vCPUs per sandbox.
+    #[arg(long, default_value_t = 4)]
+    max_vcpus: u8,
+
+    /// Maximum sum of Running+Stopping RAM plus a new create (MiB).
+    #[arg(long, default_value_t = 8192)]
+    max_running_ram_mib: u32,
+
+    /// Maximum recursive data-dir usage in bytes (`Runtime::data_dir_usage`).
+    #[arg(long, default_value_t = 32_u64 * 1024 * 1024 * 1024)]
+    max_disk_bytes: u64,
+
+    /// Default `ram_mib` when omitted on create.
+    #[arg(long, default_value_t = 512)]
+    default_ram_mib: u32,
+
+    /// Default `vcpus` when omitted on create.
+    #[arg(long, default_value_t = 1)]
+    default_vcpus: u8,
 }
 
 impl ServeStartArgs {
@@ -225,7 +257,19 @@ impl ServeStartArgs {
             self.api_key_file.as_deref(),
             env_keys.as_deref().filter(|s| !s.is_empty()),
         )?;
-        let config = bux_serve::ServeConfig::new(&self.listen, keys)?;
+        let limits = bux_serve::Limits {
+            max_sandboxes: self.max_sandboxes,
+            max_sandboxes_global: self.max_sandboxes_global,
+            max_ram_mib: self.max_ram_mib,
+            max_vcpus: self.max_vcpus,
+            max_running_ram_mib: self.max_running_ram_mib,
+            max_disk_bytes: self.max_disk_bytes,
+            default_ram_mib: self.default_ram_mib,
+            default_vcpus: self.default_vcpus,
+        };
+        let config = bux_serve::ServeConfig::new(&self.listen, keys)?
+            .data_dir(bux::default_data_dir())
+            .limits(limits);
         bux_serve::run(config)
     }
 }
@@ -696,6 +740,10 @@ mod log_level_tests {
         assert!(help.contains("--api-key-file"), "{help}");
         assert!(help.contains("--listen"), "{help}");
         assert!(help.contains("BUX_API_KEYS"), "{help}");
+        assert!(help.contains("--max-sandboxes"), "{help}");
+        assert!(help.contains("--max-ram-mib"), "{help}");
+        assert!(help.contains("--max-running-ram-mib"), "{help}");
+        assert!(help.contains("--max-disk-bytes"), "{help}");
     }
 
     #[test]

--- a/crates/bux-cli/src/vm.rs
+++ b/crates/bux-cli/src/vm.rs
@@ -683,7 +683,8 @@ pub async fn stats(args: &StatsArgs) -> Result<()> {
 #[cfg(unix)]
 pub async fn clone_box(args: CloneArgs) -> Result<()> {
     let rt = open_runtime()?;
-    let handle = rt.clone(&args.source, args.name).await?;
+    let source = rt.get(&args.source)?;
+    let handle = rt.clone(&source.info().id, args.name).await?;
     println!("{}", handle.info().id);
     Ok(())
 }

--- a/crates/bux-oci/Cargo.toml
+++ b/crates/bux-oci/Cargo.toml
@@ -20,5 +20,8 @@ tar.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 
+[dev-dependencies]
+tempfile.workspace = true
+
 [lints]
 workspace = true

--- a/crates/bux-oci/src/lib.rs
+++ b/crates/bux-oci/src/lib.rs
@@ -237,6 +237,24 @@ impl Oci {
         self.store.list_images()
     }
 
+    /// Sum of compressed layer sizes from the image manifest, before `pull_blob`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the reference is invalid or the registry request fails.
+    pub async fn manifest_compressed_bytes(&self, image: &str) -> Result<u64> {
+        let reference = parse_reference(image)?;
+        let (manifest, _digest, _config) = self
+            .client
+            .pull_manifest_and_config(&reference, &self.auth)
+            .await?;
+        Ok(manifest
+            .layers
+            .iter()
+            .map(|layer| u64::try_from(layer.size).unwrap_or(0))
+            .sum())
+    }
+
     /// Removes a locally stored image and its extracted rootfs.
     ///
     /// Layer blobs are ref-counted; only orphaned blobs are deleted.
@@ -256,6 +274,15 @@ fn parse_reference(image: &str) -> Result<Reference> {
     image
         .parse()
         .map_err(|e: oci_client::ParseError| OciError::InvalidReference(e.to_string()))
+}
+
+/// Parse `image` and return the canonical OCI reference string.
+///
+/// # Errors
+///
+/// Returns [`OciError::InvalidReference`] if `image` is not a valid OCI reference.
+pub fn canonical_reference(image: &str) -> Result<String> {
+    Ok(parse_reference(image)?.to_string())
 }
 
 /// Deserializes the raw OCI config JSON blob into our minimal [`ImageConfig`].
@@ -332,4 +359,24 @@ fn dirs_default_store() -> PathBuf {
         }
     }
     PathBuf::from("bux")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::canonical_reference;
+
+    #[test]
+    fn canonical_reference_library_alias() {
+        let short = canonical_reference("python:slim").unwrap();
+        let long = canonical_reference("docker.io/library/python:slim").unwrap();
+        assert_eq!(
+            short, long,
+            "short and fully-qualified python:slim must canonicalize equally"
+        );
+        assert_eq!(
+            short, "docker.io/library/python:slim",
+            "canonical form must be the docker.io library reference"
+        );
+    }
 }

--- a/crates/bux-oci/src/lib.rs
+++ b/crates/bux-oci/src/lib.rs
@@ -265,7 +265,11 @@ impl Oci {
     /// or a database/filesystem operation fails.
     pub fn remove(&self, image: &str) -> Result<()> {
         let reference = parse_reference(image)?;
-        self.store.remove_image(&reference.to_string())
+        let ref_str = reference.to_string();
+        if self.store.get_digest(&ref_str)?.is_none() {
+            return Err(OciError::NotFound(ref_str));
+        }
+        self.store.remove_image(&ref_str)
     }
 }
 
@@ -296,26 +300,16 @@ fn parse_image_config(data: &str) -> Option<ImageConfig> {
     serde_json::from_str::<TopLevel>(data).ok()?.config
 }
 
-/// Platform resolver that always selects `linux/{arch}`.
+/// Platform resolver that selects `linux/{arch}` only.
 ///
-/// VMs always run Linux regardless of the host OS, so we must pull Linux
-/// images even when running on macOS.
+/// VMs always run Linux regardless of the host OS. Wrong-arch and non-linux
+/// entries are not selected.
 fn linux_platform_resolver(platforms: &[oci_client::manifest::ImageIndexEntry]) -> Option<String> {
     let target_arch = target_oci_arch();
-
-    // Prefer exact linux/{arch} match.
     for entry in platforms {
         if let Some(ref p) = entry.platform
             && p.os.to_string() == "linux"
             && p.architecture.to_string() == target_arch
-        {
-            return Some(entry.digest.clone());
-        }
-    }
-    // Fallback: first linux entry regardless of arch.
-    for entry in platforms {
-        if let Some(ref p) = entry.platform
-            && p.os.to_string() == "linux"
         {
             return Some(entry.digest.clone());
         }
@@ -364,7 +358,18 @@ fn dirs_default_store() -> PathBuf {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
-    use super::canonical_reference;
+    use super::{Oci, RegistryAuth, canonical_reference, linux_platform_resolver, target_oci_arch};
+    use crate::OciError;
+
+    fn index_entry(os: &str, arch: &str, digest: &str) -> oci_client::manifest::ImageIndexEntry {
+        serde_json::from_value(serde_json::json!({
+            "mediaType": "application/vnd.oci.image.manifest.v1+json",
+            "digest": digest,
+            "size": 1,
+            "platform": { "architecture": arch, "os": os }
+        }))
+        .unwrap()
+    }
 
     #[test]
     fn canonical_reference_library_alias() {
@@ -378,5 +383,47 @@ mod tests {
             short, "docker.io/library/python:slim",
             "canonical form must be the docker.io library reference"
         );
+    }
+
+    #[test]
+    fn linux_platform_resolver_requires_linux_and_host_arch() {
+        let arch = target_oci_arch();
+        let other = if arch == "arm64" { "amd64" } else { "arm64" };
+        let want = "sha256:wanted";
+        let got = linux_platform_resolver(&[
+            index_entry("linux", other, "sha256:wrong"),
+            index_entry("linux", arch, want),
+            index_entry("darwin", arch, "sha256:darwin"),
+        ]);
+        assert_eq!(got.as_deref(), Some(want), "exact linux/arch");
+        assert_eq!(
+            linux_platform_resolver(&[index_entry("linux", other, "sha256:wrong")]),
+            None,
+            "no first-linux fallback"
+        );
+        assert_eq!(
+            linux_platform_resolver(&[index_entry("darwin", arch, "sha256:darwin")]),
+            None,
+            "non-linux"
+        );
+        assert_eq!(linux_platform_resolver(&[]), None, "empty");
+    }
+
+    #[test]
+    fn linux_platform_resolver_has_no_arch_fallback() {
+        let prod = include_str!("lib.rs").split("#[cfg(test)]").next().unwrap();
+        assert!(
+            !prod.contains("regardless of arch"),
+            "first-linux fallback must stay deleted"
+        );
+        assert!(prod.contains("linux_platform_resolver"), "resolver exists");
+    }
+
+    #[test]
+    fn remove_missing_is_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let oci = Oci::open_at(dir.path(), RegistryAuth::Anonymous).unwrap();
+        let err = oci.remove("alpine:latest").unwrap_err();
+        assert!(matches!(err, OciError::NotFound(_)), "missing image: {err}");
     }
 }

--- a/crates/bux-serve/Cargo.toml
+++ b/crates/bux-serve/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "bux-serve"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "../../README.md"
+description = "HTTP worker for hosted bux agent sandboxes"
+keywords = ["ai", "sandbox", "vm", "http"]
+categories = ["web-programming::http-server", "virtualization"]
+
+[dependencies]
+axum.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tower.workspace = true
+tower-http.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/bux-serve/Cargo.toml
+++ b/crates/bux-serve/Cargo.toml
@@ -10,8 +10,9 @@ keywords = ["ai", "sandbox", "vm", "http"]
 categories = ["web-programming::http-server", "virtualization"]
 
 [dependencies]
-axum.workspace = true
+axum = { workspace = true, features = ["query"] }
 bux.workspace = true
+bux-proto.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }

--- a/crates/bux-serve/Cargo.toml
+++ b/crates/bux-serve/Cargo.toml
@@ -20,6 +20,7 @@ tower-http.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+rusqlite.workspace = true
 serde_json.workspace = true
 tempfile.workspace = true
 

--- a/crates/bux-serve/Cargo.toml
+++ b/crates/bux-serve/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["web-programming::http-server", "virtualization"]
 
 [dependencies]
 axum.workspace = true
+bux.workspace = true
 serde.workspace = true
-serde_json.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower.workspace = true
@@ -20,6 +20,7 @@ tower-http.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+serde_json.workspace = true
 tempfile.workspace = true
 
 [lints]

--- a/crates/bux-serve/Cargo.toml
+++ b/crates/bux-serve/Cargo.toml
@@ -21,6 +21,9 @@ tower-http.workspace = true
 tracing.workspace = true
 utoipa.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 rusqlite.workspace = true
 serde_json.workspace = true

--- a/crates/bux-serve/Cargo.toml
+++ b/crates/bux-serve/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { workspace = true, features = ["rt-multi-thread"] }
 tower.workspace = true
 tower-http.workspace = true
 tracing.workspace = true
+utoipa.workspace = true
 
 [dev-dependencies]
 rusqlite.workspace = true

--- a/crates/bux-serve/src/auth.rs
+++ b/crates/bux-serve/src/auth.rs
@@ -1,0 +1,57 @@
+//! Bearer authentication. Only `GET /v1/health` is unauthenticated.
+
+use axum::extract::{FromRequestParts, Request, State};
+use axum::http::HeaderMap;
+use axum::http::header::AUTHORIZATION;
+use axum::http::request::Parts;
+use axum::middleware::Next;
+use axum::response::Response;
+
+use crate::error::ApiError;
+use crate::state::AppState;
+
+/// Authenticated tenant (`ApiKey.id`).
+#[derive(Clone, Debug)]
+pub(crate) struct Tenant {
+    pub id: String,
+}
+
+impl FromRequestParts<AppState> for Tenant {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<Self>()
+            .cloned()
+            .ok_or_else(ApiError::unauthorized)
+    }
+}
+
+pub(crate) async fn require_bearer(
+    State(state): State<AppState>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    let token = bearer_token(req.headers()).ok_or_else(ApiError::unauthorized)?;
+    let tenant = state
+        .tenant_for_bearer(token)
+        .ok_or_else(ApiError::unauthorized)?;
+    req.extensions_mut().insert(Tenant {
+        id: tenant.to_owned(),
+    });
+    Ok(next.run(req).await)
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get(AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, rest) = value.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("bearer") && !rest.is_empty() {
+        Some(rest)
+    } else {
+        None
+    }
+}

--- a/crates/bux-serve/src/error.rs
+++ b/crates/bux-serve/src/error.rs
@@ -1,0 +1,123 @@
+//! Start-up errors and the HTTP `{ "error": { "code", "message" } }` envelope.
+
+use std::io;
+use std::net::SocketAddr;
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use crate::ids::IdError;
+
+/// Result alias for serve start and key loading.
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Errors from worker start, listen, and API-key loading.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+#[allow(
+    clippy::error_impl_error,
+    reason = "Error is the crate's public error type"
+)]
+pub enum Error {
+    /// No API keys were provided.
+    #[error("at least one API key is required")]
+    NoApiKeys,
+
+    /// `--api-key` / `BUX_API_KEYS` value was not `id:secret`.
+    #[error("API key must be id:secret")]
+    ApiKeyMissingSeparator,
+
+    /// Key file line was not `id=secret`.
+    #[error("API key file {path}: line {line}: expected id=secret")]
+    ApiKeyFileSyntax {
+        /// Path of the key file.
+        path: String,
+        /// 1-based line number.
+        line: usize,
+    },
+
+    /// Secret was empty.
+    #[error("API key {0:?} has an empty secret")]
+    EmptyApiKeySecret(String),
+
+    /// Two keys used the same id.
+    #[error("duplicate API key id {0:?}")]
+    DuplicateApiKeyId(String),
+
+    /// Tenant / agent / key id failed alphabet or length checks.
+    #[error(transparent)]
+    InvalidId(#[from] IdError),
+
+    /// `--listen` was not `IP:PORT`.
+    #[error("invalid listen address {0:?}")]
+    InvalidListen(String),
+
+    /// TCP bind was not loopback.
+    #[error("refusing non-loopback listen {0}")]
+    NonLoopback(SocketAddr),
+
+    /// Bind, file, or runtime I/O.
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+impl Error {
+    /// Process exit status: `2` for usage / config, `1` for I/O.
+    #[must_use]
+    pub const fn exit_code(&self) -> i32 {
+        match self {
+            Self::Io(_) => 1,
+            _ => 2,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ApiError {
+    status: StatusCode,
+    code: &'static str,
+    message: &'static str,
+}
+
+impl ApiError {
+    pub(crate) const fn unauthorized() -> Self {
+        Self {
+            status: StatusCode::UNAUTHORIZED,
+            code: "unauthorized",
+            message: "missing or invalid bearer token",
+        }
+    }
+
+    pub(crate) const fn payload_too_large() -> Self {
+        Self {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            code: "payload_too_large",
+            message: "request body too large",
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ErrorEnvelope<'a> {
+    error: ErrorBody<'a>,
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    code: &'a str,
+    message: &'a str,
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ErrorEnvelope {
+            error: ErrorBody {
+                code: self.code,
+                message: self.message,
+            },
+        };
+        (self.status, Json(body)).into_response()
+    }
+}

--- a/crates/bux-serve/src/error.rs
+++ b/crates/bux-serve/src/error.rs
@@ -1,19 +1,22 @@
-//! Start-up errors and the HTTP `{ "error": { "code", "message" } }` envelope.
+//! Start-up errors and the HTTP `{ "error": { "code", "message", ... } }` envelope.
 
 use std::io;
 use std::net::SocketAddr;
 
 use axum::Json;
+use axum::extract::FromRequest;
+use axum::extract::rejection::JsonRejection;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use crate::ids::IdError;
 
 /// Result alias for serve start and key loading.
 pub type Result<T> = std::result::Result<T, Error>;
 
-/// Errors from worker start, listen, and API-key loading.
+/// Errors from worker start, listen, API-key loading, and runtime open.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 #[allow(
@@ -61,14 +64,18 @@ pub enum Error {
     /// Bind, file, or runtime I/O.
     #[error(transparent)]
     Io(#[from] io::Error),
+
+    /// Engine [`bux::Error`] (exclusive flock [`bux::Error::Busy`], and others).
+    #[error(transparent)]
+    Runtime(#[from] bux::Error),
 }
 
 impl Error {
-    /// Process exit status: `2` for usage / config, `1` for I/O.
+    /// Process exit status: `2` for usage / config, `1` for I/O and engine.
     #[must_use]
     pub const fn exit_code(&self) -> i32 {
         match self {
-            Self::Io(_) => 1,
+            Self::Io(_) | Self::Runtime(_) => 1,
             _ => 2,
         }
     }
@@ -78,25 +85,190 @@ impl Error {
 pub(crate) struct ApiError {
     status: StatusCode,
     code: &'static str,
-    message: &'static str,
+    message: String,
+    existing_id: Option<String>,
+    field: Option<String>,
 }
 
 impl ApiError {
-    pub(crate) const fn unauthorized() -> Self {
+    pub(crate) fn unauthorized() -> Self {
         Self {
             status: StatusCode::UNAUTHORIZED,
             code: "unauthorized",
-            message: "missing or invalid bearer token",
+            message: "missing or invalid bearer token".into(),
+            existing_id: None,
+            field: None,
         }
     }
 
-    pub(crate) const fn payload_too_large() -> Self {
+    pub(crate) fn payload_too_large() -> Self {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             code: "payload_too_large",
-            message: "request body too large",
+            message: "request body too large".into(),
+            existing_id: None,
+            field: None,
         }
     }
+
+    pub(crate) fn invalid_config(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_config",
+            message: message.into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn not_found() -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "not_found",
+            message: "sandbox not found".into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn name_occupied(existing_id: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "name_occupied",
+            message: "sandbox name is occupied".into(),
+            existing_id: Some(existing_id.into()),
+            field: None,
+        }
+    }
+
+    pub(crate) fn name_occupied_unknown() -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "name_occupied",
+            message: "sandbox name is occupied".into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn resource_exhausted(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            code: "resource_exhausted",
+            message: message.into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn internal(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal",
+            message: message.into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn with_field(mut self, field: &'static str) -> Self {
+        self.field = Some(field.into());
+        self
+    }
+
+    pub(crate) fn from_engine(err: bux::Error) -> Self {
+        match err {
+            bux::Error::InvalidConfig(message) => Self::invalid_config(message),
+            bux::Error::NotFound(_) => Self::not_found(),
+            bux::Error::Ambiguous(_) => Self::name_occupied_unknown(),
+            bux::Error::InvalidState(message) => Self::conflict("invalid_state", message),
+            bux::Error::Busy(message) => Self::conflict("busy", message),
+            bux::Error::GuestUnavailable(message) => Self {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "guest_unavailable",
+                message,
+                existing_id: None,
+                field: None,
+            },
+            bux::Error::SecretsRequired => {
+                Self::conflict("secrets_required", "secrets required for this sandbox")
+            }
+            bux::Error::SecretsNeedVirtioNet => Self::invalid_config("secrets require virtio-net"),
+            bux::Error::SecurityUnavailable(message) => Self {
+                status: StatusCode::PRECONDITION_FAILED,
+                code: "security_unavailable",
+                message,
+                existing_id: None,
+                field: None,
+            },
+            bux::Error::Oci(e) => map_oci(e),
+            bux::Error::Shutdown => Self {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                code: "shutdown",
+                message: "runtime has been shut down".into(),
+                existing_id: None,
+                field: None,
+            },
+            other => Self::internal(other.to_string()),
+        }
+    }
+
+    fn conflict(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code,
+            message: message.into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+}
+
+/// Display-based OCI mapping so serve does not depend on `bux-oci`.
+fn map_oci(err: impl std::fmt::Display) -> ApiError {
+    let message = err.to_string();
+    if message.starts_with("invalid image reference") {
+        ApiError::invalid_config(message)
+    } else {
+        ApiError {
+            status: StatusCode::BAD_GATEWAY,
+            code: "oci",
+            message,
+            existing_id: None,
+            field: None,
+        }
+    }
+}
+
+impl From<IdError> for ApiError {
+    fn from(err: IdError) -> Self {
+        Self::invalid_config(err.to_string())
+    }
+}
+
+/// JSON body that maps extractor failures to the error envelope (400).
+pub(crate) struct JsonBody<T>(pub T);
+
+impl<S, T> FromRequest<S> for JsonBody<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request(
+        req: axum::extract::Request,
+        state: &S,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        match Json::<T>::from_request(req, state).await {
+            Ok(Json(value)) => Ok(Self(value)),
+            Err(rejection) => Err(json_rejection(&rejection)),
+        }
+    }
+}
+
+fn json_rejection(rejection: &JsonRejection) -> ApiError {
+    ApiError::invalid_config(rejection.body_text())
 }
 
 #[derive(Serialize)]
@@ -108,6 +280,10 @@ struct ErrorEnvelope<'a> {
 struct ErrorBody<'a> {
     code: &'a str,
     message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    existing_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    field: Option<&'a str>,
 }
 
 impl IntoResponse for ApiError {
@@ -115,7 +291,9 @@ impl IntoResponse for ApiError {
         let body = ErrorEnvelope {
             error: ErrorBody {
                 code: self.code,
-                message: self.message,
+                message: &self.message,
+                existing_id: self.existing_id.as_deref(),
+                field: self.field.as_deref(),
             },
         };
         (self.status, Json(body)).into_response()

--- a/crates/bux-serve/src/error.rs
+++ b/crates/bux-serve/src/error.rs
@@ -182,6 +182,26 @@ impl ApiError {
         }
     }
 
+    pub(crate) fn sandbox_exists(existing_id: impl Into<String>, field: &'static str) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "sandbox_exists",
+            message: "sandbox exists with a different spec".into(),
+            existing_id: Some(existing_id.into()),
+            field: Some(field.into()),
+        }
+    }
+
+    pub(crate) fn still_stopping() -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "guest_unavailable",
+            message: "sandbox still stopping".into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
     pub(crate) fn resource_exhausted(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::TOO_MANY_REQUESTS,

--- a/crates/bux-serve/src/error.rs
+++ b/crates/bux-serve/src/error.rs
@@ -56,13 +56,17 @@ pub enum Error {
     #[error(transparent)]
     InvalidId(#[from] IdError),
 
-    /// `--listen` was not `IP:PORT`.
+    /// `--listen` was not `HOST:PORT` or `unix://PATH`.
     #[error("invalid listen address {0:?}")]
     InvalidListen(String),
 
     /// TCP bind was not loopback.
     #[error("refusing non-loopback listen {0}")]
     NonLoopback(SocketAddr),
+
+    /// `--public` was set but every listener is a Unix socket.
+    #[error("--public requires a TCP listen address")]
+    PublicRequiresTcp,
 
     /// Bind, file, or runtime I/O.
     #[error(transparent)]

--- a/crates/bux-serve/src/error.rs
+++ b/crates/bux-serve/src/error.rs
@@ -5,8 +5,11 @@ use std::net::SocketAddr;
 
 use axum::Json;
 use axum::extract::FromRequest;
-use axum::extract::rejection::JsonRejection;
+use axum::extract::FromRequestParts;
+use axum::extract::Query;
+use axum::extract::rejection::{JsonRejection, QueryRejection};
 use axum::http::StatusCode;
+use axum::http::request::Parts;
 use axum::response::{IntoResponse, Response};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -102,10 +105,14 @@ impl ApiError {
     }
 
     pub(crate) fn payload_too_large() -> Self {
+        Self::payload_too_large_msg("request body too large")
+    }
+
+    pub(crate) fn payload_too_large_msg(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::PAYLOAD_TOO_LARGE,
             code: "payload_too_large",
-            message: "request body too large".into(),
+            message: message.into(),
             existing_id: None,
             field: None,
         }
@@ -122,10 +129,34 @@ impl ApiError {
     }
 
     pub(crate) fn not_found() -> Self {
+        Self::not_found_msg("sandbox not found")
+    }
+
+    pub(crate) fn not_found_msg(message: impl Into<String>) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,
             code: "not_found",
-            message: "sandbox not found".into(),
+            message: message.into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn image_in_use() -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "busy",
+            message: "image is in use".into(),
+            existing_id: None,
+            field: None,
+        }
+    }
+
+    pub(crate) fn oci(message: impl Into<String>) -> Self {
+        Self {
+            status: StatusCode::BAD_GATEWAY,
+            code: "oci",
+            message: message.into(),
             existing_id: None,
             field: None,
         }
@@ -229,14 +260,10 @@ fn map_oci(err: impl std::fmt::Display) -> ApiError {
     let message = err.to_string();
     if message.starts_with("invalid image reference") {
         ApiError::invalid_config(message)
+    } else if message.starts_with("image not found") {
+        ApiError::not_found_msg(message)
     } else {
-        ApiError {
-            status: StatusCode::BAD_GATEWAY,
-            code: "oci",
-            message,
-            existing_id: None,
-            field: None,
-        }
+        ApiError::oci(message)
     }
 }
 
@@ -268,6 +295,31 @@ where
 }
 
 fn json_rejection(rejection: &JsonRejection) -> ApiError {
+    ApiError::invalid_config(rejection.body_text())
+}
+
+/// Query string that maps extractor failures to the error envelope (400).
+pub(crate) struct QueryBody<T>(pub T);
+
+impl<S, T> FromRequestParts<S> for QueryBody<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &S,
+    ) -> std::result::Result<Self, Self::Rejection> {
+        match Query::<T>::from_request_parts(parts, state).await {
+            Ok(Query(value)) => Ok(Self(value)),
+            Err(rejection) => Err(query_rejection(&rejection)),
+        }
+    }
+}
+
+fn query_rejection(rejection: &QueryRejection) -> ApiError {
     ApiError::invalid_config(rejection.body_text())
 }
 

--- a/crates/bux-serve/src/exec.rs
+++ b/crates/bux-serve/src/exec.rs
@@ -1,0 +1,506 @@
+//! Collect-only `POST /v1/sandboxes/{id}/exec`. Guest `ExecStart::timeout` is required.
+
+use axum::Json;
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::routing::post;
+use bux::{ExecHandle, ExecStart};
+use bux_proto::ExecOut;
+use serde::{Deserialize, Serialize};
+
+use crate::auth::Tenant;
+use crate::error::{ApiError, JsonBody};
+use crate::sandboxes::load_owned;
+use crate::state::AppState;
+
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+const MAX_TIMEOUT_MS: u64 = 300_000;
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new().route("/v1/sandboxes/{id}/exec", post(exec_one))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecRequest {
+    cmd: String,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default)]
+    env: Vec<String>,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecResponse {
+    stdout: String,
+    stderr: String,
+    code: i32,
+    timed_out: bool,
+    duration_ms: u64,
+    truncated: bool,
+}
+
+async fn exec_one(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+    JsonBody(req): JsonBody<ExecRequest>,
+) -> Result<Json<ExecResponse>, ApiError> {
+    if req.cmd.is_empty() {
+        return Err(ApiError::invalid_config("cmd is required").with_field("cmd"));
+    }
+    let timeout_ms = parse_timeout_ms(req.timeout_ms)?;
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    if vm.info().secrets_required {
+        return Err(ApiError::from_engine(bux::Error::SecretsRequired));
+    }
+
+    let mut start = ExecStart::new(req.cmd)
+        .args(req.args)
+        .env(req.env)
+        .timeout(timeout_ms);
+    if let Some(cwd) = req.cwd {
+        start = start.cwd(cwd);
+    }
+
+    let handle = vm.exec(start).await.map_err(ApiError::from_engine)?;
+    let cap = usize::try_from(state.limits.max_exec_output_bytes).unwrap_or(usize::MAX);
+    Ok(Json(collect_capped(handle, cap).await?))
+}
+
+fn parse_timeout_ms(timeout_ms: Option<u64>) -> Result<u64, ApiError> {
+    let timeout_ms = timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS);
+    if !(1..=MAX_TIMEOUT_MS).contains(&timeout_ms) {
+        return Err(
+            ApiError::invalid_config("timeout_ms must be between 1 and 300000")
+                .with_field("timeout_ms"),
+        );
+    }
+    Ok(timeout_ms)
+}
+
+async fn collect_capped(mut handle: ExecHandle, cap: usize) -> Result<ExecResponse, ApiError> {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut truncated = false;
+    let mut signaled = false;
+    loop {
+        match handle.next_output().await {
+            Ok(ExecOut::Stdout(chunk)) => {
+                if !append_capped(&mut stdout, &chunk, cap) {
+                    truncated = true;
+                    kill_once(&mut handle, &mut signaled).await;
+                }
+            }
+            Ok(ExecOut::Stderr(chunk)) => {
+                if !append_capped(&mut stderr, &chunk, cap) {
+                    truncated = true;
+                    kill_once(&mut handle, &mut signaled).await;
+                }
+            }
+            Ok(ExecOut::Exit {
+                code,
+                timed_out,
+                duration_ms,
+                ..
+            }) => {
+                return Ok(ExecResponse {
+                    stdout: String::from_utf8_lossy(&stdout).into_owned(),
+                    stderr: String::from_utf8_lossy(&stderr).into_owned(),
+                    code,
+                    timed_out,
+                    duration_ms,
+                    truncated,
+                });
+            }
+            Ok(ExecOut::Error(info)) => {
+                return Err(ApiError::from_engine(bux::Error::Io(
+                    std::io::Error::other(info.message),
+                )));
+            }
+            Err(err) => return Err(ApiError::from_engine(err.into())),
+            Ok(_) => {}
+        }
+    }
+}
+
+fn append_capped(buf: &mut Vec<u8>, chunk: &[u8], cap: usize) -> bool {
+    let room = cap.saturating_sub(buf.len());
+    if chunk.len() <= room {
+        buf.extend_from_slice(chunk);
+        return true;
+    }
+    if let Some(head) = chunk.get(..room) {
+        buf.extend_from_slice(head);
+    }
+    false
+}
+
+async fn kill_once(handle: &mut ExecHandle, signaled: &mut bool) {
+    if *signaled {
+        return;
+    }
+    *signaled = true;
+    drop(handle.signal(9).await);
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
+    use axum::http::{Request, StatusCode};
+    use rusqlite::params;
+    use tower::ServiceExt;
+
+    use crate::ApiKey;
+    use crate::router::router;
+    use crate::state::Limits;
+
+    fn test_app() -> (tempfile::TempDir, Router) {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let app = router(AppState::new(
+            vec![
+                ApiKey::new("tenant1", "secret1").unwrap(),
+                ApiKey::new("tenant2", "secret2").unwrap(),
+            ],
+            runtime,
+            Limits::default(),
+        ));
+        (dir, app)
+    }
+
+    async fn json_body(res: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        token: Option<&str>,
+        body: Body,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        if method == "POST" {
+            builder = builder.header(CONTENT_TYPE, "application/json");
+        }
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    fn plant_vm(data_dir: &Path, id: &str, config: &serde_json::Value) {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        drop(child.wait());
+        let socket = data_dir.join("socks").join(format!("{id}.sock"));
+        let conn = rusqlite::Connection::open(data_dir.join("bux.db")).unwrap();
+        conn.busy_timeout(Duration::from_secs(5)).unwrap();
+        conn.execute(
+            "INSERT INTO vms (id, name, pid, image, socket, status, config, created_at)
+             VALUES (?1, ?2, ?3, NULL, ?4, 'stopped', ?5, 0)",
+            params![
+                id,
+                "a-tenant1-a1",
+                pid,
+                socket.to_str().expect("utf-8"),
+                config.to_string(),
+            ],
+        )
+        .unwrap();
+    }
+
+    fn error_code(v: &serde_json::Value) -> Option<&str> {
+        v.pointer("/error/code").and_then(serde_json::Value::as_str)
+    }
+
+    #[tokio::test]
+    async fn exec_without_bearer_is_401() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            None,
+            Body::from(r#"{"cmd":"echo"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+    }
+
+    #[tokio::test]
+    async fn exec_missing_sandbox_is_404() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":"echo"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "status");
+        assert_eq!(error_code(&json_body(res).await), Some("not_found"), "code");
+    }
+
+    #[tokio::test]
+    async fn exec_other_tenant_is_404() {
+        let (dir, app) = test_app();
+        plant_vm(
+            dir.path(),
+            "abc123aaa001",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant1",
+                "agent_id": "a1",
+            }),
+        );
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/abc123aaa001/exec",
+            Some("secret2"),
+            Body::from(r#"{"cmd":"echo"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "other tenant");
+    }
+
+    #[tokio::test]
+    async fn exec_timeout_ms_zero_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":"sleep","timeout_ms":0}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "zero");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("invalid_config"), "code");
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("timeout_ms"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_timeout_ms_over_max_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":"sleep","timeout_ms":300001}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "max");
+    }
+
+    #[tokio::test]
+    async fn exec_timeout_ms_one_is_not_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":"echo","timeout_ms":1}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "1 is valid");
+    }
+
+    #[tokio::test]
+    async fn exec_empty_cmd_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":""}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "empty cmd");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("cmd"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn exec_missing_cmd_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"args":["x"]}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "missing cmd");
+    }
+
+    #[tokio::test]
+    async fn exec_unknown_field_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":"echo","tty":true}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "tty");
+    }
+
+    #[tokio::test]
+    async fn exec_json_over_1mib_is_413() {
+        let (_dir, app) = test_app();
+        let len = crate::router::MAX_JSON_BODY_BYTES.saturating_add(1);
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/sandboxes/0123456789ab/exec")
+                    .header(AUTHORIZATION, "Bearer secret1")
+                    .header(CONTENT_TYPE, "application/json")
+                    .header("content-length", len.to_string())
+                    .body(Body::from(vec![0_u8; len]))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE, "json cap");
+    }
+
+    #[tokio::test]
+    async fn exec_get_is_405() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/exec",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::METHOD_NOT_ALLOWED, "no get");
+    }
+
+    #[tokio::test]
+    async fn exec_id_route_is_404() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/exec/abc",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "no exec_id");
+    }
+
+    #[tokio::test]
+    async fn exec_secrets_required_is_409() {
+        let (dir, app) = test_app();
+        plant_vm(
+            dir.path(),
+            "abc123aaa002",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant1",
+                "agent_id": "a1",
+                "secrets_required": true,
+            }),
+        );
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/abc123aaa002/exec",
+            Some("secret1"),
+            Body::from(r#"{"cmd":"echo"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "secrets");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("secrets_required"),
+            "code"
+        );
+    }
+
+    #[test]
+    fn timeout_ms_never_zero() {
+        assert!(parse_timeout_ms(Some(0)).is_err(), "0");
+        assert_eq!(
+            parse_timeout_ms(None).unwrap(),
+            DEFAULT_TIMEOUT_MS,
+            "default"
+        );
+        assert_eq!(parse_timeout_ms(Some(1)).unwrap(), 1, "min");
+        assert_eq!(
+            parse_timeout_ms(Some(MAX_TIMEOUT_MS)).unwrap(),
+            MAX_TIMEOUT_MS,
+            "max"
+        );
+        assert!(parse_timeout_ms(Some(MAX_TIMEOUT_MS + 1)).is_err(), "over");
+    }
+
+    #[test]
+    fn append_capped_truncates_over_cap() {
+        let mut buf = Vec::new();
+        assert!(append_capped(&mut buf, b"abc", 4), "under");
+        assert!(!append_capped(&mut buf, b"xyz", 4), "over");
+        assert_eq!(buf, b"abcx", "kept cap");
+    }
+
+    #[test]
+    fn production_sets_guest_timeout_and_collects() {
+        let prod = include_str!("exec.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(
+            prod.contains(".timeout(timeout_ms)"),
+            "must set ExecStart::timeout"
+        );
+        assert!(prod.contains("next_output"), "collect via next_output");
+        assert!(prod.contains("signal(9)"), "cap sends SIGKILL");
+        assert!(
+            !prod.contains("tokio::time::timeout"),
+            "must not wrap the host future"
+        );
+        assert!(!prod.contains("/exec/{"), "no exec_id routes");
+        assert!(prod.contains("ExecStart::new"), "build ExecStart");
+    }
+}

--- a/crates/bux-serve/src/exec.rs
+++ b/crates/bux-serve/src/exec.rs
@@ -7,6 +7,7 @@ use axum::routing::post;
 use bux::{ExecHandle, ExecStart};
 use bux_proto::ExecOut;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::auth::Tenant;
 use crate::error::{ApiError, JsonBody};
@@ -20,9 +21,9 @@ pub(crate) fn routes() -> Router<AppState> {
     Router::new().route("/v1/sandboxes/{id}/exec", post(exec_one))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct ExecRequest {
+pub(crate) struct ExecRequest {
     cmd: String,
     #[serde(default)]
     args: Vec<String>,
@@ -34,8 +35,8 @@ struct ExecRequest {
     timeout_ms: Option<u64>,
 }
 
-#[derive(Debug, Serialize)]
-struct ExecResponse {
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct ExecResponse {
     stdout: String,
     stderr: String,
     code: i32,
@@ -44,7 +45,22 @@ struct ExecResponse {
     truncated: bool,
 }
 
-async fn exec_one(
+#[utoipa::path(
+    post,
+    path = "/v1/sandboxes/{id}/exec",
+    operation_id = "exec",
+    tag = "Exec",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    request_body = ExecRequest,
+    responses(
+        (status = 200, description = "Collected exec output", body = ExecResponse),
+        (status = 400, description = "Invalid body or timeout_ms"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant"),
+        (status = 409, description = "secrets_required")
+    )
+)]
+pub(crate) async fn exec_one(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,

--- a/crates/bux-serve/src/exec.rs
+++ b/crates/bux-serve/src/exec.rs
@@ -500,6 +500,14 @@ mod tests {
             !prod.contains("tokio::time::timeout"),
             "must not wrap the host future"
         );
+        assert!(
+            !prod.contains("time::timeout"),
+            "must not wrap the host future via time::timeout"
+        );
+        assert!(
+            !prod.contains("tokio::time"),
+            "exec must not import tokio::time"
+        );
         assert!(!prod.contains("/exec/{"), "no exec_id routes");
         assert!(prod.contains("ExecStart::new"), "build ExecStart");
     }

--- a/crates/bux-serve/src/files.rs
+++ b/crates/bux-serve/src/files.rs
@@ -13,6 +13,8 @@ use crate::sandboxes::load_owned;
 use crate::state::AppState;
 
 const DEFAULT_FILE_MODE: u32 = 0o644;
+/// Files PUT body and GET response cap.
+pub(crate) const MAX_FILE_BODY_BYTES: usize = 32 * 1024 * 1024;
 
 pub(crate) fn routes() -> Router<AppState> {
     Router::new().route("/v1/sandboxes/{id}/files", get(get_file).put(put_file))
@@ -55,6 +57,9 @@ async fn get_file(
         .await
         .map_err(ApiError::from_engine)?;
     vm.touch_activity().map_err(ApiError::from_engine)?;
+    if data.len() > MAX_FILE_BODY_BYTES {
+        return Err(ApiError::payload_too_large());
+    }
     Ok(data)
 }
 
@@ -299,5 +304,15 @@ mod tests {
         assert!(prod.contains("validate_guest_path"), "path check");
         assert!(prod.contains("0o644"), "default mode");
         assert!(prod.contains("contains(\"..\")"), "reject ..");
+        let get_fn = prod
+            .split("async fn get_file(")
+            .nth(1)
+            .and_then(|rest| rest.split("\nasync fn ").next())
+            .expect("get_file");
+        assert!(
+            get_fn.contains("MAX_FILE_BODY_BYTES"),
+            "GET must cap at the files body limit"
+        );
+        assert!(get_fn.contains("payload_too_large"), "oversized GET is 413");
     }
 }

--- a/crates/bux-serve/src/files.rs
+++ b/crates/bux-serve/src/files.rs
@@ -21,13 +21,32 @@ pub(crate) fn routes() -> Router<AppState> {
 }
 
 #[derive(Debug, Deserialize)]
-struct FileQuery {
+pub(crate) struct FileQuery {
     path: String,
     #[serde(default)]
     mode: Option<u32>,
 }
 
-async fn put_file(
+#[utoipa::path(
+    put,
+    path = "/v1/sandboxes/{id}/files",
+    operation_id = "putFile",
+    tag = "Files",
+    params(
+        ("id" = String, Path, description = "Exact 12-char hex sandbox id"),
+        ("path" = String, Query, description = "Absolute guest path"),
+        ("mode" = Option<u32>, Query, description = "Decimal file mode (default 420 = 0644)")
+    ),
+    request_body(content = Vec<u8>, content_type = "application/octet-stream", description = "Raw file bytes"),
+    responses(
+        (status = 204, description = "Written"),
+        (status = 400, description = "Invalid path or mode"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant"),
+        (status = 413, description = "Body over 32 MiB")
+    )
+)]
+pub(crate) async fn put_file(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -44,7 +63,23 @@ async fn put_file(
     Ok(StatusCode::NO_CONTENT)
 }
 
-async fn get_file(
+#[utoipa::path(
+    get,
+    path = "/v1/sandboxes/{id}/files",
+    operation_id = "getFile",
+    tag = "Files",
+    params(
+        ("id" = String, Path, description = "Exact 12-char hex sandbox id"),
+        ("path" = String, Query, description = "Absolute guest path")
+    ),
+    responses(
+        (status = 200, description = "File bytes", content_type = "application/octet-stream", body = Vec<u8>),
+        (status = 400, description = "Invalid path"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant")
+    )
+)]
+pub(crate) async fn get_file(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,

--- a/crates/bux-serve/src/files.rs
+++ b/crates/bux-serve/src/files.rs
@@ -1,0 +1,303 @@
+//! `PUT`/`GET /v1/sandboxes/{id}/files?path=` — single file, absolute guest path.
+
+use axum::Router;
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use serde::Deserialize;
+
+use crate::auth::Tenant;
+use crate::error::{ApiError, QueryBody};
+use crate::sandboxes::load_owned;
+use crate::state::AppState;
+
+const DEFAULT_FILE_MODE: u32 = 0o644;
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new().route("/v1/sandboxes/{id}/files", get(get_file).put(put_file))
+}
+
+#[derive(Debug, Deserialize)]
+struct FileQuery {
+    path: String,
+    #[serde(default)]
+    mode: Option<u32>,
+}
+
+async fn put_file(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+    QueryBody(query): QueryBody<FileQuery>,
+    body: Bytes,
+) -> Result<StatusCode, ApiError> {
+    validate_guest_path(&query.path)?;
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let mode = query.mode.unwrap_or(DEFAULT_FILE_MODE);
+    vm.write_file(&query.path, &body, mode)
+        .await
+        .map_err(ApiError::from_engine)?;
+    vm.touch_activity().map_err(ApiError::from_engine)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn get_file(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+    QueryBody(query): QueryBody<FileQuery>,
+) -> Result<Vec<u8>, ApiError> {
+    validate_guest_path(&query.path)?;
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let data = vm
+        .read_file(&query.path)
+        .await
+        .map_err(ApiError::from_engine)?;
+    vm.touch_activity().map_err(ApiError::from_engine)?;
+    Ok(data)
+}
+
+fn validate_guest_path(path: &str) -> Result<(), ApiError> {
+    if path.starts_with('/') && !path.contains("..") {
+        Ok(())
+    } else {
+        Err(
+            ApiError::invalid_config("path must be an absolute guest path without ..")
+                .with_field("path"),
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use crate::ApiKey;
+    use crate::router::{MAX_FILE_BODY_BYTES, MAX_JSON_BODY_BYTES, router};
+    use crate::state::Limits;
+
+    fn test_app() -> (tempfile::TempDir, Router) {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let app = router(AppState::new(
+            vec![ApiKey::new("tenant1", "secret1").unwrap()],
+            runtime,
+            Limits::default(),
+        ));
+        (dir, app)
+    }
+
+    async fn json_body(res: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        token: Option<&str>,
+        body: Body,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    fn error_code(v: &serde_json::Value) -> Option<&str> {
+        v.pointer("/error/code").and_then(serde_json::Value::as_str)
+    }
+
+    #[test]
+    fn guest_path_must_be_absolute_without_dotdot() {
+        assert!(validate_guest_path("/workspace/x").is_ok(), "ok");
+        assert!(validate_guest_path("/").is_ok(), "root");
+        assert!(validate_guest_path("relative").is_err(), "relative");
+        assert!(validate_guest_path("").is_err(), "empty");
+        assert!(validate_guest_path("/foo/../bar").is_err(), "dotdot");
+        assert!(validate_guest_path("/foo/..").is_err(), "trailing");
+        assert!(validate_guest_path("..").is_err(), "only dotdot");
+    }
+
+    #[tokio::test]
+    async fn files_without_bearer_is_401() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/files?path=/x",
+            None,
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+    }
+
+    #[tokio::test]
+    async fn files_missing_path_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/files",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "missing path");
+    }
+
+    #[tokio::test]
+    async fn files_relative_path_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "PUT",
+            "/v1/sandboxes/0123456789ab/files?path=tmp/x",
+            Some("secret1"),
+            Body::from("hi"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "relative");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("invalid_config"), "code");
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("path"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn files_dotdot_path_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/files?path=/foo/../bar",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "dotdot");
+    }
+
+    #[tokio::test]
+    async fn files_missing_sandbox_is_404() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/files?path=/workspace/x",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "missing");
+    }
+
+    #[tokio::test]
+    async fn files_put_missing_sandbox_is_404() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "PUT",
+            "/v1/sandboxes/0123456789ab/files?path=/workspace/x&mode=420",
+            Some("secret1"),
+            Body::from("hello"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "put missing");
+    }
+
+    #[tokio::test]
+    async fn files_invalid_mode_is_400() {
+        let (_dir, app) = test_app();
+        let res = send(
+            app,
+            "PUT",
+            "/v1/sandboxes/0123456789ab/files?path=/x&mode=abc",
+            Some("secret1"),
+            Body::from("x"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "mode");
+    }
+
+    #[tokio::test]
+    async fn files_over_json_limit_is_not_413() {
+        let (_dir, app) = test_app();
+        let len = MAX_JSON_BODY_BYTES.saturating_add(1);
+        let res = send(
+            app,
+            "PUT",
+            "/v1/sandboxes/0123456789ab/files?path=/x",
+            Some("secret1"),
+            Body::from(vec![0_u8; len]),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "files allow >1MiB");
+    }
+
+    #[tokio::test]
+    async fn files_over_axum_default_2mib_is_not_413() {
+        let (_dir, app) = test_app();
+        let len = (2_usize * 1024 * 1024).saturating_add(1);
+        assert!(len < MAX_FILE_BODY_BYTES, "under files cap");
+        let res = send(
+            app,
+            "PUT",
+            "/v1/sandboxes/0123456789ab/files?path=/x",
+            Some("secret1"),
+            Body::from(vec![0_u8; len]),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "files allow >2MiB");
+    }
+
+    #[tokio::test]
+    async fn files_over_32mib_is_413() {
+        let (_dir, app) = test_app();
+        let len = MAX_FILE_BODY_BYTES.saturating_add(1);
+        let res = send(
+            app,
+            "PUT",
+            "/v1/sandboxes/0123456789ab/files?path=/x",
+            Some("secret1"),
+            Body::from(vec![0_u8; len]),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE, "32MiB");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("payload_too_large"),
+            "code"
+        );
+    }
+
+    #[test]
+    fn production_touches_activity_and_rejects_dotdot() {
+        let prod = include_str!("files.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(prod.contains("touch_activity"), "idle clock");
+        assert!(prod.contains("write_file"), "PUT");
+        assert!(prod.contains("read_file"), "GET");
+        assert!(prod.contains("validate_guest_path"), "path check");
+        assert!(prod.contains("0o644"), "default mode");
+        assert!(prod.contains("contains(\"..\")"), "reject ..");
+    }
+}

--- a/crates/bux-serve/src/ids.rs
+++ b/crates/bux-serve/src/ids.rs
@@ -1,0 +1,132 @@
+//! Tenant and agent identifiers.
+//!
+//! `-` is the separator in formatted names and is not in the id alphabet.
+//! That keeps [`sandbox_name`] and [`workspace_volume_name`] injective.
+
+const TENANT_LEN: std::ops::RangeInclusive<usize> = 1..=32;
+const AGENT_LEN: std::ops::RangeInclusive<usize> = 1..=64;
+
+/// Invalid tenant or agent identifier.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum IdError {
+    /// `tenant_id` failed the alphabet or length check.
+    #[error("invalid tenant_id {0:?}: ids are [A-Za-z0-9._], tenant 1..=32, agent 1..=64")]
+    Tenant(String),
+    /// `agent_id` failed the alphabet or length check.
+    #[error("invalid agent_id {0:?}: ids are [A-Za-z0-9._], tenant 1..=32, agent 1..=64")]
+    Agent(String),
+}
+
+const fn is_id_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '.' || c == '_'
+}
+
+fn id_ok(id: &str, len: std::ops::RangeInclusive<usize>) -> bool {
+    len.contains(&id.len()) && id.chars().all(is_id_char)
+}
+
+/// Check a tenant id (`[A-Za-z0-9._]`, 1..=32).
+///
+/// # Errors
+///
+/// Returns [`IdError::Tenant`] when the id is empty, too long, or contains a
+/// character outside the alphabet (including `-`).
+pub fn validate_tenant_id(id: &str) -> Result<(), IdError> {
+    if id_ok(id, TENANT_LEN) {
+        Ok(())
+    } else {
+        Err(IdError::Tenant(id.to_owned()))
+    }
+}
+
+/// Check an agent id (`[A-Za-z0-9._]`, 1..=64).
+///
+/// # Errors
+///
+/// Returns [`IdError::Agent`] when the id is empty, too long, or contains a
+/// character outside the alphabet (including `-`).
+pub fn validate_agent_id(id: &str) -> Result<(), IdError> {
+    if id_ok(id, AGENT_LEN) {
+        Ok(())
+    } else {
+        Err(IdError::Agent(id.to_owned()))
+    }
+}
+
+/// VM name `a-{tenant_id}-{agent_id}`.
+///
+/// # Errors
+///
+/// Returns [`IdError`] if either id fails validation. Validation runs before
+/// formatting so a hyphen in an id cannot collide with the separator.
+pub fn sandbox_name(tenant_id: &str, agent_id: &str) -> Result<String, IdError> {
+    validate_tenant_id(tenant_id)?;
+    validate_agent_id(agent_id)?;
+    Ok(format!("a-{tenant_id}-{agent_id}"))
+}
+
+/// Volume name `ws-{tenant_id}-{agent_id}`.
+///
+/// # Errors
+///
+/// Returns [`IdError`] if either id fails validation. Validation runs before
+/// formatting so a hyphen in an id cannot collide with the separator.
+pub fn workspace_volume_name(tenant_id: &str, agent_id: &str) -> Result<String, IdError> {
+    validate_tenant_id(tenant_id)?;
+    validate_agent_id(agent_id)?;
+    Ok(format!("ws-{tenant_id}-{agent_id}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sandbox_name_is_injective_across_hyphen_boundary() {
+        assert_ne!(
+            sandbox_name("x", "yz").unwrap(),
+            sandbox_name("xy", "z").unwrap(),
+            "a-x-yz vs a-xy-z"
+        );
+        assert_ne!(
+            workspace_volume_name("x", "yz").unwrap(),
+            workspace_volume_name("xy", "z").unwrap(),
+            "ws-x-yz vs ws-xy-z"
+        );
+        assert!(sandbox_name("x-y", "z").is_err(), "hyphen in tenant");
+        assert!(sandbox_name("x", "y-z").is_err(), "hyphen in agent");
+        assert!(sandbox_name("x", "y:z").is_err(), "colon in agent");
+    }
+
+    #[test]
+    fn formatted_names() {
+        assert_eq!(sandbox_name("t", "a").unwrap(), "a-t-a", "sandbox");
+        assert_eq!(workspace_volume_name("t", "a").unwrap(), "ws-t-a", "volume");
+    }
+
+    #[test]
+    fn tenant_length_bounds() {
+        let ok32 = "a".repeat(32);
+        let bad33 = "a".repeat(33);
+        assert!(validate_tenant_id(&ok32).is_ok(), "32");
+        assert!(validate_tenant_id(&bad33).is_err(), "33");
+        assert!(validate_tenant_id("").is_err(), "empty");
+    }
+
+    #[test]
+    fn agent_length_bounds() {
+        let ok64 = "a".repeat(64);
+        let bad65 = "a".repeat(65);
+        assert!(validate_agent_id(&ok64).is_ok(), "64");
+        assert!(validate_agent_id(&bad65).is_err(), "65");
+    }
+
+    #[test]
+    fn dot_and_underscore_allowed() {
+        assert!(
+            sandbox_name("t.id_1", "ag.nt_2").is_ok(),
+            "dot and underscore"
+        );
+    }
+}

--- a/crates/bux-serve/src/ids.rs
+++ b/crates/bux-serve/src/ids.rs
@@ -10,10 +10,14 @@ const AGENT_LEN: std::ops::RangeInclusive<usize> = 1..=64;
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum IdError {
     /// `tenant_id` failed the alphabet or length check.
-    #[error("invalid tenant_id {0:?}: ids are [A-Za-z0-9._], tenant 1..=32, agent 1..=64")]
+    #[error(
+        "invalid tenant_id {0:?}: ids are [A-Za-z0-9._], tenant 1..=32, agent 1..=64, no \"..\""
+    )]
     Tenant(String),
     /// `agent_id` failed the alphabet or length check.
-    #[error("invalid agent_id {0:?}: ids are [A-Za-z0-9._], tenant 1..=32, agent 1..=64")]
+    #[error(
+        "invalid agent_id {0:?}: ids are [A-Za-z0-9._], tenant 1..=32, agent 1..=64, no \"..\""
+    )]
     Agent(String),
 }
 
@@ -22,15 +26,15 @@ const fn is_id_char(c: char) -> bool {
 }
 
 fn id_ok(id: &str, len: std::ops::RangeInclusive<usize>) -> bool {
-    len.contains(&id.len()) && id.chars().all(is_id_char)
+    len.contains(&id.len()) && id.chars().all(is_id_char) && !id.contains("..")
 }
 
 /// Check a tenant id (`[A-Za-z0-9._]`, 1..=32).
 ///
 /// # Errors
 ///
-/// Returns [`IdError::Tenant`] when the id is empty, too long, or contains a
-/// character outside the alphabet (including `-`).
+/// Returns [`IdError::Tenant`] when the id is empty, too long, contains `..`,
+/// or a character outside the alphabet (including `-`).
 pub fn validate_tenant_id(id: &str) -> Result<(), IdError> {
     if id_ok(id, TENANT_LEN) {
         Ok(())
@@ -43,8 +47,8 @@ pub fn validate_tenant_id(id: &str) -> Result<(), IdError> {
 ///
 /// # Errors
 ///
-/// Returns [`IdError::Agent`] when the id is empty, too long, or contains a
-/// character outside the alphabet (including `-`).
+/// Returns [`IdError::Agent`] when the id is empty, too long, contains `..`,
+/// or a character outside the alphabet (including `-`).
 pub fn validate_agent_id(id: &str) -> Result<(), IdError> {
     if id_ok(id, AGENT_LEN) {
         Ok(())
@@ -97,6 +101,29 @@ mod tests {
         assert!(sandbox_name("x-y", "z").is_err(), "hyphen in tenant");
         assert!(sandbox_name("x", "y-z").is_err(), "hyphen in agent");
         assert!(sandbox_name("x", "y:z").is_err(), "colon in agent");
+        assert!(
+            workspace_volume_name("x-y", "z").is_err(),
+            "hyphen in tenant volume"
+        );
+        assert!(
+            workspace_volume_name("x", "y-z").is_err(),
+            "hyphen in agent volume"
+        );
+        assert!(
+            workspace_volume_name("x", "y:z").is_err(),
+            "colon in agent volume"
+        );
+    }
+
+    #[test]
+    fn consecutive_dots_rejected() {
+        assert!(
+            workspace_volume_name("a..b", "x").is_err(),
+            "dot-dot tenant"
+        );
+        assert!(sandbox_name("t", "a..b").is_err(), "dot-dot agent");
+        assert!(validate_tenant_id("..").is_err(), "dot-dot only");
+        assert!(sandbox_name("a.b", "x").is_ok(), "single dots allowed");
     }
 
     #[test]

--- a/crates/bux-serve/src/images.rs
+++ b/crates/bux-serve/src/images.rs
@@ -1,0 +1,402 @@
+//! Worker-global image pull / list / delete. Serve uses [`bux::Runtime`], not `bux-oci`.
+
+use std::time::Duration;
+
+use axum::Json;
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use bux::ImageInfo;
+use serde::Deserialize;
+
+use crate::error::{ApiError, JsonBody, QueryBody};
+use crate::state::AppState;
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/v1/images", get(list_images).delete(delete_image))
+        .route("/v1/images/pull", post(pull_image))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PullRequest {
+    reference: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ReferenceQuery {
+    reference: String,
+}
+
+async fn list_images(State(state): State<AppState>) -> Result<Json<Vec<ImageInfo>>, ApiError> {
+    let images = state.runtime.images().map_err(ApiError::from_engine)?;
+    Ok(Json(images))
+}
+
+async fn pull_image(
+    State(state): State<AppState>,
+    JsonBody(req): JsonBody<PullRequest>,
+) -> Result<Json<ImageInfo>, ApiError> {
+    let reference = bux::canonical_reference(&req.reference)
+        .map_err(|e| ApiError::invalid_config(e.to_string()))?;
+    admit_disk(&state)?;
+    let compressed = state
+        .runtime
+        .manifest_compressed_bytes(&reference)
+        .await
+        .map_err(ApiError::from_engine)?;
+    if compressed > state.limits.max_pull_bytes {
+        return Err(ApiError::payload_too_large_msg(
+            "image exceeds max-pull-bytes",
+        ));
+    }
+    let pull = state.runtime.pull(&reference, |_| {});
+    match tokio::time::timeout(Duration::from_secs(state.limits.pull_timeout_secs), pull).await {
+        Ok(Ok(info)) => Ok(Json(info)),
+        Ok(Err(err)) => Err(ApiError::from_engine(err)),
+        Err(_) => Err(ApiError::oci("pull timed out")),
+    }
+}
+
+async fn delete_image(
+    State(state): State<AppState>,
+    QueryBody(query): QueryBody<ReferenceQuery>,
+) -> Result<StatusCode, ApiError> {
+    let reference = bux::canonical_reference(&query.reference)
+        .map_err(|e| ApiError::invalid_config(e.to_string()))?;
+    if image_in_use(&state, &reference)? {
+        return Err(ApiError::image_in_use());
+    }
+    state
+        .runtime
+        .remove_image(&reference)
+        .map_err(ApiError::from_engine)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn admit_disk(state: &AppState) -> Result<(), ApiError> {
+    let usage = state
+        .runtime
+        .data_dir_usage()
+        .map_err(|e| ApiError::from_engine(e.into()))?;
+    if usage >= state.limits.max_disk_bytes {
+        return Err(ApiError::resource_exhausted("disk limit reached"));
+    }
+    Ok(())
+}
+
+fn image_in_use(state: &AppState, canonical: &str) -> Result<bool, ApiError> {
+    let infos = state.runtime.list().map_err(ApiError::from_engine)?;
+    for info in infos {
+        let Some(label) = info.image.as_deref() else {
+            continue;
+        };
+        if bux::canonical_reference(label).ok().as_deref() == Some(canonical) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use std::path::Path;
+    use std::time::Duration;
+
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::header::{AUTHORIZATION, CONTENT_TYPE};
+    use axum::http::{Request, StatusCode};
+    use rusqlite::params;
+    use tower::ServiceExt;
+
+    use crate::ApiKey;
+    use crate::router::router;
+    use crate::state::Limits;
+
+    struct Harness {
+        dir: tempfile::TempDir,
+        app: Router,
+    }
+
+    fn harness(limits: Limits) -> Harness {
+        let dir = tempfile::tempdir().unwrap();
+        let opened = bux::Runtime::open(dir.path()).unwrap();
+        let state = AppState::new(
+            vec![
+                ApiKey::new("tenant1", "secret1").unwrap(),
+                ApiKey::new("tenant2", "secret2").unwrap(),
+            ],
+            opened,
+            limits,
+        );
+        let app = router(state);
+        Harness { dir, app }
+    }
+
+    async fn json_body(res: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        if bytes.is_empty() {
+            return serde_json::Value::Null;
+        }
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        token: Option<&str>,
+        body: Body,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        if method == "POST" {
+            builder = builder.header(CONTENT_TYPE, "application/json");
+        }
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    fn error_code(v: &serde_json::Value) -> Option<&str> {
+        v.pointer("/error/code").and_then(serde_json::Value::as_str)
+    }
+
+    fn plant_vm(data_dir: &Path, id: &str, image: Option<&str>, tenant: &str) {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        drop(child.wait());
+        let socket = data_dir.join("socks").join(format!("{id}.sock"));
+        let conn = rusqlite::Connection::open(data_dir.join("bux.db")).unwrap();
+        conn.busy_timeout(Duration::from_secs(5)).unwrap();
+        let config = serde_json::json!({
+            "vcpus": 1,
+            "ram_mib": 512,
+            "tenant_id": tenant,
+            "agent_id": "a1",
+        });
+        conn.execute(
+            "INSERT INTO vms (id, name, pid, image, socket, status, config, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, 'stopped', ?6, 0)",
+            params![
+                id,
+                format!("a-{tenant}-a1"),
+                pid,
+                image,
+                socket.to_str().expect("utf-8"),
+                config.to_string(),
+            ],
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn images_without_bearer_is_401() {
+        let h = harness(Limits::default());
+        let res = send(h.app, "GET", "/v1/images", None, Body::empty()).await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+    }
+
+    #[tokio::test]
+    async fn list_images_is_worker_global_empty() {
+        let h = harness(Limits::default());
+        let a = send(
+            h.app.clone(),
+            "GET",
+            "/v1/images",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        let b = send(h.app, "GET", "/v1/images", Some("secret2"), Body::empty()).await;
+        assert_eq!(a.status(), StatusCode::OK, "t1");
+        assert_eq!(b.status(), StatusCode::OK, "t2");
+        assert_eq!(json_body(a).await, serde_json::json!([]), "t1 list");
+        assert_eq!(json_body(b).await, serde_json::json!([]), "t2 list");
+    }
+
+    #[tokio::test]
+    async fn pull_invalid_reference_is_400() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/images/pull",
+            Some("secret1"),
+            Body::from(r#"{"reference":"not a ref"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "invalid");
+    }
+
+    #[tokio::test]
+    async fn pull_missing_reference_is_400() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/images/pull",
+            Some("secret1"),
+            Body::from("{}"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "missing");
+    }
+
+    #[tokio::test]
+    async fn pull_unknown_field_is_400() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/images/pull",
+            Some("secret1"),
+            Body::from(r#"{"reference":"alpine","extra":1}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "unknown");
+    }
+
+    #[tokio::test]
+    async fn pull_disk_cap_is_429() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let disk = runtime.disk_usage().unwrap();
+        let data = runtime.data_dir_usage().unwrap();
+        assert!(data > disk, "data_dir_usage exceeds disk_usage");
+        let cap = disk.saturating_add(1);
+        assert!(cap <= data, "cap in (disk_usage, data_dir_usage]");
+        let app = router(AppState::new(
+            vec![ApiKey::new("tenant1", "secret1").unwrap()],
+            runtime,
+            Limits {
+                max_disk_bytes: cap,
+                ..Limits::default()
+            },
+        ));
+        let res = send(
+            app,
+            "POST",
+            "/v1/images/pull",
+            Some("secret1"),
+            Body::from(r#"{"reference":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "disk");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("resource_exhausted"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_missing_reference_query_is_400() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "DELETE",
+            "/v1/images",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "no query");
+    }
+
+    #[tokio::test]
+    async fn delete_invalid_reference_is_400() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "DELETE",
+            "/v1/images?reference=not%20a%20ref",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "invalid");
+    }
+
+    #[tokio::test]
+    async fn delete_missing_image_is_404() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "DELETE",
+            "/v1/images?reference=alpine",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "missing");
+        assert_eq!(error_code(&json_body(res).await), Some("not_found"), "code");
+    }
+
+    #[tokio::test]
+    async fn delete_in_use_is_409() {
+        let h = harness(Limits::default());
+        plant_vm(h.dir.path(), "abc123aaa010", Some("python:slim"), "tenant2");
+        let res = send(
+            h.app,
+            "DELETE",
+            "/v1/images?reference=docker.io/library/python:slim",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "in use");
+        assert_eq!(error_code(&json_body(res).await), Some("busy"), "code");
+    }
+
+    #[tokio::test]
+    async fn delete_unparsable_vm_label_is_not_in_use() {
+        let h = harness(Limits::default());
+        plant_vm(h.dir.path(), "abc123aaa011", Some("not a ref"), "tenant1");
+        let res = send(
+            h.app,
+            "DELETE",
+            "/v1/images?reference=alpine",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "skip unparsable");
+    }
+
+    #[test]
+    fn production_uses_runtime_preflight_not_second_oci() {
+        let prod = include_str!("images.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(prod.contains("canonical_reference"), "parse");
+        assert!(prod.contains("manifest_compressed_bytes"), "pull byte cap");
+        assert!(prod.contains("data_dir_usage"), "disk cap");
+        assert!(prod.contains("remove_image"), "delete");
+        assert!(prod.contains(".pull("), "Runtime::pull");
+        let pull_fn = prod
+            .split("async fn pull_image(")
+            .nth(1)
+            .and_then(|rest| rest.split("\nasync fn ").next())
+            .expect("pull_image");
+        let disk = pull_fn.find("admit_disk").expect("disk");
+        let manifest = pull_fn.find("manifest_compressed_bytes").expect("manifest");
+        let pull = pull_fn.find(".pull(").expect("pull");
+        assert!(disk < manifest, "disk cap before manifest");
+        assert!(manifest < pull, "manifest cap before pull");
+        assert!(!prod.contains("Oci::open"), "no second OCI handle");
+        assert!(!prod.contains("open_at"), "no Oci::open_at");
+        assert!(
+            !prod.contains("bux_oci"),
+            "serve depends on bux only, not bux-oci"
+        );
+    }
+}

--- a/crates/bux-serve/src/images.rs
+++ b/crates/bux-serve/src/images.rs
@@ -8,7 +8,8 @@ use axum::extract::State;
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use bux::ImageInfo;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::error::{ApiError, JsonBody, QueryBody};
 use crate::state::AppState;
@@ -19,32 +20,75 @@ pub(crate) fn routes() -> Router<AppState> {
         .route("/v1/images/pull", post(pull_image))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct PullRequest {
+pub(crate) struct PullRequest {
     reference: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct ImageInfoBody {
+    reference: String,
+    digest: String,
+    size: u64,
+}
+
+impl From<ImageInfo> for ImageInfoBody {
+    fn from(info: ImageInfo) -> Self {
+        Self {
+            reference: info.reference,
+            digest: info.digest,
+            size: info.size,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
-struct ReferenceQuery {
+pub(crate) struct ReferenceQuery {
     reference: String,
 }
 
-async fn list_images(State(state): State<AppState>) -> Result<Json<Vec<ImageInfo>>, ApiError> {
+#[utoipa::path(
+    get,
+    path = "/v1/images",
+    operation_id = "listImages",
+    tag = "Images",
+    responses(
+        (status = 200, description = "Cached images (worker-global)", body = [ImageInfoBody]),
+        (status = 401, description = "Missing or invalid Bearer token")
+    )
+)]
+pub(crate) async fn list_images(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<ImageInfoBody>>, ApiError> {
     let images = state.runtime.images().map_err(ApiError::from_engine)?;
-    Ok(Json(images))
+    Ok(Json(images.into_iter().map(ImageInfoBody::from).collect()))
 }
 
-async fn pull_image(
+#[utoipa::path(
+    post,
+    path = "/v1/images/pull",
+    operation_id = "pullImage",
+    tag = "Images",
+    request_body = PullRequest,
+    responses(
+        (status = 200, description = "Pulled", body = ImageInfoBody),
+        (status = 400, description = "Invalid reference"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 413, description = "Manifest compressed size over max-pull-bytes"),
+        (status = 429, description = "Disk cap")
+    )
+)]
+pub(crate) async fn pull_image(
     State(state): State<AppState>,
     JsonBody(req): JsonBody<PullRequest>,
-) -> Result<Json<ImageInfo>, ApiError> {
+) -> Result<Json<ImageInfoBody>, ApiError> {
     let reference = bux::canonical_reference(&req.reference)
         .map_err(|e| ApiError::invalid_config(e.to_string()))?;
     admit_disk(&state)?;
     let deadline = Duration::from_secs(state.limits.pull_timeout_secs);
     match tokio::time::timeout(deadline, pull_from_registry(&state, &reference)).await {
-        Ok(Ok(info)) => Ok(Json(info)),
+        Ok(Ok(info)) => Ok(Json(ImageInfoBody::from(info))),
         Ok(Err(err)) => Err(err),
         Err(_) => Err(ApiError::oci("pull timed out")),
     }
@@ -68,7 +112,21 @@ async fn pull_from_registry(state: &AppState, reference: &str) -> Result<ImageIn
         .map_err(ApiError::from_engine)
 }
 
-async fn delete_image(
+#[utoipa::path(
+    delete,
+    path = "/v1/images",
+    operation_id = "deleteImage",
+    tag = "Images",
+    params(("reference" = String, Query, description = "OCI reference")),
+    responses(
+        (status = 204, description = "Index entry removed"),
+        (status = 400, description = "Invalid reference"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Not in store"),
+        (status = 409, description = "Image is in use")
+    )
+)]
+pub(crate) async fn delete_image(
     State(state): State<AppState>,
     QueryBody(query): QueryBody<ReferenceQuery>,
 ) -> Result<StatusCode, ApiError> {

--- a/crates/bux-serve/src/images.rs
+++ b/crates/bux-serve/src/images.rs
@@ -42,9 +42,18 @@ async fn pull_image(
     let reference = bux::canonical_reference(&req.reference)
         .map_err(|e| ApiError::invalid_config(e.to_string()))?;
     admit_disk(&state)?;
+    let deadline = Duration::from_secs(state.limits.pull_timeout_secs);
+    match tokio::time::timeout(deadline, pull_from_registry(&state, &reference)).await {
+        Ok(Ok(info)) => Ok(Json(info)),
+        Ok(Err(err)) => Err(err),
+        Err(_) => Err(ApiError::oci("pull timed out")),
+    }
+}
+
+async fn pull_from_registry(state: &AppState, reference: &str) -> Result<ImageInfo, ApiError> {
     let compressed = state
         .runtime
-        .manifest_compressed_bytes(&reference)
+        .manifest_compressed_bytes(reference)
         .await
         .map_err(ApiError::from_engine)?;
     if compressed > state.limits.max_pull_bytes {
@@ -52,12 +61,11 @@ async fn pull_image(
             "image exceeds max-pull-bytes",
         ));
     }
-    let pull = state.runtime.pull(&reference, |_| {});
-    match tokio::time::timeout(Duration::from_secs(state.limits.pull_timeout_secs), pull).await {
-        Ok(Ok(info)) => Ok(Json(info)),
-        Ok(Err(err)) => Err(ApiError::from_engine(err)),
-        Err(_) => Err(ApiError::oci("pull timed out")),
-    }
+    state
+        .runtime
+        .pull(reference, |_| {})
+        .await
+        .map_err(ApiError::from_engine)
 }
 
 async fn delete_image(
@@ -281,14 +289,18 @@ mod tests {
                 ..Limits::default()
             },
         ));
-        let res = send(
-            app,
-            "POST",
-            "/v1/images/pull",
-            Some("secret1"),
-            Body::from(r#"{"reference":"alpine"}"#),
+        let res = tokio::time::timeout(
+            Duration::from_secs(2),
+            send(
+                app,
+                "POST",
+                "/v1/images/pull",
+                Some("secret1"),
+                Body::from(r#"{"reference":"127.0.0.1:1/bux-no-registry:test"}"#),
+            ),
         )
-        .await;
+        .await
+        .expect("disk admission must return without registry I/O");
         assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "disk");
         assert_eq!(
             error_code(&json_body(res).await),
@@ -388,9 +400,19 @@ mod tests {
             .and_then(|rest| rest.split("\nasync fn ").next())
             .expect("pull_image");
         let disk = pull_fn.find("admit_disk").expect("disk");
-        let manifest = pull_fn.find("manifest_compressed_bytes").expect("manifest");
-        let pull = pull_fn.find(".pull(").expect("pull");
-        assert!(disk < manifest, "disk cap before manifest");
+        let timeout = pull_fn.find("tokio::time::timeout").expect("deadline");
+        let registry = pull_fn.find("pull_from_registry").expect("registry work");
+        assert!(disk < timeout, "disk cap before registry deadline");
+        assert!(timeout < registry, "deadline wraps registry work");
+        let admitted = prod
+            .split("async fn pull_from_registry(")
+            .nth(1)
+            .and_then(|rest| rest.split("\nasync fn ").next())
+            .expect("pull_from_registry");
+        let manifest = admitted
+            .find("manifest_compressed_bytes")
+            .expect("manifest");
+        let pull = admitted.find(".pull(").expect("pull");
         assert!(manifest < pull, "manifest cap before pull");
         assert!(!prod.contains("Oci::open"), "no second OCI handle");
         assert!(!prod.contains("open_at"), "no Oci::open_at");

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -1,0 +1,350 @@
+//! HTTP worker for hosted bux sandboxes.
+//!
+//! `bux serve start` binds a TCP loopback address and serves `/v1/health`
+//! (public) plus Bearer-protected routes. At least one API key is required
+//! to start. Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is only a
+//! separator in formatted sandbox and volume names.
+
+#![allow(
+    clippy::missing_docs_in_private_items,
+    reason = "internal fields are named for their role"
+)]
+
+mod error;
+mod ids;
+mod router;
+
+use std::fmt;
+use std::net::SocketAddr;
+use std::path::Path;
+
+pub use error::{Error, Result};
+pub use ids::{
+    IdError, sandbox_name, validate_agent_id, validate_tenant_id, workspace_volume_name,
+};
+
+use router::AppState;
+
+/// Bearer credential. `id` is the tenant id.
+#[derive(Clone)]
+pub struct ApiKey {
+    id: String,
+    secret: String,
+}
+
+impl fmt::Debug for ApiKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApiKey")
+            .field("id", &self.id)
+            .field("secret", &"<redacted>")
+            .finish()
+    }
+}
+
+impl ApiKey {
+    /// Construct a key. `id` uses the tenant alphabet.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidId`] when `id` fails tenant validation, or
+    /// [`Error::EmptyApiKeySecret`] when `secret` is empty.
+    pub fn new(id: impl AsRef<str>, secret: impl Into<String>) -> Result<Self> {
+        let id = id.as_ref();
+        validate_tenant_id(id)?;
+        let secret = secret.into();
+        if secret.is_empty() {
+            return Err(Error::EmptyApiKeySecret(id.to_owned()));
+        }
+        Ok(Self {
+            id: id.to_owned(),
+            secret,
+        })
+    }
+
+    /// Tenant id for this key.
+    #[must_use]
+    pub const fn id(&self) -> &str {
+        self.id.as_str()
+    }
+
+    const fn secret_bytes(&self) -> &[u8] {
+        self.secret.as_bytes()
+    }
+}
+
+/// TCP bind address and loaded API keys.
+#[derive(Debug)]
+pub struct ServeConfig {
+    listen: SocketAddr,
+    keys: Vec<ApiKey>,
+}
+
+impl ServeConfig {
+    /// Loopback `IP:PORT` and at least one API key.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`], or
+    /// [`Error::NonLoopback`].
+    pub fn new(listen: &str, keys: Vec<ApiKey>) -> Result<Self> {
+        if keys.is_empty() {
+            return Err(Error::NoApiKeys);
+        }
+        let listen: SocketAddr = listen
+            .parse()
+            .map_err(|_| Error::InvalidListen(listen.to_owned()))?;
+        if !listen.ip().is_loopback() {
+            return Err(Error::NonLoopback(listen));
+        }
+        Ok(Self { listen, keys })
+    }
+}
+
+/// Load keys from CLI `id:secret` specs, an `id=secret` file, and comma-separated env specs.
+///
+/// # Errors
+///
+/// Returns [`Error`] if a spec is malformed, an id is invalid, ids collide, or
+/// the file cannot be read.
+pub fn load_api_keys(
+    cli_keys: &[String],
+    key_file: Option<&Path>,
+    env_keys: Option<&str>,
+) -> Result<Vec<ApiKey>> {
+    let mut keys = Vec::new();
+    if let Some(path) = key_file {
+        load_key_file(path, &mut keys)?;
+    }
+    if let Some(env_keys) = env_keys {
+        for spec in env_keys.split(',') {
+            if spec.is_empty() {
+                continue;
+            }
+            push_colon_spec(&mut keys, spec)?;
+        }
+    }
+    for spec in cli_keys {
+        push_colon_spec(&mut keys, spec)?;
+    }
+    Ok(keys)
+}
+
+fn push_colon_spec(keys: &mut Vec<ApiKey>, spec: &str) -> Result<()> {
+    let Some((id, secret)) = spec.split_once(':') else {
+        return Err(Error::ApiKeyMissingSeparator);
+    };
+    push_key(keys, id, secret)
+}
+
+fn push_key(keys: &mut Vec<ApiKey>, id: &str, secret: &str) -> Result<()> {
+    let key = ApiKey::new(id, secret)?;
+    if keys.iter().any(|existing| existing.id == key.id) {
+        return Err(Error::DuplicateApiKeyId(key.id));
+    }
+    keys.push(key);
+    Ok(())
+}
+
+fn load_key_file(path: &Path, keys: &mut Vec<ApiKey>) -> Result<()> {
+    #[cfg(unix)]
+    warn_if_world_readable(path);
+    let text = std::fs::read_to_string(path)?;
+    for (i, raw) in text.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((id, secret)) = line.split_once('=') else {
+            return Err(Error::ApiKeyFileSyntax {
+                path: path.display().to_string(),
+                line: i + 1,
+            });
+        };
+        push_key(keys, id.trim(), secret)?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn warn_if_world_readable(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::metadata(path) {
+        let mode = meta.permissions().mode();
+        if mode & 0o077 != 0 {
+            tracing::warn!(
+                path = %path.display(),
+                "API key file is readable by group or others"
+            );
+        }
+    }
+}
+
+/// Bind `config.listen` and serve until SIGINT / SIGTERM.
+///
+/// Builds a multi-thread tokio runtime. Must not be called from an existing runtime.
+///
+/// # Errors
+///
+/// Returns [`Error::Io`] if the address cannot be bound or the server fails.
+pub fn run(config: ServeConfig) -> Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(serve(config))
+}
+
+async fn serve(config: ServeConfig) -> Result<()> {
+    let listen = config.listen;
+    let listener = tokio::net::TcpListener::bind(listen).await?;
+    tracing::info!(%listen, api_keys = config.keys.len(), "listening");
+    let app = router::router(AppState::new(config.keys));
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::error!(%e, "ctrl_c handler");
+        }
+    };
+    #[cfg(unix)]
+    {
+        let term = async {
+            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+                Ok(mut signal) => {
+                    signal.recv().await;
+                }
+                Err(e) => tracing::error!(%e, "SIGTERM handler"),
+            }
+        };
+        tokio::select! {
+            () = ctrl_c => {}
+            () = term => {}
+        }
+    }
+    #[cfg(not(unix))]
+    ctrl_c.await;
+}
+
+/// OpenAPI 3.1 document for routes this worker currently serves.
+#[must_use]
+pub const fn openapi_json() -> &'static str {
+    OPENAPI_JSON
+}
+
+const OPENAPI_JSON: &str = concat!(
+    "{\n",
+    "  \"openapi\": \"3.1.0\",\n",
+    "  \"info\": {\n",
+    "    \"title\": \"bux\",\n",
+    "    \"version\": \"",
+    env!("CARGO_PKG_VERSION"),
+    "\"\n",
+    "  },\n",
+    "  \"paths\": {\n",
+    "    \"/v1/health\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"health\",\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Worker is up\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/config\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"config\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Worker config\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
+    "        }\n",
+    "      }\n",
+    "    }\n",
+    "  },\n",
+    "  \"components\": {\n",
+    "    \"securitySchemes\": {\n",
+    "      \"bearer\": { \"type\": \"http\", \"scheme\": \"bearer\" }\n",
+    "    }\n",
+    "  }\n",
+    "}"
+);
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn refuses_zero_keys() {
+        let err = ServeConfig::new("127.0.0.1:8080", vec![]).unwrap_err();
+        assert!(matches!(err, Error::NoApiKeys), "{err}");
+        assert_eq!(err.exit_code(), 2, "exit");
+    }
+
+    #[test]
+    fn refuses_non_loopback() {
+        let key = ApiKey::new("t", "s").unwrap();
+        let err = ServeConfig::new("0.0.0.0:8080", vec![key]).unwrap_err();
+        assert!(matches!(err, Error::NonLoopback(_)), "{err}");
+    }
+
+    #[test]
+    fn accepts_loopback() {
+        let key = ApiKey::new("t", "s").unwrap();
+        ServeConfig::new("127.0.0.1:8080", vec![key]).unwrap();
+    }
+
+    #[test]
+    fn api_key_requires_colon() {
+        let err = load_api_keys(&["noseparator".into()], None, None).unwrap_err();
+        assert!(matches!(err, Error::ApiKeyMissingSeparator), "{err}");
+    }
+
+    #[test]
+    fn api_key_id_rejects_hyphen() {
+        let err = load_api_keys(&["foo-bar:secret".into()], None, None).unwrap_err();
+        assert!(matches!(err, Error::InvalidId(_)), "{err}");
+    }
+
+    #[test]
+    fn duplicate_ids() {
+        let err = load_api_keys(&["t:a".into(), "t:b".into()], None, None).unwrap_err();
+        assert!(matches!(err, Error::DuplicateApiKeyId(_)), "{err}");
+    }
+
+    #[test]
+    fn env_keys_comma_separated() {
+        let keys = load_api_keys(&[], None, Some("a:one,b:two")).unwrap();
+        assert_eq!(keys.len(), 2, "count");
+        assert_eq!(keys.first().map(ApiKey::id), Some("a"), "first");
+        assert_eq!(keys.get(1).map(ApiKey::id), Some("b"), "second");
+    }
+
+    #[test]
+    fn key_file_parses_comments_and_blank_lines() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("keys");
+        std::fs::write(&path, "# c\n\nt1=sec1\nt2=sec2\n").unwrap();
+        let keys = load_api_keys(&[], Some(&path), None).unwrap();
+        assert_eq!(keys.len(), 2, "count");
+        assert_eq!(keys.first().map(ApiKey::id), Some("t1"), "t1");
+        assert_eq!(keys.get(1).map(ApiKey::id), Some("t2"), "t2");
+    }
+
+    #[test]
+    fn openapi_is_json_object() {
+        let v: serde_json::Value = serde_json::from_str(openapi_json()).unwrap();
+        assert!(v.get("openapi").is_some(), "openapi field");
+        assert!(
+            v.get("paths").and_then(|p| p.get("/v1/health")).is_some(),
+            "health path"
+        );
+        assert!(
+            v.get("paths").and_then(|p| p.get("/v1/config")).is_some(),
+            "config path"
+        );
+    }
+}

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -194,39 +194,45 @@ pub fn run(config: ServeConfig) -> Result<()> {
 }
 
 async fn serve(config: ServeConfig) -> Result<()> {
+    let shutdown = install_shutdown()?;
     let listen = config.listen;
     let listener = tokio::net::TcpListener::bind(listen).await?;
     tracing::info!(%listen, api_keys = config.keys.len(), "listening");
     let app = router::router(AppState::new(config.keys));
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(shutdown)
         .await?;
     Ok(())
 }
 
-async fn shutdown_signal() {
-    let ctrl_c = async {
-        if let Err(e) = tokio::signal::ctrl_c().await {
-            tracing::error!(%e, "ctrl_c handler");
-        }
-    };
-    #[cfg(unix)]
-    {
-        let term = async {
-            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
-                Ok(mut signal) => {
-                    signal.recv().await;
-                }
-                Err(e) => tracing::error!(%e, "SIGTERM handler"),
-            }
-        };
+/// Install SIGINT/SIGTERM first. A failed install is I/O, not shutdown.
+#[cfg(unix)]
+fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send> {
+    let mut interrupt = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
+    let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
+    Ok(async move {
         tokio::select! {
-            () = ctrl_c => {}
-            () = term => {}
+            () = recv_signal(&mut interrupt) => {}
+            () = recv_signal(&mut terminate) => {}
         }
+    })
+}
+
+/// `None` from `recv` means the stream closed, not that a signal arrived.
+#[cfg(unix)]
+async fn recv_signal(signal: &mut tokio::signal::unix::Signal) {
+    if signal.recv().await.is_none() {
+        std::future::pending::<()>().await;
     }
-    #[cfg(not(unix))]
-    ctrl_c.await;
+}
+
+#[cfg(not(unix))]
+fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send> {
+    Ok(async {
+        if tokio::signal::ctrl_c().await.is_err() {
+            std::future::pending::<()>().await;
+        }
+    })
 }
 
 /// OpenAPI 3.1 document for routes this worker currently serves.

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -1,29 +1,34 @@
 //! HTTP worker for hosted bux sandboxes.
 //!
-//! `bux serve start` binds a TCP loopback address and serves `/v1/health`
-//! (public) plus Bearer-protected routes. At least one API key is required
-//! to start. Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is only a
-//! separator in formatted sandbox and volume names.
+//! `bux serve start` opens one [`bux::Runtime`] (exclusive flock on `BUX_HOME`),
+//! binds a TCP loopback address, and serves `/v1/health` (public) plus
+//! Bearer-protected sandbox CRUD. At least one API key is required to start.
+//! Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is only a separator in
+//! formatted sandbox and volume names.
 
 #![allow(
     clippy::missing_docs_in_private_items,
     reason = "internal fields are named for their role"
 )]
 
+mod auth;
 mod error;
 mod ids;
 mod router;
+mod sandboxes;
+mod state;
 
 use std::fmt;
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use error::{Error, Result};
 pub use ids::{
     IdError, sandbox_name, validate_agent_id, validate_tenant_id, workspace_volume_name,
 };
+pub use state::Limits;
 
-use router::AppState;
+use state::AppState;
 
 /// Bearer credential. `id` is the tenant id.
 #[derive(Clone)]
@@ -67,20 +72,24 @@ impl ApiKey {
         self.id.as_str()
     }
 
-    const fn secret_bytes(&self) -> &[u8] {
+    pub(crate) const fn secret_bytes(&self) -> &[u8] {
         self.secret.as_bytes()
     }
 }
 
-/// TCP bind address and loaded API keys.
+/// TCP bind address, API keys, data dir, and admission limits.
 #[derive(Debug)]
 pub struct ServeConfig {
     listen: SocketAddr,
     keys: Vec<ApiKey>,
+    data_dir: PathBuf,
+    limits: Limits,
 }
 
 impl ServeConfig {
     /// Loopback `IP:PORT` and at least one API key.
+    ///
+    /// Data dir defaults to [`bux::default_data_dir`]; limits to [`Limits::default`].
     ///
     /// # Errors
     ///
@@ -96,7 +105,26 @@ impl ServeConfig {
         if !listen.ip().is_loopback() {
             return Err(Error::NonLoopback(listen));
         }
-        Ok(Self { listen, keys })
+        Ok(Self {
+            listen,
+            keys,
+            data_dir: bux::default_data_dir(),
+            limits: Limits::default(),
+        })
+    }
+
+    /// Runtime data directory (`bux.lock` / `bux.db`). Second process → [`bux::Error::Busy`].
+    #[must_use]
+    pub fn data_dir(mut self, data_dir: impl Into<PathBuf>) -> Self {
+        self.data_dir = data_dir.into();
+        self
+    }
+
+    /// Admission caps applied before `Runtime::create`.
+    #[must_use]
+    pub const fn limits(mut self, limits: Limits) -> Self {
+        self.limits = limits;
+        self
     }
 }
 
@@ -181,11 +209,13 @@ fn warn_if_world_readable(path: &Path) {
 
 /// Bind `config.listen` and serve until SIGINT / SIGTERM.
 ///
+/// Opens [`bux::Runtime`] on `config.data_dir` (exclusive flock) before bind.
 /// Builds a multi-thread tokio runtime. Must not be called from an existing runtime.
 ///
 /// # Errors
 ///
-/// Returns [`Error::Io`] if the address cannot be bound or the server fails.
+/// Returns [`Error::Runtime`] with [`bux::Error::Busy`] if another process holds
+/// the data-dir lock. Returns [`Error::Io`] if the address cannot be bound.
 pub fn run(config: ServeConfig) -> Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -193,12 +223,22 @@ pub fn run(config: ServeConfig) -> Result<()> {
     rt.block_on(serve(config))
 }
 
+fn open_runtime(data_dir: &Path) -> Result<bux::Runtime> {
+    bux::Runtime::open(data_dir).map_err(Error::from)
+}
+
 async fn serve(config: ServeConfig) -> Result<()> {
     let shutdown = install_shutdown()?;
+    let runtime = open_runtime(&config.data_dir)?;
     let listen = config.listen;
     let listener = tokio::net::TcpListener::bind(listen).await?;
-    tracing::info!(%listen, api_keys = config.keys.len(), "listening");
-    let app = router::router(AppState::new(config.keys));
+    tracing::info!(
+        %listen,
+        api_keys = config.keys.len(),
+        data_dir = %config.data_dir.display(),
+        "listening"
+    );
+    let app = router::router(AppState::new(config.keys, runtime, config.limits));
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
         .await?;
@@ -266,6 +306,51 @@ const OPENAPI_JSON: &str = concat!(
     "        \"responses\": {\n",
     "          \"200\": { \"description\": \"Worker config\" },\n",
     "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/sandboxes\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"listSandboxes\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Sandboxes for this tenant\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
+    "        }\n",
+    "      },\n",
+    "      \"post\": {\n",
+    "        \"operationId\": \"createSandbox\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"responses\": {\n",
+    "          \"201\": { \"description\": \"Created\" },\n",
+    "          \"200\": { \"description\": \"Existing sandbox for this tenant and agent\" },\n",
+    "          \"400\": { \"description\": \"Invalid body or per-sandbox admission\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"409\": { \"description\": \"Name occupied\" },\n",
+    "          \"412\": { \"description\": \"No hardware virtualization\" },\n",
+    "          \"429\": { \"description\": \"Count, running RAM, or disk cap\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/sandboxes/{id}\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"getSandbox\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Sandbox\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
+    "        }\n",
+    "      },\n",
+    "      \"delete\": {\n",
+    "        \"operationId\": \"deleteSandbox\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
+    "        \"responses\": {\n",
+    "          \"204\": { \"description\": \"Removed, workspace volume deleted\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
     "        }\n",
     "      }\n",
     "    }\n",
@@ -352,5 +437,23 @@ mod tests {
             v.get("paths").and_then(|p| p.get("/v1/config")).is_some(),
             "config path"
         );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes"))
+                .is_some(),
+            "sandboxes path"
+        );
+    }
+
+    #[test]
+    fn second_runtime_open_on_same_dir_is_busy() {
+        let dir = tempfile::tempdir().unwrap();
+        let _held = bux::Runtime::open(dir.path()).unwrap();
+        let err = open_runtime(dir.path()).unwrap_err();
+        assert!(
+            matches!(err, Error::Runtime(bux::Error::Busy(_))),
+            "exclusive flock: {err}"
+        );
+        assert_eq!(err.exit_code(), 1, "engine Busy is exit 1");
     }
 }

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -625,6 +625,25 @@ mod tests {
                 .is_some(),
             "clone path"
         );
+        let clone_codes = v.pointer("/paths/~1v1~1sandboxes~1{id}~1clone/post/responses");
+        assert!(
+            clone_codes.and_then(|r| r.get("409")).is_some(),
+            "clone 409"
+        );
+        assert!(
+            clone_codes.and_then(|r| r.get("412")).is_some(),
+            "clone 412"
+        );
+        let restore_codes =
+            v.pointer("/paths/~1v1~1sandboxes~1{id}~1snapshots~1{sid}~1restore/post/responses");
+        assert!(
+            restore_codes.and_then(|r| r.get("409")).is_some(),
+            "restore 409"
+        );
+        assert!(
+            restore_codes.and_then(|r| r.get("412")).is_some(),
+            "restore 412"
+        );
     }
 
     #[test]

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -1,11 +1,11 @@
 //! HTTP worker for hosted bux sandboxes.
 //!
 //! `bux serve start` opens one [`bux::Runtime`] (exclusive flock on `BUX_HOME`),
-//! binds a TCP loopback address, and serves `/v1/health` (public) plus
-//! Bearer-protected sandbox CRUD, collect exec, files, and images. At least
-//! one API key is required to start. Identifiers use the alphabet
-//! `[A-Za-z0-9._]`; `-` is only a separator in formatted sandbox and volume
-//! names.
+//! binds TCP (loopback unless `--public`), sweeps idle VMs every 30s, and
+//! serves `/v1/health` (public) plus Bearer-protected `/v1/me`, sandbox
+//! get-or-create, collect exec, files, and images. At least one API key is
+//! required to start. Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is
+//! only a separator in formatted sandbox and volume names.
 
 #![allow(
     clippy::missing_docs_in_private_items,
@@ -25,6 +25,7 @@ mod state;
 use std::fmt;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 pub use error::{Error, Result};
 pub use ids::{
@@ -81,6 +82,9 @@ impl ApiKey {
     }
 }
 
+/// How often the worker calls [`bux::Runtime::sweep`].
+pub(crate) const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
+
 /// TCP bind address, API keys, data dir, and admission limits.
 #[derive(Debug)]
 pub struct ServeConfig {
@@ -88,6 +92,7 @@ pub struct ServeConfig {
     keys: Vec<ApiKey>,
     data_dir: PathBuf,
     limits: Limits,
+    allow_unrestricted_net: bool,
 }
 
 impl ServeConfig {
@@ -100,13 +105,26 @@ impl ServeConfig {
     /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`], or
     /// [`Error::NonLoopback`].
     pub fn new(listen: &str, keys: Vec<ApiKey>) -> Result<Self> {
+        Self::bind(listen, keys, false)
+    }
+
+    /// TCP bind with at least one API key.
+    ///
+    /// `public` is required for a non-loopback address (`--public`). Zero keys
+    /// is always [`Error::NoApiKeys`], including with `public`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`], or
+    /// [`Error::NonLoopback`].
+    pub fn bind(listen: &str, keys: Vec<ApiKey>, public: bool) -> Result<Self> {
         if keys.is_empty() {
             return Err(Error::NoApiKeys);
         }
         let listen: SocketAddr = listen
             .parse()
             .map_err(|_| Error::InvalidListen(listen.to_owned()))?;
-        if !listen.ip().is_loopback() {
+        if !listen.ip().is_loopback() && !public {
             return Err(Error::NonLoopback(listen));
         }
         Ok(Self {
@@ -114,7 +132,16 @@ impl ServeConfig {
             keys,
             data_dir: bux::default_data_dir(),
             limits: Limits::default(),
+            allow_unrestricted_net: false,
         })
+    }
+
+    /// Permit `"unrestricted": true` on create (`NetworkSpec::Enabled` with an
+    /// empty allow-list).
+    #[must_use]
+    pub const fn allow_unrestricted_net(mut self, allow: bool) -> Self {
+        self.allow_unrestricted_net = allow;
+        self
     }
 
     /// Runtime data directory (`bux.lock` / `bux.db`). Second process → [`bux::Error::Busy`].
@@ -240,13 +267,39 @@ async fn serve(config: ServeConfig) -> Result<()> {
         %listen,
         api_keys = config.keys.len(),
         data_dir = %config.data_dir.display(),
+        allow_unrestricted_net = config.allow_unrestricted_net,
         "listening"
     );
-    let app = router::router(AppState::new(config.keys, runtime, config.limits));
-    axum::serve(listener, app)
+    let state = AppState::new(config.keys, runtime, config.limits)
+        .with_unrestricted_net(config.allow_unrestricted_net);
+    let sweep = tokio::spawn(sweep_loop(state.clone()));
+    let app = router::router(state);
+    let result = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown)
-        .await?;
+        .await;
+    sweep.abort();
+    result?;
     Ok(())
+}
+
+async fn sweep_loop(state: AppState) {
+    let mut interval = tokio::time::interval(SWEEP_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    #[allow(
+        clippy::infinite_loop,
+        reason = "aborted when the HTTP server shuts down"
+    )]
+    loop {
+        interval.tick().await;
+        match state.runtime.sweep() {
+            Ok(report) => {
+                if report.stopped > 0 || report.deleted > 0 {
+                    tracing::info!(stopped = report.stopped, deleted = report.deleted, "sweep");
+                }
+            }
+            Err(err) => tracing::warn!(error = %err, "sweep failed"),
+        }
+    }
 }
 
 /// Install SIGINT/SIGTERM first. A failed install is I/O, not shutdown.
@@ -313,6 +366,16 @@ const OPENAPI_JSON: &str = concat!(
     "        }\n",
     "      }\n",
     "    },\n",
+    "    \"/v1/me\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"me\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Bearer tenant_id and max_sandboxes\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
     "    \"/v1/sandboxes\": {\n",
     "      \"get\": {\n",
     "        \"operationId\": \"listSandboxes\",\n",
@@ -355,6 +418,19 @@ const OPENAPI_JSON: &str = concat!(
     "          \"204\": { \"description\": \"Removed, workspace volume deleted\" },\n",
     "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
     "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/sandboxes/{id}/start\": {\n",
+    "      \"post\": {\n",
+    "        \"operationId\": \"startSandbox\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Started\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Missing or other tenant\" },\n",
+    "          \"409\": { \"description\": \"secrets_required or not stopped\" }\n",
     "        }\n",
     "      }\n",
     "    },\n",
@@ -462,15 +538,42 @@ mod tests {
 
     #[test]
     fn refuses_non_loopback() {
-        let key = ApiKey::new("t", "s").unwrap();
-        let err = ServeConfig::new("0.0.0.0:8080", vec![key]).unwrap_err();
+        let err =
+            ServeConfig::new("0.0.0.0:8080", vec![ApiKey::new("t", "s").unwrap()]).unwrap_err();
         assert!(matches!(err, Error::NonLoopback(_)), "{err}");
+        let err = ServeConfig::bind("0.0.0.0:8080", vec![ApiKey::new("t", "s").unwrap()], false)
+            .unwrap_err();
+        assert!(matches!(err, Error::NonLoopback(_)), "{err}");
+    }
+
+    #[test]
+    fn public_bind_allows_non_loopback() {
+        let key = ApiKey::new("t", "s").unwrap();
+        ServeConfig::bind("0.0.0.0:8080", vec![key], true).unwrap();
+    }
+
+    #[test]
+    fn public_bind_without_keys_is_hard_error() {
+        let err = ServeConfig::bind("0.0.0.0:8080", vec![], true).unwrap_err();
+        assert!(matches!(err, Error::NoApiKeys), "{err}");
+        assert_eq!(err.exit_code(), 2, "exit");
     }
 
     #[test]
     fn accepts_loopback() {
         let key = ApiKey::new("t", "s").unwrap();
         ServeConfig::new("127.0.0.1:8080", vec![key]).unwrap();
+    }
+
+    #[test]
+    fn sweep_interval_is_30s() {
+        assert_eq!(SWEEP_INTERVAL, Duration::from_secs(30), "30s");
+        let prod = include_str!("lib.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(prod.contains("sweep_loop"), "sweep task");
+        assert!(prod.contains("runtime.sweep"), "Runtime::sweep");
     }
 
     #[test]
@@ -523,10 +626,20 @@ mod tests {
             "config path"
         );
         assert!(
+            v.get("paths").and_then(|p| p.get("/v1/me")).is_some(),
+            "me path"
+        );
+        assert!(
             v.get("paths")
                 .and_then(|p| p.get("/v1/sandboxes"))
                 .is_some(),
             "sandboxes path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/start"))
+                .is_some(),
+            "start path"
         );
         assert!(
             v.get("paths")

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -3,10 +3,10 @@
 //! `bux serve start` opens one [`bux::Runtime`] (exclusive flock on `BUX_HOME`),
 //! binds TCP (loopback unless `--public`) and a Unix socket, sweeps idle VMs
 //! every 30s, and serves `/v1/health` (public) plus Bearer-protected `/v1/me`,
-//! `/v1/metrics`, sandbox get-or-create, collect exec, files, images, and logs.
-//! At least one API key is required to start, including on the Unix socket.
-//! Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is only a separator in
-//! formatted sandbox and volume names.
+//! `/v1/metrics`, sandbox get-or-create, collect exec, files, images, logs,
+//! snapshots, clone, and restore. At least one API key is required to start,
+//! including on the Unix socket. Identifiers use the alphabet `[A-Za-z0-9._]`;
+//! `-` is only a separator in formatted sandbox and volume names.
 
 #![allow(
     clippy::missing_docs_in_private_items,
@@ -24,6 +24,7 @@ mod logs;
 mod openapi;
 mod router;
 mod sandboxes;
+mod snapshots;
 mod state;
 
 use std::fmt;
@@ -599,6 +600,30 @@ mod tests {
             v.get("security"),
             Some(&serde_json::json!([{"bearer": []}])),
             "global bearer"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/snapshots"))
+                .is_some(),
+            "snapshots path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/snapshots/{sid}"))
+                .is_some(),
+            "delete snapshot path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/snapshots/{sid}/restore"))
+                .is_some(),
+            "restore path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/clone"))
+                .is_some(),
+            "clone path"
         );
     }
 

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -578,10 +578,6 @@ mod tests {
             assert!(paths.get(path).is_some(), "{path}");
         }
         assert!(
-            paths.get("/v1/sandboxes/{id}/snapshots").is_none(),
-            "snapshots are a later PR"
-        );
-        assert!(
             v.pointer("/components/schemas/MetricsBody").is_some(),
             "utoipa schema"
         );

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -1,11 +1,12 @@
 //! HTTP worker for hosted bux sandboxes.
 //!
 //! `bux serve start` opens one [`bux::Runtime`] (exclusive flock on `BUX_HOME`),
-//! binds TCP (loopback unless `--public`), sweeps idle VMs every 30s, and
-//! serves `/v1/health` (public) plus Bearer-protected `/v1/me`, `/v1/metrics`,
-//! sandbox get-or-create, collect exec, files, images, and logs. At least one
-//! API key is required to start. Identifiers use the alphabet `[A-Za-z0-9._]`;
-//! `-` is only a separator in formatted sandbox and volume names.
+//! binds TCP (loopback unless `--public`) and a Unix socket, sweeps idle VMs
+//! every 30s, and serves `/v1/health` (public) plus Bearer-protected `/v1/me`,
+//! `/v1/metrics`, sandbox get-or-create, collect exec, files, images, and logs.
+//! At least one API key is required to start, including on the Unix socket.
+//! Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is only a separator in
+//! formatted sandbox and volume names.
 
 #![allow(
     clippy::missing_docs_in_private_items,
@@ -18,6 +19,7 @@ mod exec;
 mod files;
 mod ids;
 mod images;
+mod listen;
 mod logs;
 mod openapi;
 mod router;
@@ -25,7 +27,6 @@ mod sandboxes;
 mod state;
 
 use std::fmt;
-use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
@@ -33,6 +34,7 @@ pub use error::{Error, Result};
 pub use ids::{
     IdError, sandbox_name, validate_agent_id, validate_tenant_id, workspace_volume_name,
 };
+pub use listen::listen_specs;
 pub use state::Limits;
 
 use state::AppState;
@@ -87,10 +89,10 @@ impl ApiKey {
 /// How often the worker calls [`bux::Runtime::sweep`].
 pub(crate) const SWEEP_INTERVAL: Duration = Duration::from_secs(30);
 
-/// TCP bind address, API keys, data dir, and admission limits.
+/// Listen addresses, API keys, data dir, and admission limits.
 #[derive(Debug)]
 pub struct ServeConfig {
-    listen: SocketAddr,
+    listen: Vec<listen::ListenAddr>,
     keys: Vec<ApiKey>,
     data_dir: PathBuf,
     limits: Limits,
@@ -98,39 +100,47 @@ pub struct ServeConfig {
 }
 
 impl ServeConfig {
-    /// Loopback `IP:PORT` and at least one API key.
+    /// Bind specs and at least one API key. Empty `listen` uses the defaults
+    /// (`127.0.0.1:8080` and `unix://$XDG_RUNTIME_DIR/bux.sock`, fallback
+    /// `/tmp/bux-$UID.sock`).
     ///
     /// Data dir defaults to [`bux::default_data_dir`]; limits to [`Limits::default`].
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`], or
-    /// [`Error::NonLoopback`].
-    pub fn new(listen: &str, keys: Vec<ApiKey>) -> Result<Self> {
+    /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`],
+    /// [`Error::NonLoopback`], or [`Error::PublicRequiresTcp`].
+    pub fn new<I, S>(listen: I, keys: Vec<ApiKey>) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         Self::bind(listen, keys, false)
     }
 
-    /// TCP bind with at least one API key.
+    /// Bind with at least one API key.
     ///
-    /// `public` is required for a non-loopback address (`--public`). Zero keys
-    /// is always [`Error::NoApiKeys`], including with `public`.
+    /// Each spec is `HOST:PORT`, `unix://ABS_PATH`, or an absolute `/path`.
+    /// Empty `listen` uses TCP loopback plus the default Unix socket.
+    /// `public` is required for a non-loopback **TCP** address (`--public`).
+    /// `--public` with only Unix listeners is [`Error::PublicRequiresTcp`].
+    /// Zero keys is always [`Error::NoApiKeys`], including Unix-only and
+    /// `public`.
     ///
     /// # Errors
     ///
-    /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`], or
-    /// [`Error::NonLoopback`].
-    pub fn bind(listen: &str, keys: Vec<ApiKey>, public: bool) -> Result<Self> {
+    /// Returns [`Error::NoApiKeys`], [`Error::InvalidListen`],
+    /// [`Error::NonLoopback`], or [`Error::PublicRequiresTcp`].
+    pub fn bind<I, S>(listen: I, keys: Vec<ApiKey>, public: bool) -> Result<Self>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
         if keys.is_empty() {
             return Err(Error::NoApiKeys);
         }
-        let listen: SocketAddr = listen
-            .parse()
-            .map_err(|_| Error::InvalidListen(listen.to_owned()))?;
-        if !listen.ip().is_loopback() && !public {
-            return Err(Error::NonLoopback(listen));
-        }
         Ok(Self {
-            listen,
+            listen: listen::resolve_listen(listen, public)?,
             keys,
             data_dir: bux::default_data_dir(),
             limits: Limits::default(),
@@ -240,15 +250,16 @@ fn warn_if_world_readable(path: &Path) {
     }
 }
 
-/// Bind `config.listen` and serve until SIGINT / SIGTERM.
+/// Bind every `config.listen` address (same router / [`AppState`]) until SIGINT / SIGTERM.
 ///
 /// Opens [`bux::Runtime`] on `config.data_dir` (exclusive flock) before bind.
 /// Builds a multi-thread tokio runtime. Must not be called from an existing runtime.
+/// Unix socket files are unlinked on shutdown.
 ///
 /// # Errors
 ///
 /// Returns [`Error::Runtime`] with [`bux::Error::Busy`] if another process holds
-/// the data-dir lock. Returns [`Error::Io`] if the address cannot be bound.
+/// the data-dir lock. Returns [`Error::Io`] if an address cannot be bound.
 pub fn run(config: ServeConfig) -> Result<()> {
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -262,26 +273,27 @@ fn open_runtime(data_dir: &Path) -> Result<bux::Runtime> {
 
 async fn serve(config: ServeConfig) -> Result<()> {
     let shutdown = install_shutdown()?;
+    serve_until(config, shutdown).await
+}
+
+async fn serve_until(
+    config: ServeConfig,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> Result<()> {
     let runtime = open_runtime(&config.data_dir)?;
-    let listen = config.listen;
-    let listener = tokio::net::TcpListener::bind(listen).await?;
     tracing::info!(
-        %listen,
         api_keys = config.keys.len(),
         data_dir = %config.data_dir.display(),
         allow_unrestricted_net = config.allow_unrestricted_net,
-        "listening"
+        "starting worker"
     );
     let state = AppState::new(config.keys, runtime, config.limits)
         .with_unrestricted_net(config.allow_unrestricted_net);
     let sweep = tokio::spawn(sweep_loop(state.clone()));
     let app = router::router(state);
-    let result = axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown)
-        .await;
+    let result = listen::serve_listeners(&config.listen, app, shutdown).await;
     sweep.abort();
-    result?;
-    Ok(())
+    result
 }
 
 async fn sweep_loop(state: AppState) {
@@ -306,7 +318,7 @@ async fn sweep_loop(state: AppState) {
 
 /// Install SIGINT/SIGTERM first. A failed install is I/O, not shutdown.
 #[cfg(unix)]
-fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send> {
+fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send + 'static> {
     let mut interrupt = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())?;
     let mut terminate = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;
     Ok(async move {
@@ -326,7 +338,7 @@ async fn recv_signal(signal: &mut tokio::signal::unix::Signal) {
 }
 
 #[cfg(not(unix))]
-fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send> {
+fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send + 'static> {
     Ok(async {
         if tokio::signal::ctrl_c().await.is_err() {
             std::future::pending::<()>().await;
@@ -338,44 +350,161 @@ fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send> {
 pub use openapi::openapi_json;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::shadow_unrelated, reason = "tests")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::shadow_unrelated,
+    reason = "tests"
+)]
 mod tests {
     use super::*;
 
     #[test]
     fn refuses_zero_keys() {
-        let err = ServeConfig::new("127.0.0.1:8080", vec![]).unwrap_err();
+        let err = ServeConfig::new(["127.0.0.1:8080"], vec![]).unwrap_err();
         assert!(matches!(err, Error::NoApiKeys), "{err}");
         assert_eq!(err.exit_code(), 2, "exit");
     }
 
     #[test]
     fn refuses_non_loopback() {
-        let err =
-            ServeConfig::new("0.0.0.0:8080", vec![ApiKey::new("t", "s").unwrap()]).unwrap_err();
-        assert!(matches!(err, Error::NonLoopback(_)), "{err}");
-        let err = ServeConfig::bind("0.0.0.0:8080", vec![ApiKey::new("t", "s").unwrap()], false)
-            .unwrap_err();
-        assert!(matches!(err, Error::NonLoopback(_)), "{err}");
+        let new_err =
+            ServeConfig::new(["0.0.0.0:8080"], vec![ApiKey::new("t", "s").unwrap()]).unwrap_err();
+        assert!(matches!(new_err, Error::NonLoopback(_)), "{new_err}");
+        let bind_err = ServeConfig::bind(
+            ["0.0.0.0:8080"],
+            vec![ApiKey::new("t", "s").unwrap()],
+            false,
+        )
+        .unwrap_err();
+        assert!(matches!(bind_err, Error::NonLoopback(_)), "{bind_err}");
     }
 
     #[test]
     fn public_bind_allows_non_loopback() {
         let key = ApiKey::new("t", "s").unwrap();
-        ServeConfig::bind("0.0.0.0:8080", vec![key], true).unwrap();
+        ServeConfig::bind(["0.0.0.0:8080"], vec![key], true).unwrap();
     }
 
     #[test]
     fn public_bind_without_keys_is_hard_error() {
-        let err = ServeConfig::bind("0.0.0.0:8080", vec![], true).unwrap_err();
+        let err = ServeConfig::bind(["0.0.0.0:8080"], vec![], true).unwrap_err();
         assert!(matches!(err, Error::NoApiKeys), "{err}");
+        assert_eq!(err.exit_code(), 2, "exit");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn public_unix_only_is_hard_error() {
+        let key = ApiKey::new("t", "s").unwrap();
+        let err = ServeConfig::bind(["unix:///tmp/bux.sock"], vec![key], true).unwrap_err();
+        assert!(matches!(err, Error::PublicRequiresTcp), "{err}");
         assert_eq!(err.exit_code(), 2, "exit");
     }
 
     #[test]
     fn accepts_loopback() {
         let key = ApiKey::new("t", "s").unwrap();
-        ServeConfig::new("127.0.0.1:8080", vec![key]).unwrap();
+        ServeConfig::new(["127.0.0.1:8080"], vec![key]).unwrap();
+    }
+
+    #[test]
+    fn omitted_listen_defaults_tcp_and_unix() {
+        let key = ApiKey::new("t", "s").unwrap();
+        let cfg = ServeConfig::new(Vec::<&str>::new(), vec![key]).unwrap();
+        assert!(
+            cfg.listen
+                .iter()
+                .any(|addr| matches!(addr, listen::ListenAddr::Tcp(_))),
+            "tcp: {:?}",
+            cfg.listen
+        );
+        #[cfg(unix)]
+        assert!(
+            cfg.listen
+                .iter()
+                .any(|addr| matches!(addr, listen::ListenAddr::Unix(_))),
+            "unix: {:?}",
+            cfg.listen
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_only_listen_without_public_is_ok() {
+        let key = ApiKey::new("t", "s").unwrap();
+        ServeConfig::bind(["unix:///tmp/bux.sock"], vec![key], false).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unix_listen_health_and_unauth_mutate() {
+        let dir = tempfile::tempdir().unwrap();
+        let sock = dir.path().join("bux.sock");
+        std::fs::write(&sock, b"stale").unwrap();
+        let spec = format!("unix://{}", sock.display());
+        let config = ServeConfig::bind(
+            [spec.as_str()],
+            vec![ApiKey::new("t", "secret").unwrap()],
+            false,
+        )
+        .unwrap()
+        .data_dir(dir.path());
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+        let server = tokio::spawn(serve_until(config, async move {
+            drop(stop_rx.await);
+        }));
+
+        let health = unix_http(
+            &sock,
+            "GET /v1/health HTTP/1.1\r\nHost: bux\r\nConnection: close\r\n\r\n",
+        )
+        .await;
+        assert!(
+            health.starts_with("HTTP/1.1 200 ") || health.contains("HTTP/1.1 200 "),
+            "{health}"
+        );
+
+        let mutate = unix_http(
+            &sock,
+            "POST /v1/sandboxes HTTP/1.1\r\nHost: bux\r\nContent-Type: application/json\r\nContent-Length: 2\r\nConnection: close\r\n\r\n{}",
+        )
+        .await;
+        assert!(mutate.contains("401"), "{mutate}");
+        assert!(mutate.contains("unauthorized"), "{mutate}");
+
+        assert!(stop_tx.send(()).is_ok(), "server still running");
+        tokio::time::timeout(Duration::from_secs(10), server)
+            .await
+            .expect("server shutdown")
+            .expect("join")
+            .expect("serve");
+        assert!(!sock.exists(), "unlinked on shutdown");
+    }
+
+    #[cfg(unix)]
+    async fn unix_http(path: &Path, request: &str) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let mut stream = connect_unix(path).await;
+        stream.write_all(request.as_bytes()).await.unwrap();
+        let mut buf = Vec::new();
+        stream.read_to_end(&mut buf).await.unwrap();
+        String::from_utf8_lossy(&buf).into_owned()
+    }
+
+    #[cfg(unix)]
+    async fn connect_unix(path: &Path) -> tokio::net::UnixStream {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            match tokio::net::UnixStream::connect(path).await {
+                Ok(stream) => return stream,
+                Err(_) if tokio::time::Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Err(err) => panic!("connect {}: {err}", path.display()),
+            }
+        }
     }
 
     #[test]

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -2,9 +2,10 @@
 //!
 //! `bux serve start` opens one [`bux::Runtime`] (exclusive flock on `BUX_HOME`),
 //! binds a TCP loopback address, and serves `/v1/health` (public) plus
-//! Bearer-protected sandbox CRUD. At least one API key is required to start.
-//! Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is only a separator in
-//! formatted sandbox and volume names.
+//! Bearer-protected sandbox CRUD, collect exec, files, and images. At least
+//! one API key is required to start. Identifiers use the alphabet
+//! `[A-Za-z0-9._]`; `-` is only a separator in formatted sandbox and volume
+//! names.
 
 #![allow(
     clippy::missing_docs_in_private_items,
@@ -13,7 +14,10 @@
 
 mod auth;
 mod error;
+mod exec;
+mod files;
 mod ids;
+mod images;
 mod router;
 mod sandboxes;
 mod state;
@@ -353,6 +357,87 @@ const OPENAPI_JSON: &str = concat!(
     "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
     "        }\n",
     "      }\n",
+    "    },\n",
+    "    \"/v1/sandboxes/{id}/exec\": {\n",
+    "      \"post\": {\n",
+    "        \"operationId\": \"exec\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Collected exec output\" },\n",
+    "          \"400\": { \"description\": \"Invalid body or timeout_ms\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Missing or other tenant\" },\n",
+    "          \"409\": { \"description\": \"secrets_required\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/sandboxes/{id}/files\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"getFile\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [\n",
+    "          { \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } },\n",
+    "          { \"name\": \"path\", \"in\": \"query\", \"required\": true, \"schema\": { \"type\": \"string\" } }\n",
+    "        ],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"File bytes\" },\n",
+    "          \"400\": { \"description\": \"Invalid path\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
+    "        }\n",
+    "      },\n",
+    "      \"put\": {\n",
+    "        \"operationId\": \"putFile\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [\n",
+    "          { \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } },\n",
+    "          { \"name\": \"path\", \"in\": \"query\", \"required\": true, \"schema\": { \"type\": \"string\" } },\n",
+    "          { \"name\": \"mode\", \"in\": \"query\", \"required\": false, \"schema\": { \"type\": \"integer\" }, \"description\": \"Decimal file mode (default 420 = 0644)\" }\n",
+    "        ],\n",
+    "        \"responses\": {\n",
+    "          \"204\": { \"description\": \"Written\" },\n",
+    "          \"400\": { \"description\": \"Invalid path or mode\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Missing or other tenant\" },\n",
+    "          \"413\": { \"description\": \"Body over 32 MiB\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/images\": {\n",
+    "      \"get\": {\n",
+    "        \"operationId\": \"listImages\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Cached images (worker-global)\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
+    "        }\n",
+    "      },\n",
+    "      \"delete\": {\n",
+    "        \"operationId\": \"deleteImage\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"parameters\": [{ \"name\": \"reference\", \"in\": \"query\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
+    "        \"responses\": {\n",
+    "          \"204\": { \"description\": \"Index entry removed\" },\n",
+    "          \"400\": { \"description\": \"Invalid reference\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"404\": { \"description\": \"Not in store\" },\n",
+    "          \"409\": { \"description\": \"Image is in use\" }\n",
+    "        }\n",
+    "      }\n",
+    "    },\n",
+    "    \"/v1/images/pull\": {\n",
+    "      \"post\": {\n",
+    "        \"operationId\": \"pullImage\",\n",
+    "        \"security\": [{ \"bearer\": [] }],\n",
+    "        \"responses\": {\n",
+    "          \"200\": { \"description\": \"Pulled\" },\n",
+    "          \"400\": { \"description\": \"Invalid reference\" },\n",
+    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
+    "          \"413\": { \"description\": \"Manifest compressed size over max-pull-bytes\" },\n",
+    "          \"429\": { \"description\": \"Disk cap\" }\n",
+    "        }\n",
+    "      }\n",
     "    }\n",
     "  },\n",
     "  \"components\": {\n",
@@ -442,6 +527,28 @@ mod tests {
                 .and_then(|p| p.get("/v1/sandboxes"))
                 .is_some(),
             "sandboxes path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/exec"))
+                .is_some(),
+            "exec path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/sandboxes/{id}/files"))
+                .is_some(),
+            "files path"
+        );
+        assert!(
+            v.get("paths").and_then(|p| p.get("/v1/images")).is_some(),
+            "images path"
+        );
+        assert!(
+            v.get("paths")
+                .and_then(|p| p.get("/v1/images/pull"))
+                .is_some(),
+            "pull path"
         );
     }
 

--- a/crates/bux-serve/src/lib.rs
+++ b/crates/bux-serve/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! `bux serve start` opens one [`bux::Runtime`] (exclusive flock on `BUX_HOME`),
 //! binds TCP (loopback unless `--public`), sweeps idle VMs every 30s, and
-//! serves `/v1/health` (public) plus Bearer-protected `/v1/me`, sandbox
-//! get-or-create, collect exec, files, and images. At least one API key is
-//! required to start. Identifiers use the alphabet `[A-Za-z0-9._]`; `-` is
-//! only a separator in formatted sandbox and volume names.
+//! serves `/v1/health` (public) plus Bearer-protected `/v1/me`, `/v1/metrics`,
+//! sandbox get-or-create, collect exec, files, images, and logs. At least one
+//! API key is required to start. Identifiers use the alphabet `[A-Za-z0-9._]`;
+//! `-` is only a separator in formatted sandbox and volume names.
 
 #![allow(
     clippy::missing_docs_in_private_items,
@@ -18,6 +18,8 @@ mod exec;
 mod files;
 mod ids;
 mod images;
+mod logs;
+mod openapi;
 mod router;
 mod sandboxes;
 mod state;
@@ -333,199 +335,10 @@ fn install_shutdown() -> std::io::Result<impl Future<Output = ()> + Send> {
 }
 
 /// OpenAPI 3.1 document for routes this worker currently serves.
-#[must_use]
-pub const fn openapi_json() -> &'static str {
-    OPENAPI_JSON
-}
-
-const OPENAPI_JSON: &str = concat!(
-    "{\n",
-    "  \"openapi\": \"3.1.0\",\n",
-    "  \"info\": {\n",
-    "    \"title\": \"bux\",\n",
-    "    \"version\": \"",
-    env!("CARGO_PKG_VERSION"),
-    "\"\n",
-    "  },\n",
-    "  \"paths\": {\n",
-    "    \"/v1/health\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"health\",\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Worker is up\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/config\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"config\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Worker config\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/me\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"me\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Bearer tenant_id and max_sandboxes\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/sandboxes\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"listSandboxes\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Sandboxes for this tenant\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
-    "        }\n",
-    "      },\n",
-    "      \"post\": {\n",
-    "        \"operationId\": \"createSandbox\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"responses\": {\n",
-    "          \"201\": { \"description\": \"Created\" },\n",
-    "          \"200\": { \"description\": \"Existing sandbox for this tenant and agent\" },\n",
-    "          \"400\": { \"description\": \"Invalid body or per-sandbox admission\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"409\": { \"description\": \"Name occupied\" },\n",
-    "          \"412\": { \"description\": \"No hardware virtualization\" },\n",
-    "          \"429\": { \"description\": \"Count, running RAM, or disk cap\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/sandboxes/{id}\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"getSandbox\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Sandbox\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
-    "        }\n",
-    "      },\n",
-    "      \"delete\": {\n",
-    "        \"operationId\": \"deleteSandbox\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
-    "        \"responses\": {\n",
-    "          \"204\": { \"description\": \"Removed, workspace volume deleted\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/sandboxes/{id}/start\": {\n",
-    "      \"post\": {\n",
-    "        \"operationId\": \"startSandbox\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Started\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Missing or other tenant\" },\n",
-    "          \"409\": { \"description\": \"secrets_required or not stopped\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/sandboxes/{id}/exec\": {\n",
-    "      \"post\": {\n",
-    "        \"operationId\": \"exec\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [{ \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Collected exec output\" },\n",
-    "          \"400\": { \"description\": \"Invalid body or timeout_ms\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Missing or other tenant\" },\n",
-    "          \"409\": { \"description\": \"secrets_required\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/sandboxes/{id}/files\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"getFile\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [\n",
-    "          { \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } },\n",
-    "          { \"name\": \"path\", \"in\": \"query\", \"required\": true, \"schema\": { \"type\": \"string\" } }\n",
-    "        ],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"File bytes\" },\n",
-    "          \"400\": { \"description\": \"Invalid path\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Missing or other tenant\" }\n",
-    "        }\n",
-    "      },\n",
-    "      \"put\": {\n",
-    "        \"operationId\": \"putFile\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [\n",
-    "          { \"name\": \"id\", \"in\": \"path\", \"required\": true, \"schema\": { \"type\": \"string\" } },\n",
-    "          { \"name\": \"path\", \"in\": \"query\", \"required\": true, \"schema\": { \"type\": \"string\" } },\n",
-    "          { \"name\": \"mode\", \"in\": \"query\", \"required\": false, \"schema\": { \"type\": \"integer\" }, \"description\": \"Decimal file mode (default 420 = 0644)\" }\n",
-    "        ],\n",
-    "        \"responses\": {\n",
-    "          \"204\": { \"description\": \"Written\" },\n",
-    "          \"400\": { \"description\": \"Invalid path or mode\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Missing or other tenant\" },\n",
-    "          \"413\": { \"description\": \"Body over 32 MiB\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/images\": {\n",
-    "      \"get\": {\n",
-    "        \"operationId\": \"listImages\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Cached images (worker-global)\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" }\n",
-    "        }\n",
-    "      },\n",
-    "      \"delete\": {\n",
-    "        \"operationId\": \"deleteImage\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"parameters\": [{ \"name\": \"reference\", \"in\": \"query\", \"required\": true, \"schema\": { \"type\": \"string\" } }],\n",
-    "        \"responses\": {\n",
-    "          \"204\": { \"description\": \"Index entry removed\" },\n",
-    "          \"400\": { \"description\": \"Invalid reference\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"404\": { \"description\": \"Not in store\" },\n",
-    "          \"409\": { \"description\": \"Image is in use\" }\n",
-    "        }\n",
-    "      }\n",
-    "    },\n",
-    "    \"/v1/images/pull\": {\n",
-    "      \"post\": {\n",
-    "        \"operationId\": \"pullImage\",\n",
-    "        \"security\": [{ \"bearer\": [] }],\n",
-    "        \"responses\": {\n",
-    "          \"200\": { \"description\": \"Pulled\" },\n",
-    "          \"400\": { \"description\": \"Invalid reference\" },\n",
-    "          \"401\": { \"description\": \"Missing or invalid Bearer token\" },\n",
-    "          \"413\": { \"description\": \"Manifest compressed size over max-pull-bytes\" },\n",
-    "          \"429\": { \"description\": \"Disk cap\" }\n",
-    "        }\n",
-    "      }\n",
-    "    }\n",
-    "  },\n",
-    "  \"components\": {\n",
-    "    \"securitySchemes\": {\n",
-    "      \"bearer\": { \"type\": \"http\", \"scheme\": \"bearer\" }\n",
-    "    }\n",
-    "  }\n",
-    "}"
-);
+pub use openapi::openapi_json;
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, reason = "tests")]
+#[allow(clippy::unwrap_used, clippy::shadow_unrelated, reason = "tests")]
 mod tests {
     use super::*;
 
@@ -615,53 +428,48 @@ mod tests {
 
     #[test]
     fn openapi_is_json_object() {
-        let v: serde_json::Value = serde_json::from_str(openapi_json()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&openapi_json()).unwrap();
         assert!(v.get("openapi").is_some(), "openapi field");
+        let paths = v.get("paths").expect("paths");
+        for path in [
+            "/v1/health",
+            "/v1/config",
+            "/v1/me",
+            "/v1/metrics",
+            "/v1/sandboxes",
+            "/v1/sandboxes/{id}",
+            "/v1/sandboxes/{id}/start",
+            "/v1/sandboxes/{id}/logs",
+            "/v1/sandboxes/{id}/exec",
+            "/v1/sandboxes/{id}/files",
+            "/v1/images",
+            "/v1/images/pull",
+        ] {
+            assert!(paths.get(path).is_some(), "{path}");
+        }
         assert!(
-            v.get("paths").and_then(|p| p.get("/v1/health")).is_some(),
-            "health path"
+            paths.get("/v1/sandboxes/{id}/snapshots").is_none(),
+            "snapshots are a later PR"
         );
         assert!(
-            v.get("paths").and_then(|p| p.get("/v1/config")).is_some(),
-            "config path"
+            v.pointer("/components/schemas/MetricsBody").is_some(),
+            "utoipa schema"
         );
-        assert!(
-            v.get("paths").and_then(|p| p.get("/v1/me")).is_some(),
-            "me path"
+        assert_eq!(
+            v.pointer("/components/securitySchemes/bearer/scheme")
+                .and_then(serde_json::Value::as_str),
+            Some("bearer"),
+            "bearer scheme"
         );
-        assert!(
-            v.get("paths")
-                .and_then(|p| p.get("/v1/sandboxes"))
-                .is_some(),
-            "sandboxes path"
+        assert_eq!(
+            v.pointer("/paths/~1v1~1health/get/security"),
+            Some(&serde_json::json!([{}])),
+            "health overrides global bearer"
         );
-        assert!(
-            v.get("paths")
-                .and_then(|p| p.get("/v1/sandboxes/{id}/start"))
-                .is_some(),
-            "start path"
-        );
-        assert!(
-            v.get("paths")
-                .and_then(|p| p.get("/v1/sandboxes/{id}/exec"))
-                .is_some(),
-            "exec path"
-        );
-        assert!(
-            v.get("paths")
-                .and_then(|p| p.get("/v1/sandboxes/{id}/files"))
-                .is_some(),
-            "files path"
-        );
-        assert!(
-            v.get("paths").and_then(|p| p.get("/v1/images")).is_some(),
-            "images path"
-        );
-        assert!(
-            v.get("paths")
-                .and_then(|p| p.get("/v1/images/pull"))
-                .is_some(),
-            "pull path"
+        assert_eq!(
+            v.get("security"),
+            Some(&serde_json::json!([{"bearer": []}])),
+            "global bearer"
         );
     }
 

--- a/crates/bux-serve/src/listen.rs
+++ b/crates/bux-serve/src/listen.rs
@@ -164,30 +164,31 @@ enum Bound {
 #[derive(Debug)]
 struct UnixSocketGuard {
     path: PathBuf,
+    dev: u64,
+    ino: u64,
 }
 
 #[cfg(unix)]
 impl UnixSocketGuard {
-    fn prepare(path: &Path) -> Result<Self> {
-        if let Some(parent) = path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            std::fs::create_dir_all(parent)?;
-        }
-        match std::fs::remove_file(path) {
-            Ok(()) => {}
-            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
-            Err(err) => return Err(err.into()),
-        }
-        Ok(Self {
-            path: path.to_path_buf(),
-        })
+    fn from_bound(path: PathBuf) -> Result<Self> {
+        // Darwin fstat() on a unix socket fd is not the bind-path inode
+        // (`st_dev` is -1). Identify the name by lstat after bind.
+        let (dev, ino) = path_dev_ino(&path)?;
+        Ok(Self { path, dev, ino })
     }
 }
 
 #[cfg(unix)]
 impl Drop for UnixSocketGuard {
     fn drop(&mut self) {
+        // Only unlink if this path still names the inode we bound. A later
+        // worker may have stolen the name; unlinking it would drop their socket.
+        let Ok((dev, ino)) = path_dev_ino(&self.path) else {
+            return;
+        };
+        if dev != self.dev || ino != self.ino {
+            return;
+        }
         match std::fs::remove_file(&self.path) {
             Ok(()) => {}
             Err(err) if err.kind() == io::ErrorKind::NotFound => {}
@@ -198,6 +199,55 @@ impl Drop for UnixSocketGuard {
                     "failed to unlink unix socket"
                 );
             }
+        }
+    }
+}
+
+#[cfg(unix)]
+fn prepare_unix_path(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent()
+        && !parent.as_os_str().is_empty()
+    {
+        std::fs::create_dir_all(parent)?;
+    }
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+#[cfg(unix)]
+fn path_dev_ino(path: &Path) -> io::Result<(u64, u64)> {
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::symlink_metadata(path)?;
+    Ok((meta.dev(), meta.ino()))
+}
+
+#[cfg(unix)]
+fn bind_unix(path: &Path) -> Result<Bound> {
+    prepare_unix_path(path)?;
+    let listener = tokio::net::UnixListener::bind(path)?;
+    match UnixSocketGuard::from_bound(path.to_path_buf()) {
+        Ok(guard) => Ok(Bound::Unix {
+            listener,
+            _guard: guard,
+        }),
+        Err(err) => {
+            // Bound, but we cannot identify the inode; drop our name so a
+            // failed start does not leave a socket without a guard.
+            match std::fs::remove_file(path) {
+                Ok(()) => {}
+                Err(unlink_err) if unlink_err.kind() == io::ErrorKind::NotFound => {}
+                Err(unlink_err) => {
+                    tracing::warn!(
+                        path = %path.display(),
+                        error = %unlink_err,
+                        "failed to unlink unix socket after fstat error"
+                    );
+                }
+            }
+            Err(err)
         }
     }
 }
@@ -228,13 +278,9 @@ async fn bind_one(addr: &ListenAddr) -> Result<Bound> {
         }
         #[cfg(unix)]
         ListenAddr::Unix(path) => {
-            let guard = UnixSocketGuard::prepare(path)?;
-            let listener = tokio::net::UnixListener::bind(&guard.path)?;
+            let bound = bind_unix(path)?;
             tracing::info!(listen = %addr, "listening");
-            Ok(Bound::Unix {
-                listener,
-                _guard: guard,
-            })
+            Ok(bound)
         }
     }
 }
@@ -424,5 +470,34 @@ mod tests {
             default_unix_path_from(Some(OsStr::new("")), 7),
             PathBuf::from("/tmp/bux-7.sock")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_guard_drop_unlinks_own_inode() {
+        use std::os::unix::net::UnixListener;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s");
+        let listener = UnixListener::bind(&path).unwrap();
+        let guard = UnixSocketGuard::from_bound(path.clone()).unwrap();
+        drop(guard);
+        assert!(!path.exists(), "own name unlinked");
+        drop(listener);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_guard_drop_skips_replaced_inode() {
+        use std::os::unix::net::UnixListener;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("s");
+        let first = UnixListener::bind(&path).unwrap();
+        let guard = UnixSocketGuard::from_bound(path.clone()).unwrap();
+        drop(first);
+        std::fs::remove_file(&path).unwrap();
+        let second = UnixListener::bind(&path).unwrap();
+        drop(guard);
+        assert!(path.exists(), "replacement kept");
+        drop(second);
     }
 }

--- a/crates/bux-serve/src/listen.rs
+++ b/crates/bux-serve/src/listen.rs
@@ -1,0 +1,428 @@
+//! Repeatable `--listen` specs: TCP `HOST:PORT` and `unix://` sockets.
+
+use std::fmt;
+use std::future::Future;
+use std::io;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+/// A single bind target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ListenAddr {
+    Tcp(SocketAddr),
+    #[cfg(unix)]
+    Unix(PathBuf),
+}
+
+impl fmt::Display for ListenAddr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Tcp(addr) => fmt::Display::fmt(addr, f),
+            #[cfg(unix)]
+            Self::Unix(path) => write!(f, "unix://{}", path.display()),
+        }
+    }
+}
+
+/// CLI `--listen` values, else comma-separated `BUX_LISTEN`, else empty (defaults).
+#[must_use]
+pub fn listen_specs(cli: &[String], env: Option<&str>) -> Vec<String> {
+    if !cli.is_empty() {
+        return cli.to_vec();
+    }
+    env.unwrap_or("")
+        .split(',')
+        .map(str::trim)
+        .filter(|spec| !spec.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
+
+pub(crate) fn resolve_listen<I, S>(specs: I, public: bool) -> Result<Vec<ListenAddr>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let addrs = parse_listen_list(specs)?;
+    check_public(&addrs, public)?;
+    Ok(addrs)
+}
+
+fn parse_listen_list<I, S>(specs: I) -> Result<Vec<ListenAddr>>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut addrs = Vec::new();
+    for spec in specs {
+        let spec = spec.as_ref().trim();
+        if spec.is_empty() {
+            continue;
+        }
+        addrs.push(parse_listen(spec)?);
+    }
+    if addrs.is_empty() {
+        return Ok(default_listen());
+    }
+    Ok(addrs)
+}
+
+fn parse_listen(spec: &str) -> Result<ListenAddr> {
+    if let Some(path) = spec.strip_prefix("unix://") {
+        return parse_unix_path(path, spec);
+    }
+    if spec.starts_with('/') {
+        return parse_unix_path(spec, spec);
+    }
+    spec.parse::<SocketAddr>()
+        .map(ListenAddr::Tcp)
+        .map_err(|_| Error::InvalidListen(spec.to_owned()))
+}
+
+fn parse_unix_path(path: &str, original: &str) -> Result<ListenAddr> {
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        return Err(Error::InvalidListen(original.to_owned()));
+    }
+    #[cfg(unix)]
+    {
+        // Relative sockets follow cwd; the contract is an absolute path.
+        let path = PathBuf::from(path);
+        if !path.is_absolute() || path.file_name().is_none() {
+            return Err(Error::InvalidListen(original.to_owned()));
+        }
+        Ok(ListenAddr::Unix(path))
+    }
+}
+
+fn check_public(addrs: &[ListenAddr], public: bool) -> Result<()> {
+    let mut any_tcp = false;
+    for addr in addrs {
+        if let ListenAddr::Tcp(tcp) = addr {
+            any_tcp = true;
+            if !tcp.ip().is_loopback() && !public {
+                return Err(Error::NonLoopback(*tcp));
+            }
+        }
+    }
+    if public && !any_tcp {
+        return Err(Error::PublicRequiresTcp);
+    }
+    Ok(())
+}
+
+fn default_listen() -> Vec<ListenAddr> {
+    let tcp = ListenAddr::Tcp(SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, 8080)));
+    #[cfg(unix)]
+    {
+        vec![tcp, ListenAddr::Unix(default_unix_path())]
+    }
+    #[cfg(not(unix))]
+    {
+        vec![tcp]
+    }
+}
+
+#[cfg(unix)]
+fn default_unix_path() -> PathBuf {
+    default_unix_path_from(
+        std::env::var_os("XDG_RUNTIME_DIR").as_deref(),
+        current_uid(),
+    )
+}
+
+#[cfg(unix)]
+fn default_unix_path_from(xdg_runtime_dir: Option<&std::ffi::OsStr>, uid: u32) -> PathBuf {
+    match xdg_runtime_dir {
+        Some(dir) if !dir.is_empty() => Path::new(dir).join("bux.sock"),
+        _ => PathBuf::from(format!("/tmp/bux-{uid}.sock")),
+    }
+}
+
+#[cfg(unix)]
+fn current_uid() -> u32 {
+    // SAFETY: getuid is POSIX, always succeeds, and has no preconditions.
+    #[allow(unsafe_code, reason = "getuid has no preconditions")]
+    unsafe {
+        libc::getuid()
+    }
+}
+
+enum Bound {
+    Tcp(tokio::net::TcpListener),
+    #[cfg(unix)]
+    Unix {
+        listener: tokio::net::UnixListener,
+        _guard: UnixSocketGuard,
+    },
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct UnixSocketGuard {
+    path: PathBuf,
+}
+
+#[cfg(unix)]
+impl UnixSocketGuard {
+    fn prepare(path: &Path) -> Result<Self> {
+        if let Some(parent) = path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)?;
+        }
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err.into()),
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+        })
+    }
+}
+
+#[cfg(unix)]
+impl Drop for UnixSocketGuard {
+    fn drop(&mut self) {
+        match std::fs::remove_file(&self.path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => {
+                tracing::warn!(
+                    path = %self.path.display(),
+                    error = %err,
+                    "failed to unlink unix socket"
+                );
+            }
+        }
+    }
+}
+
+pub(crate) async fn serve_listeners(
+    addrs: &[ListenAddr],
+    app: axum::Router,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> Result<()> {
+    let bound = bind_all(addrs).await?;
+    run_bound(bound, app, shutdown).await
+}
+
+async fn bind_all(addrs: &[ListenAddr]) -> Result<Vec<Bound>> {
+    let mut bound = Vec::with_capacity(addrs.len());
+    for addr in addrs {
+        bound.push(bind_one(addr).await?);
+    }
+    Ok(bound)
+}
+
+async fn bind_one(addr: &ListenAddr) -> Result<Bound> {
+    match addr {
+        ListenAddr::Tcp(tcp) => {
+            let listener = tokio::net::TcpListener::bind(tcp).await?;
+            tracing::info!(listen = %tcp, "listening");
+            Ok(Bound::Tcp(listener))
+        }
+        #[cfg(unix)]
+        ListenAddr::Unix(path) => {
+            let guard = UnixSocketGuard::prepare(path)?;
+            let listener = tokio::net::UnixListener::bind(&guard.path)?;
+            tracing::info!(listen = %addr, "listening");
+            Ok(Bound::Unix {
+                listener,
+                _guard: guard,
+            })
+        }
+    }
+}
+
+async fn run_bound(
+    bound: Vec<Bound>,
+    app: axum::Router,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> Result<()> {
+    let (stop_tx, stop_rx) = tokio::sync::watch::channel(false);
+    let mut tasks = tokio::task::JoinSet::new();
+    for item in bound {
+        let app = app.clone();
+        let stop_rx = stop_rx.clone();
+        tasks.spawn(async move { serve_one(item, app, stop_rx).await });
+    }
+    let signal_tx = stop_tx.clone();
+    tokio::spawn(async move {
+        shutdown.await;
+        notify_stop(&signal_tx);
+    });
+    join_servers(&mut tasks, &stop_tx).await
+}
+
+async fn serve_one(
+    item: Bound,
+    app: axum::Router,
+    stop_rx: tokio::sync::watch::Receiver<bool>,
+) -> io::Result<()> {
+    match item {
+        Bound::Tcp(listener) => {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(wait_stop(stop_rx))
+                .await
+        }
+        #[cfg(unix)]
+        Bound::Unix { listener, _guard } => {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(wait_stop(stop_rx))
+                .await
+        }
+    }
+}
+
+async fn wait_stop(mut rx: tokio::sync::watch::Receiver<bool>) {
+    drop(rx.wait_for(|stop| *stop).await);
+}
+
+fn notify_stop(tx: &tokio::sync::watch::Sender<bool>) {
+    tx.send_replace(true);
+}
+
+async fn join_servers(
+    tasks: &mut tokio::task::JoinSet<io::Result<()>>,
+    stop_tx: &tokio::sync::watch::Sender<bool>,
+) -> Result<()> {
+    let mut first_err = None;
+    while let Some(joined) = tasks.join_next().await {
+        match joined {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => {
+                notify_stop(stop_tx);
+                first_err.get_or_insert(err);
+            }
+            Err(join_err) => {
+                notify_stop(stop_tx);
+                first_err.get_or_insert_with(|| io::Error::other(join_err));
+            }
+        }
+    }
+    first_err.map_or(Ok(()), |err| Err(err.into()))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tcp() {
+        assert_eq!(
+            parse_listen("127.0.0.1:8080").unwrap(),
+            ListenAddr::Tcp("127.0.0.1:8080".parse().unwrap())
+        );
+        assert_eq!(
+            parse_listen("[::1]:8080").unwrap(),
+            ListenAddr::Tcp("[::1]:8080".parse().unwrap())
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn parse_unix_scheme_and_absolute() {
+        let expected = ListenAddr::Unix(PathBuf::from("/tmp/bux.sock"));
+        assert_eq!(parse_listen("unix:///tmp/bux.sock").unwrap(), expected);
+        assert_eq!(parse_listen("/tmp/bux.sock").unwrap(), expected);
+    }
+
+    #[test]
+    fn parse_rejects_relative_and_garbage() {
+        assert!(matches!(
+            parse_listen("unix://bux.sock"),
+            Err(Error::InvalidListen(_))
+        ));
+        assert!(matches!(
+            parse_listen("unix://"),
+            Err(Error::InvalidListen(_))
+        ));
+        assert!(matches!(
+            parse_listen("localhost:8080"),
+            Err(Error::InvalidListen(_))
+        ));
+        assert!(matches!(parse_listen("nope"), Err(Error::InvalidListen(_))));
+    }
+
+    #[test]
+    fn empty_specs_are_tcp_and_unix_defaults() {
+        let addrs = parse_listen_list(Vec::<&str>::new()).unwrap();
+        assert!(
+            matches!(addrs.first(), Some(ListenAddr::Tcp(a)) if a.to_string() == "127.0.0.1:8080"),
+            "{addrs:?}"
+        );
+        #[cfg(unix)]
+        assert!(
+            matches!(addrs.get(1), Some(ListenAddr::Unix(_))),
+            "{addrs:?}"
+        );
+        assert_eq!(addrs.len(), default_listen().len(), "default count");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_only_is_valid() {
+        let addrs = parse_listen_list(["unix:///tmp/only.sock"]).unwrap();
+        assert_eq!(addrs.len(), 1, "one");
+        assert!(
+            matches!(addrs.first(), Some(ListenAddr::Unix(_))),
+            "{addrs:?}"
+        );
+    }
+
+    #[test]
+    fn public_requires_tcp() {
+        #[cfg(unix)]
+        {
+            let err = resolve_listen(["unix:///tmp/x.sock"], true).unwrap_err();
+            assert!(matches!(err, Error::PublicRequiresTcp), "{err}");
+        }
+        let err = resolve_listen(["0.0.0.0:8080"], false).unwrap_err();
+        assert!(matches!(err, Error::NonLoopback(_)), "{err}");
+        resolve_listen(["0.0.0.0:8080"], true).unwrap();
+        resolve_listen(["127.0.0.1:8080"], false).unwrap();
+    }
+
+    #[test]
+    fn listen_specs_cli_wins_over_env() {
+        let cli = vec!["127.0.0.1:1".into()];
+        assert_eq!(
+            listen_specs(&cli, Some("unix:///tmp/x")),
+            vec!["127.0.0.1:1"]
+        );
+    }
+
+    #[test]
+    fn listen_specs_env_is_comma_separated() {
+        assert_eq!(
+            listen_specs(&[], Some("127.0.0.1:8080, unix:///tmp/bux.sock")),
+            vec!["127.0.0.1:8080", "unix:///tmp/bux.sock"]
+        );
+        assert!(listen_specs(&[], None).is_empty(), "empty");
+        assert!(listen_specs(&[], Some("")).is_empty(), "blank env");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn default_unix_path_xdg_then_tmp_uid() {
+        use std::ffi::OsStr;
+        assert_eq!(
+            default_unix_path_from(Some(OsStr::new("/run/user/1000")), 1000),
+            PathBuf::from("/run/user/1000/bux.sock")
+        );
+        assert_eq!(
+            default_unix_path_from(None, 501),
+            PathBuf::from("/tmp/bux-501.sock")
+        );
+        assert_eq!(
+            default_unix_path_from(Some(OsStr::new("")), 7),
+            PathBuf::from("/tmp/bux-7.sock")
+        );
+    }
+}

--- a/crates/bux-serve/src/listen.rs
+++ b/crates/bux-serve/src/listen.rs
@@ -4,6 +4,8 @@ use std::fmt;
 use std::future::Future;
 use std::io;
 use std::net::SocketAddr;
+#[cfg(unix)]
+use std::os::fd::{AsFd, OwnedFd};
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
@@ -166,15 +168,22 @@ struct UnixSocketGuard {
     path: PathBuf,
     dev: u64,
     ino: u64,
+    #[allow(dead_code, reason = "cloned fd keeps the bind inode alive")]
+    _pin: OwnedFd,
 }
 
 #[cfg(unix)]
 impl UnixSocketGuard {
-    fn from_bound(path: PathBuf) -> Result<Self> {
-        // Darwin fstat() on a unix socket fd is not the bind-path inode
-        // (`st_dev` is -1). Identify the name by lstat after bind.
+    fn from_bound(path: PathBuf, fd: impl AsFd) -> Result<Self> {
+        // Darwin fstat on the listener fd is not the bind-path inode
+        // (`st_dev` is -1). Pin only stops Linux from reusing the inode.
         let (dev, ino) = path_dev_ino(&path)?;
-        Ok(Self { path, dev, ino })
+        Ok(Self {
+            path,
+            dev,
+            ino,
+            _pin: fd.as_fd().try_clone_to_owned()?,
+        })
     }
 }
 
@@ -228,7 +237,7 @@ fn path_dev_ino(path: &Path) -> io::Result<(u64, u64)> {
 fn bind_unix(path: &Path) -> Result<Bound> {
     prepare_unix_path(path)?;
     let listener = tokio::net::UnixListener::bind(path)?;
-    match UnixSocketGuard::from_bound(path.to_path_buf()) {
+    match UnixSocketGuard::from_bound(path.to_path_buf(), &listener) {
         Ok(guard) => Ok(Bound::Unix {
             listener,
             _guard: guard,
@@ -479,7 +488,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("s");
         let listener = UnixListener::bind(&path).unwrap();
-        let guard = UnixSocketGuard::from_bound(path.clone()).unwrap();
+        let guard = UnixSocketGuard::from_bound(path.clone(), &listener).unwrap();
         drop(guard);
         assert!(!path.exists(), "own name unlinked");
         drop(listener);
@@ -492,7 +501,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("s");
         let first = UnixListener::bind(&path).unwrap();
-        let guard = UnixSocketGuard::from_bound(path.clone()).unwrap();
+        let guard = UnixSocketGuard::from_bound(path.clone(), &first).unwrap();
         drop(first);
         std::fs::remove_file(&path).unwrap();
         let second = UnixListener::bind(&path).unwrap();

--- a/crates/bux-serve/src/logs.rs
+++ b/crates/bux-serve/src/logs.rs
@@ -1,0 +1,245 @@
+//! `GET /v1/sandboxes/{id}/logs` — shim stderr at [`bux::Vm::log_path`].
+
+use std::io;
+
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::routing::get;
+use bux::Vm;
+
+use crate::auth::Tenant;
+use crate::error::ApiError;
+use crate::sandboxes::load_owned;
+use crate::state::AppState;
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new().route("/v1/sandboxes/{id}/logs", get(logs_one))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/sandboxes/{id}/logs",
+    operation_id = "getSandboxLogs",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    responses(
+        (status = 200, description = "Shim stderr ({socks}/{id}.stderr)", content_type = "text/plain", body = String),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant")
+    )
+)]
+pub(crate) async fn logs_one(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+) -> Result<String, ApiError> {
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    read_stderr(&vm)
+}
+
+fn read_stderr(vm: &Vm) -> Result<String, ApiError> {
+    match std::fs::read(vm.log_path()) {
+        Ok(bytes) => Ok(String::from_utf8_lossy(&bytes).into_owned()),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(String::new()),
+        Err(err) => Err(ApiError::from_engine(err.into())),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::{Request, StatusCode};
+    use rusqlite::params;
+    use tower::ServiceExt;
+
+    use crate::ApiKey;
+    use crate::router::router;
+    use crate::state::Limits;
+
+    struct Harness {
+        dir: tempfile::TempDir,
+        runtime: Arc<bux::Runtime>,
+        app: Router,
+    }
+
+    fn harness() -> Harness {
+        let dir = tempfile::tempdir().unwrap();
+        let opened = bux::Runtime::open(dir.path()).unwrap();
+        let state = AppState::new(
+            vec![
+                ApiKey::new("tenant1", "secret1").unwrap(),
+                ApiKey::new("tenant2", "secret2").unwrap(),
+            ],
+            opened,
+            Limits::default(),
+        );
+        let runtime = Arc::clone(&state.runtime);
+        let app = router(state);
+        Harness { dir, runtime, app }
+    }
+
+    async fn json_body(res: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn text_body(res: axum::response::Response) -> String {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        String::from_utf8(bytes.to_vec()).expect("utf-8")
+    }
+
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        token: Option<&str>,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        app.oneshot(builder.body(Body::empty()).unwrap())
+            .await
+            .unwrap()
+    }
+
+    fn plant_vm(data_dir: &Path, id: &str, tenant: &str, agent: &str) {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        drop(child.wait());
+        let socket = data_dir.join("socks").join(format!("{id}.sock"));
+        let conn = rusqlite::Connection::open(data_dir.join("bux.db")).unwrap();
+        conn.busy_timeout(Duration::from_secs(5)).unwrap();
+        let config = serde_json::json!({
+            "vcpus": 1,
+            "ram_mib": 512,
+            "tenant_id": tenant,
+            "agent_id": agent,
+        });
+        conn.execute(
+            "INSERT INTO vms (id, name, pid, image, socket, status, config, created_at)
+             VALUES (?1, ?2, ?3, NULL, ?4, 'stopped', ?5, 0)",
+            params![
+                id,
+                format!("a-{tenant}-{agent}"),
+                pid,
+                socket.to_str().expect("utf-8"),
+                config.to_string(),
+            ],
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn logs_without_bearer_is_401() {
+        let h = harness();
+        let res = send(h.app, "GET", "/v1/sandboxes/0123456789ab/logs", None).await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("unauthorized"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn logs_missing_is_404() {
+        let h = harness();
+        let res = send(
+            h.app,
+            "GET",
+            "/v1/sandboxes/0123456789ab/logs",
+            Some("secret1"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "missing");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("not_found"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn logs_other_tenant_is_404_same_as_missing() {
+        const ID: &str = "abc123aaa020";
+        let h = harness();
+        plant_vm(h.dir.path(), ID, "tenant1", "a1");
+        let missing = send(
+            h.app.clone(),
+            "GET",
+            "/v1/sandboxes/ffffffffffff/logs",
+            Some("secret2"),
+        )
+        .await;
+        let other = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{ID}/logs"),
+            Some("secret2"),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND, "missing");
+        assert_eq!(other.status(), StatusCode::NOT_FOUND, "other tenant");
+        assert_eq!(json_body(missing).await, json_body(other).await, "envelope");
+    }
+
+    #[tokio::test]
+    async fn logs_returns_engine_stderr_file() {
+        const ID: &str = "abc123aaa021";
+        let h = harness();
+        plant_vm(h.dir.path(), ID, "tenant1", "a1");
+        let vm = h.runtime.get_exact(ID).unwrap();
+        std::fs::write(vm.log_path(), "shim says hi\n").unwrap();
+        let res = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{ID}/logs"),
+            Some("secret1"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK, "owner");
+        assert_eq!(text_body(res).await, "shim says hi\n", "stderr");
+    }
+
+    #[tokio::test]
+    async fn logs_missing_file_is_empty_200() {
+        const ID: &str = "abc123aaa022";
+        let h = harness();
+        plant_vm(h.dir.path(), ID, "tenant1", "a1");
+        let res = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{ID}/logs"),
+            Some("secret1"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK, "no file yet");
+        assert_eq!(text_body(res).await, "", "empty");
+    }
+
+    #[test]
+    fn production_uses_engine_log_path() {
+        let prod = include_str!("logs.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(prod.contains("log_path"), "Vm::log_path");
+        assert!(prod.contains("from_utf8_lossy"), "lossy utf-8");
+        assert!(prod.contains("ErrorKind::NotFound"), "missing file");
+    }
+}

--- a/crates/bux-serve/src/openapi.rs
+++ b/crates/bux-serve/src/openapi.rs
@@ -7,6 +7,7 @@ use crate::exec::{ExecRequest, ExecResponse};
 use crate::images::{ImageInfoBody, PullRequest};
 use crate::router::{MeBody, MetricsBody};
 use crate::sandboxes::{CreateRequest, SandboxBody};
+use crate::snapshots::{AgentRequest, CreateSnapshotRequest, SnapshotBody};
 use crate::state::Limits;
 
 struct BearerAuth;
@@ -49,6 +50,11 @@ impl Modify for BearerAuth {
         crate::images::list_images,
         crate::images::pull_image,
         crate::images::delete_image,
+        crate::snapshots::list_snapshots,
+        crate::snapshots::create_snapshot,
+        crate::snapshots::delete_snapshot,
+        crate::snapshots::restore_snapshot,
+        crate::snapshots::clone_one,
     ),
     components(schemas(
         Limits,
@@ -60,6 +66,9 @@ impl Modify for BearerAuth {
         ExecResponse,
         PullRequest,
         ImageInfoBody,
+        CreateSnapshotRequest,
+        AgentRequest,
+        SnapshotBody,
     )),
     tags(
         (name = "Worker", description = "Health, config, identity, metrics"),

--- a/crates/bux-serve/src/openapi.rs
+++ b/crates/bux-serve/src/openapi.rs
@@ -1,0 +1,88 @@
+//! OpenAPI document from handler `#[utoipa::path]` annotations.
+
+use utoipa::openapi::security::{HttpAuthScheme, HttpBuilder, SecurityScheme};
+use utoipa::{Modify, OpenApi};
+
+use crate::exec::{ExecRequest, ExecResponse};
+use crate::images::{ImageInfoBody, PullRequest};
+use crate::router::{MeBody, MetricsBody};
+use crate::sandboxes::{CreateRequest, SandboxBody};
+use crate::state::Limits;
+
+struct BearerAuth;
+
+impl Modify for BearerAuth {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components = openapi
+            .components
+            .get_or_insert_with(utoipa::openapi::Components::new);
+        components.add_security_scheme(
+            "bearer",
+            SecurityScheme::Http(HttpBuilder::new().scheme(HttpAuthScheme::Bearer).build()),
+        );
+    }
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "bux",
+        version = env!("CARGO_PKG_VERSION"),
+        description = "Hosted agent sandbox HTTP API"
+    ),
+    modifiers(&BearerAuth),
+    security(("bearer" = [])),
+    paths(
+        crate::router::health,
+        crate::router::config,
+        crate::router::me,
+        crate::router::metrics,
+        crate::sandboxes::list,
+        crate::sandboxes::create,
+        crate::sandboxes::get_one,
+        crate::sandboxes::delete_one,
+        crate::sandboxes::start_one,
+        crate::logs::logs_one,
+        crate::exec::exec_one,
+        crate::files::get_file,
+        crate::files::put_file,
+        crate::images::list_images,
+        crate::images::pull_image,
+        crate::images::delete_image,
+    ),
+    components(schemas(
+        Limits,
+        MeBody,
+        MetricsBody,
+        CreateRequest,
+        SandboxBody,
+        ExecRequest,
+        ExecResponse,
+        PullRequest,
+        ImageInfoBody,
+    )),
+    tags(
+        (name = "Worker", description = "Health, config, identity, metrics"),
+        (name = "Sandboxes", description = "Per-agent VM lifecycle and logs"),
+        (name = "Exec", description = "Collect-only exec"),
+        (name = "Files", description = "Single-file PUT/GET"),
+        (name = "Images", description = "Worker-global OCI images"),
+    )
+)]
+struct ApiDoc;
+
+/// Serialize the OpenAPI document as pretty JSON.
+///
+/// # Panics
+///
+/// Panics if the generated document cannot be serialized (a utoipa bug).
+#[must_use]
+#[allow(
+    clippy::expect_used,
+    reason = "OpenAPI types are always JSON-serializable"
+)]
+pub fn openapi_json() -> String {
+    ApiDoc::openapi()
+        .to_pretty_json()
+        .expect("openapi serialize")
+}

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -1,0 +1,257 @@
+//! HTTP router: public health, Bearer-protected stubs.
+
+use std::sync::Arc;
+
+use axum::extract::{DefaultBodyLimit, Request, State};
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderMap, StatusCode};
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use tower::ServiceBuilder;
+use tower_http::limit::RequestBodyLimitLayer;
+use tower_http::trace::TraceLayer;
+
+use crate::ApiKey;
+use crate::error::ApiError;
+
+/// JSON and default request body cap.
+pub(crate) const MAX_JSON_BODY_BYTES: usize = 1024 * 1024;
+
+#[derive(Clone, Debug)]
+pub(crate) struct AppState {
+    keys: Arc<[ApiKey]>,
+}
+
+impl AppState {
+    pub(crate) fn new(keys: Vec<ApiKey>) -> Self {
+        Self { keys: keys.into() }
+    }
+
+    fn tenant_for_bearer(&self, token: &str) -> Option<&str> {
+        let token = token.as_bytes();
+        let mut found = None;
+        for key in self.keys.iter() {
+            if constant_time_eq(key.secret_bytes(), token) {
+                found = Some(key.id());
+            }
+        }
+        found
+    }
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let mut acc = u8::from(left.len() != right.len());
+    for (a, b) in left.iter().zip(right.iter()) {
+        acc |= a ^ b;
+    }
+    acc == 0
+}
+
+pub(crate) fn router(state: AppState) -> Router {
+    let protected =
+        Router::new()
+            .route("/v1/config", get(config))
+            .route_layer(middleware::from_fn_with_state(
+                state.clone(),
+                require_bearer,
+            ));
+
+    Router::new()
+        .route("/v1/health", get(health))
+        .merge(protected)
+        .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
+        .layer(
+            ServiceBuilder::new()
+                .layer(TraceLayer::new_for_http())
+                .layer(RequestBodyLimitLayer::new(MAX_JSON_BODY_BYTES)),
+        )
+        .layer(middleware::map_response(map_payload_too_large))
+        .with_state(state)
+}
+
+async fn health() -> StatusCode {
+    StatusCode::OK
+}
+
+async fn config() -> Json<serde_json::Value> {
+    Json(serde_json::json!({}))
+}
+
+async fn require_bearer(
+    State(state): State<AppState>,
+    req: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    let token = bearer_token(req.headers()).ok_or_else(ApiError::unauthorized)?;
+    if state.tenant_for_bearer(token).is_none() {
+        return Err(ApiError::unauthorized());
+    }
+    Ok(next.run(req).await)
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    let value = headers.get(AUTHORIZATION)?.to_str().ok()?;
+    let (scheme, rest) = value.split_once(' ')?;
+    if scheme.eq_ignore_ascii_case("bearer") && !rest.is_empty() {
+        Some(rest)
+    } else {
+        None
+    }
+}
+
+async fn map_payload_too_large(response: Response) -> Response {
+    if response.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        ApiError::payload_too_large().into_response()
+    } else {
+        response
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+    use tower::ServiceExt;
+
+    fn sample_state() -> AppState {
+        AppState::new(vec![ApiKey::new("tenant1", "secret1").unwrap()])
+    }
+
+    async fn json_body(res: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    #[tokio::test]
+    async fn health_is_public() {
+        let app = router(sample_state());
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "health");
+    }
+
+    #[tokio::test]
+    async fn config_without_bearer_is_401_envelope() {
+        let app = router(sample_state());
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/config")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("unauthorized"),
+            "code"
+        );
+        assert!(
+            v.pointer("/error/message")
+                .and_then(serde_json::Value::as_str)
+                .is_some(),
+            "message"
+        );
+    }
+
+    #[tokio::test]
+    async fn config_with_bearer_is_200() {
+        let app = router(sample_state());
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/config")
+                    .header(AUTHORIZATION, "Bearer secret1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "config");
+    }
+
+    #[tokio::test]
+    async fn config_wrong_secret_is_401() {
+        let app = router(sample_state());
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/config")
+                    .header(AUTHORIZATION, "Bearer nope")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "wrong secret");
+    }
+
+    #[tokio::test]
+    async fn bearer_matches_any_key() {
+        let app = router(AppState::new(vec![
+            ApiKey::new("a", "one").unwrap(),
+            ApiKey::new("b", "two").unwrap(),
+        ]));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/config")
+                    .header(AUTHORIZATION, "Bearer two")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "second key");
+    }
+
+    #[tokio::test]
+    async fn body_over_1mib_is_413_envelope() {
+        let app = router(sample_state());
+        let len = MAX_JSON_BODY_BYTES.saturating_add(1);
+        let body = vec![0_u8; len];
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/config")
+                    .header(AUTHORIZATION, "Bearer secret1")
+                    .header("content-length", len.to_string())
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE, "limit");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("payload_too_large"),
+            "code"
+        );
+    }
+
+    #[test]
+    fn constant_time_eq_cases() {
+        assert!(constant_time_eq(b"abc", b"abc"), "eq");
+        assert!(!constant_time_eq(b"abc", b"abd"), "neq");
+        assert!(!constant_time_eq(b"abc", b"ab"), "len");
+        assert!(constant_time_eq(b"", b""), "empty");
+    }
+}

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -1,4 +1,4 @@
-//! HTTP router: public health, Bearer-protected me/config/metrics, sandboxes, exec, files, images.
+//! HTTP router: public health, Bearer-protected me/config/metrics, sandboxes, exec, files, images, logs, snapshots.
 
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
@@ -15,7 +15,7 @@ use utoipa::ToSchema;
 use crate::auth::{Tenant, require_bearer};
 use crate::error::ApiError;
 use crate::state::{AppState, Limits};
-use crate::{exec, files, images, logs, sandboxes};
+use crate::{exec, files, images, logs, sandboxes, snapshots};
 
 /// JSON request body cap.
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 1024 * 1024;
@@ -29,6 +29,7 @@ pub(crate) fn router(state: AppState) -> Router {
         .merge(sandboxes::routes())
         .merge(exec::routes())
         .merge(logs::routes())
+        .merge(snapshots::routes())
         .merge(images::routes())
         .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
         .layer(RequestBodyLimitLayer::new(MAX_JSON_BODY_BYTES));
@@ -413,6 +414,7 @@ mod tests {
         assert!(prod.contains("images::routes"), "images routes");
         assert!(prod.contains("logs::routes"), "logs routes");
         assert!(prod.contains("/v1/metrics"), "metrics");
+        assert!(prod.contains("snapshots::routes"), "snapshot routes");
         assert!(prod.contains("MAX_FILE_BODY_BYTES"), "files body limit");
     }
 

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -1,4 +1,4 @@
-//! HTTP router: public health, Bearer-protected me/config, sandboxes, exec, files, images.
+//! HTTP router: public health, Bearer-protected me/config/metrics, sandboxes, exec, files, images.
 
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
@@ -10,11 +10,12 @@ use serde::Serialize;
 use tower::ServiceBuilder;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
+use utoipa::ToSchema;
 
 use crate::auth::{Tenant, require_bearer};
 use crate::error::ApiError;
 use crate::state::{AppState, Limits};
-use crate::{exec, files, images, sandboxes};
+use crate::{exec, files, images, logs, sandboxes};
 
 /// JSON request body cap.
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 1024 * 1024;
@@ -24,8 +25,10 @@ pub(crate) fn router(state: AppState) -> Router {
     let json = Router::new()
         .route("/v1/config", get(config))
         .route("/v1/me", get(me))
+        .route("/v1/metrics", get(metrics))
         .merge(sandboxes::routes())
         .merge(exec::routes())
+        .merge(logs::routes())
         .merge(images::routes())
         .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
         .layer(RequestBodyLimitLayer::new(MAX_JSON_BODY_BYTES));
@@ -49,25 +52,89 @@ pub(crate) fn router(state: AppState) -> Router {
         .with_state(state)
 }
 
-async fn health() -> StatusCode {
+#[utoipa::path(
+    get,
+    path = "/v1/health",
+    operation_id = "health",
+    tag = "Worker",
+    responses((status = 200, description = "Worker is up")),
+    security(())
+)]
+pub(crate) async fn health() -> StatusCode {
     StatusCode::OK
 }
 
-async fn config(State(state): State<AppState>) -> Json<Limits> {
+#[utoipa::path(
+    get,
+    path = "/v1/config",
+    operation_id = "config",
+    tag = "Worker",
+    responses(
+        (status = 200, description = "Worker config", body = Limits),
+        (status = 401, description = "Missing or invalid Bearer token")
+    )
+)]
+pub(crate) async fn config(State(state): State<AppState>) -> Json<Limits> {
     Json(state.limits)
 }
 
-#[derive(Debug, Serialize)]
-struct MeBody {
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct MeBody {
     tenant_id: String,
     max_sandboxes: u32,
 }
 
-async fn me(State(state): State<AppState>, tenant: Tenant) -> Json<MeBody> {
+#[utoipa::path(
+    get,
+    path = "/v1/me",
+    operation_id = "me",
+    tag = "Worker",
+    responses(
+        (status = 200, description = "Bearer tenant_id and max_sandboxes", body = MeBody),
+        (status = 401, description = "Missing or invalid Bearer token")
+    )
+)]
+pub(crate) async fn me(State(state): State<AppState>, tenant: Tenant) -> Json<MeBody> {
     Json(MeBody {
         tenant_id: tenant.id,
         max_sandboxes: state.limits.max_sandboxes,
     })
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct MetricsBody {
+    vms_created_total: u64,
+    num_running_vms: i64,
+    vms_failed_total: u64,
+    total_uptime_ms: u64,
+    disk_bytes_used: u64,
+    data_dir_bytes: u64,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/metrics",
+    operation_id = "metrics",
+    tag = "Worker",
+    responses(
+        (status = 200, description = "RuntimeMetrics getters plus data_dir_bytes", body = MetricsBody),
+        (status = 401, description = "Missing or invalid Bearer token")
+    )
+)]
+pub(crate) async fn metrics(State(state): State<AppState>) -> Result<Json<MetricsBody>, ApiError> {
+    let m = state.runtime.metrics();
+    let data_dir_bytes = state
+        .runtime
+        .data_dir_usage()
+        .map_err(|e| ApiError::from_engine(e.into()))?;
+    Ok(Json(MetricsBody {
+        vms_created_total: m.vms_created_total(),
+        num_running_vms: m.num_running_vms(),
+        vms_failed_total: m.vms_failed_total(),
+        total_uptime_ms: m.total_uptime_ms(),
+        disk_bytes_used: m.disk_bytes_used(),
+        data_dir_bytes,
+    }))
 }
 
 async fn map_payload_too_large(response: Response) -> Response {
@@ -344,6 +411,116 @@ mod tests {
         assert!(prod.contains("files::routes"), "files routes");
         assert!(prod.contains("exec::routes"), "exec routes");
         assert!(prod.contains("images::routes"), "images routes");
+        assert!(prod.contains("logs::routes"), "logs routes");
+        assert!(prod.contains("/v1/metrics"), "metrics");
         assert!(prod.contains("MAX_FILE_BODY_BYTES"), "files body limit");
+    }
+
+    #[tokio::test]
+    async fn metrics_without_bearer_is_401() {
+        let (_dir, app) = sample_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("unauthorized"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn metrics_is_worker_global_with_data_dir_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let data_dir_bytes = runtime.data_dir_usage().unwrap();
+        let disk_bytes_used = runtime.metrics().disk_bytes_used();
+        let overlays = runtime.disk_usage().unwrap();
+        assert!(
+            data_dir_bytes > overlays,
+            "data_dir_usage={data_dir_bytes} must exceed disk_usage={overlays}"
+        );
+        let app = router(AppState::new(
+            vec![
+                ApiKey::new("a", "one").unwrap(),
+                ApiKey::new("b", "two").unwrap(),
+            ],
+            runtime,
+            Limits::default(),
+        ));
+        let a = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/metrics")
+                    .header(AUTHORIZATION, "Bearer one")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let b = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/metrics")
+                    .header(AUTHORIZATION, "Bearer two")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(a.status(), StatusCode::OK, "first key");
+        assert_eq!(b.status(), StatusCode::OK, "second key");
+        let va = json_body(a).await;
+        let vb = json_body(b).await;
+        assert_eq!(va, vb, "worker-global");
+        assert_eq!(va.as_object().map(serde_json::Map::len), Some(6), "keys");
+        assert_eq!(
+            va.get("data_dir_bytes").and_then(serde_json::Value::as_u64),
+            Some(data_dir_bytes),
+            "admission gauge"
+        );
+        assert_eq!(
+            va.get("disk_bytes_used")
+                .and_then(serde_json::Value::as_u64),
+            Some(disk_bytes_used),
+            "overlays+bases gauge"
+        );
+        assert_ne!(
+            data_dir_bytes, disk_bytes_used,
+            "data_dir_bytes is not disk_bytes_used"
+        );
+        assert_eq!(
+            va.get("vms_created_total")
+                .and_then(serde_json::Value::as_u64),
+            Some(0),
+            "vms_created_total"
+        );
+        assert_eq!(
+            va.get("num_running_vms")
+                .and_then(serde_json::Value::as_i64),
+            Some(0),
+            "num_running_vms"
+        );
+        assert_eq!(
+            va.get("vms_failed_total")
+                .and_then(serde_json::Value::as_u64),
+            Some(0),
+            "vms_failed_total"
+        );
+        assert_eq!(
+            va.get("total_uptime_ms")
+                .and_then(serde_json::Value::as_u64),
+            Some(0),
+            "total_uptime_ms"
+        );
     }
 }

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -17,8 +17,7 @@ use crate::{exec, files, images, sandboxes};
 
 /// JSON request body cap.
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 1024 * 1024;
-/// Files PUT body cap.
-pub(crate) const MAX_FILE_BODY_BYTES: usize = 32 * 1024 * 1024;
+pub(crate) use crate::files::MAX_FILE_BODY_BYTES;
 
 pub(crate) fn router(state: AppState) -> Router {
     let json = Router::new()

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -41,10 +41,14 @@ impl AppState {
     }
 }
 
+/// Pad to at least this many bytes so unequal lengths are not a `zip` min-len oracle.
+const CT_EQ_MIN_ITERS: usize = 256;
+
 fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
     let mut acc = u8::from(left.len() != right.len());
-    for (a, b) in left.iter().zip(right.iter()) {
-        acc |= a ^ b;
+    let n = left.len().max(right.len()).max(CT_EQ_MIN_ITERS);
+    for i in 0..n {
+        acc |= left.get(i).copied().unwrap_or(0) ^ right.get(i).copied().unwrap_or(0);
     }
     acc == 0
 }
@@ -200,6 +204,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "wrong secret");
+    }
+
+    #[test]
+    fn tenant_for_bearer_last_match_wins() {
+        let state = AppState::new(vec![
+            ApiKey::new("first", "shared").unwrap(),
+            ApiKey::new("second", "shared").unwrap(),
+        ]);
+        assert_eq!(
+            state.tenant_for_bearer("shared"),
+            Some("second"),
+            "must walk every key"
+        );
     }
 
     #[tokio::test]

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -1,11 +1,8 @@
-//! HTTP router: public health, Bearer-protected stubs.
+//! HTTP router: public health, Bearer-protected config and sandboxes.
 
-use std::sync::Arc;
-
-use axum::extract::{DefaultBodyLimit, Request, State};
-use axum::http::header::AUTHORIZATION;
-use axum::http::{HeaderMap, StatusCode};
-use axum::middleware::{self, Next};
+use axum::extract::{DefaultBodyLimit, State};
+use axum::http::StatusCode;
+use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
@@ -13,54 +10,22 @@ use tower::ServiceBuilder;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 
-use crate::ApiKey;
+use crate::auth::require_bearer;
 use crate::error::ApiError;
+use crate::sandboxes;
+use crate::state::{AppState, Limits};
 
 /// JSON and default request body cap.
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 1024 * 1024;
 
-#[derive(Clone, Debug)]
-pub(crate) struct AppState {
-    keys: Arc<[ApiKey]>,
-}
-
-impl AppState {
-    pub(crate) fn new(keys: Vec<ApiKey>) -> Self {
-        Self { keys: keys.into() }
-    }
-
-    fn tenant_for_bearer(&self, token: &str) -> Option<&str> {
-        let token = token.as_bytes();
-        let mut found = None;
-        for key in self.keys.iter() {
-            if constant_time_eq(key.secret_bytes(), token) {
-                found = Some(key.id());
-            }
-        }
-        found
-    }
-}
-
-/// Pad to at least this many bytes so unequal lengths are not a `zip` min-len oracle.
-const CT_EQ_MIN_ITERS: usize = 256;
-
-fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
-    let mut acc = u8::from(left.len() != right.len());
-    let n = left.len().max(right.len()).max(CT_EQ_MIN_ITERS);
-    for i in 0..n {
-        acc |= left.get(i).copied().unwrap_or(0) ^ right.get(i).copied().unwrap_or(0);
-    }
-    acc == 0
-}
-
 pub(crate) fn router(state: AppState) -> Router {
-    let protected =
-        Router::new()
-            .route("/v1/config", get(config))
-            .route_layer(middleware::from_fn_with_state(
-                state.clone(),
-                require_bearer,
-            ));
+    let protected = Router::new()
+        .route("/v1/config", get(config))
+        .merge(sandboxes::routes())
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_bearer,
+        ));
 
     Router::new()
         .route("/v1/health", get(health))
@@ -79,30 +44,8 @@ async fn health() -> StatusCode {
     StatusCode::OK
 }
 
-async fn config() -> Json<serde_json::Value> {
-    Json(serde_json::json!({}))
-}
-
-async fn require_bearer(
-    State(state): State<AppState>,
-    req: Request,
-    next: Next,
-) -> Result<Response, ApiError> {
-    let token = bearer_token(req.headers()).ok_or_else(ApiError::unauthorized)?;
-    if state.tenant_for_bearer(token).is_none() {
-        return Err(ApiError::unauthorized());
-    }
-    Ok(next.run(req).await)
-}
-
-fn bearer_token(headers: &HeaderMap) -> Option<&str> {
-    let value = headers.get(AUTHORIZATION)?.to_str().ok()?;
-    let (scheme, rest) = value.split_once(' ')?;
-    if scheme.eq_ignore_ascii_case("bearer") && !rest.is_empty() {
-        Some(rest)
-    } else {
-        None
-    }
+async fn config(State(state): State<AppState>) -> Json<Limits> {
+    Json(state.limits)
 }
 
 async fn map_payload_too_large(response: Response) -> Response {
@@ -119,10 +62,20 @@ mod tests {
     use super::*;
     use axum::body::Body;
     use axum::http::Request;
+    use axum::http::header::AUTHORIZATION;
     use tower::ServiceExt;
 
-    fn sample_state() -> AppState {
-        AppState::new(vec![ApiKey::new("tenant1", "secret1").unwrap()])
+    use crate::ApiKey;
+
+    fn sample_app() -> (tempfile::TempDir, Router) {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let state = AppState::new(
+            vec![ApiKey::new("tenant1", "secret1").unwrap()],
+            runtime,
+            Limits::default(),
+        );
+        (dir, router(state))
     }
 
     async fn json_body(res: Response) -> serde_json::Value {
@@ -134,7 +87,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_is_public() {
-        let app = router(sample_state());
+        let (_dir, app) = sample_app();
         let res = app
             .oneshot(
                 Request::builder()
@@ -149,7 +102,7 @@ mod tests {
 
     #[tokio::test]
     async fn config_without_bearer_is_401_envelope() {
-        let app = router(sample_state());
+        let (_dir, app) = sample_app();
         let res = app
             .oneshot(
                 Request::builder()
@@ -175,8 +128,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn config_with_bearer_is_200() {
-        let app = router(sample_state());
+    async fn config_with_bearer_is_200_limits() {
+        let (_dir, app) = sample_app();
         let res = app
             .oneshot(
                 Request::builder()
@@ -188,11 +141,22 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(res.status(), StatusCode::OK, "config");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.get("max_sandboxes").and_then(serde_json::Value::as_u64),
+            Some(32),
+            "max_sandboxes"
+        );
+        assert_eq!(
+            v.get("max_ram_mib").and_then(serde_json::Value::as_u64),
+            Some(2048),
+            "max_ram_mib"
+        );
     }
 
     #[tokio::test]
     async fn config_wrong_secret_is_401() {
-        let app = router(sample_state());
+        let (_dir, app) = sample_app();
         let res = app
             .oneshot(
                 Request::builder()
@@ -206,25 +170,18 @@ mod tests {
         assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "wrong secret");
     }
 
-    #[test]
-    fn tenant_for_bearer_last_match_wins() {
-        let state = AppState::new(vec![
-            ApiKey::new("first", "shared").unwrap(),
-            ApiKey::new("second", "shared").unwrap(),
-        ]);
-        assert_eq!(
-            state.tenant_for_bearer("shared"),
-            Some("second"),
-            "must walk every key"
-        );
-    }
-
     #[tokio::test]
     async fn bearer_matches_any_key() {
-        let app = router(AppState::new(vec![
-            ApiKey::new("a", "one").unwrap(),
-            ApiKey::new("b", "two").unwrap(),
-        ]));
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let app = router(AppState::new(
+            vec![
+                ApiKey::new("a", "one").unwrap(),
+                ApiKey::new("b", "two").unwrap(),
+            ],
+            runtime,
+            Limits::default(),
+        ));
         let res = app
             .oneshot(
                 Request::builder()
@@ -240,7 +197,7 @@ mod tests {
 
     #[tokio::test]
     async fn body_over_1mib_is_413_envelope() {
-        let app = router(sample_state());
+        let (_dir, app) = sample_app();
         let len = MAX_JSON_BODY_BYTES.saturating_add(1);
         let body = vec![0_u8; len];
         let res = app
@@ -262,13 +219,5 @@ mod tests {
             Some("payload_too_large"),
             "code"
         );
-    }
-
-    #[test]
-    fn constant_time_eq_cases() {
-        assert!(constant_time_eq(b"abc", b"abc"), "eq");
-        assert!(!constant_time_eq(b"abc", b"abd"), "neq");
-        assert!(!constant_time_eq(b"abc", b"ab"), "len");
-        assert!(constant_time_eq(b"", b""), "empty");
     }
 }

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -1,4 +1,4 @@
-//! HTTP router: public health, Bearer-protected config and sandboxes.
+//! HTTP router: public health, Bearer-protected config, sandboxes, exec, files, images.
 
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
@@ -12,16 +12,29 @@ use tower_http::trace::TraceLayer;
 
 use crate::auth::require_bearer;
 use crate::error::ApiError;
-use crate::sandboxes;
 use crate::state::{AppState, Limits};
+use crate::{exec, files, images, sandboxes};
 
-/// JSON and default request body cap.
+/// JSON request body cap.
 pub(crate) const MAX_JSON_BODY_BYTES: usize = 1024 * 1024;
+/// Files PUT body cap.
+pub(crate) const MAX_FILE_BODY_BYTES: usize = 32 * 1024 * 1024;
 
 pub(crate) fn router(state: AppState) -> Router {
-    let protected = Router::new()
+    let json = Router::new()
         .route("/v1/config", get(config))
         .merge(sandboxes::routes())
+        .merge(exec::routes())
+        .merge(images::routes())
+        .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
+        .layer(RequestBodyLimitLayer::new(MAX_JSON_BODY_BYTES));
+
+    let files = files::routes()
+        .layer(DefaultBodyLimit::max(MAX_FILE_BODY_BYTES))
+        .layer(RequestBodyLimitLayer::new(MAX_FILE_BODY_BYTES));
+
+    let protected = json
+        .merge(files)
         .route_layer(middleware::from_fn_with_state(
             state.clone(),
             require_bearer,
@@ -30,12 +43,7 @@ pub(crate) fn router(state: AppState) -> Router {
     Router::new()
         .route("/v1/health", get(health))
         .merge(protected)
-        .layer(DefaultBodyLimit::max(MAX_JSON_BODY_BYTES))
-        .layer(
-            ServiceBuilder::new()
-                .layer(TraceLayer::new_for_http())
-                .layer(RequestBodyLimitLayer::new(MAX_JSON_BODY_BYTES)),
-        )
+        .layer(ServiceBuilder::new().layer(TraceLayer::new_for_http()))
         .layer(middleware::map_response(map_payload_too_large))
         .with_state(state)
 }
@@ -152,6 +160,17 @@ mod tests {
             Some(2048),
             "max_ram_mib"
         );
+        assert_eq!(
+            v.get("max_exec_output_bytes")
+                .and_then(serde_json::Value::as_u64),
+            Some(1024 * 1024),
+            "max_exec_output_bytes"
+        );
+        assert_eq!(
+            v.get("max_pull_bytes").and_then(serde_json::Value::as_u64),
+            Some(4_u64 * 1024 * 1024 * 1024),
+            "max_pull_bytes"
+        );
     }
 
     #[tokio::test]
@@ -219,5 +238,19 @@ mod tests {
             Some("payload_too_large"),
             "code"
         );
+    }
+
+    #[test]
+    fn files_limit_is_32mib_and_json_is_1mib() {
+        assert_eq!(MAX_JSON_BODY_BYTES, 1024 * 1024, "json");
+        assert_eq!(MAX_FILE_BODY_BYTES, 32 * 1024 * 1024, "files");
+        let prod = include_str!("router.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(prod.contains("files::routes"), "files routes");
+        assert!(prod.contains("exec::routes"), "exec routes");
+        assert!(prod.contains("images::routes"), "images routes");
+        assert!(prod.contains("MAX_FILE_BODY_BYTES"), "files body limit");
     }
 }

--- a/crates/bux-serve/src/router.rs
+++ b/crates/bux-serve/src/router.rs
@@ -1,4 +1,4 @@
-//! HTTP router: public health, Bearer-protected config, sandboxes, exec, files, images.
+//! HTTP router: public health, Bearer-protected me/config, sandboxes, exec, files, images.
 
 use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
@@ -6,11 +6,12 @@ use axum::middleware;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use axum::{Json, Router};
+use serde::Serialize;
 use tower::ServiceBuilder;
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::trace::TraceLayer;
 
-use crate::auth::require_bearer;
+use crate::auth::{Tenant, require_bearer};
 use crate::error::ApiError;
 use crate::state::{AppState, Limits};
 use crate::{exec, files, images, sandboxes};
@@ -22,6 +23,7 @@ pub(crate) use crate::files::MAX_FILE_BODY_BYTES;
 pub(crate) fn router(state: AppState) -> Router {
     let json = Router::new()
         .route("/v1/config", get(config))
+        .route("/v1/me", get(me))
         .merge(sandboxes::routes())
         .merge(exec::routes())
         .merge(images::routes())
@@ -53,6 +55,19 @@ async fn health() -> StatusCode {
 
 async fn config(State(state): State<AppState>) -> Json<Limits> {
     Json(state.limits)
+}
+
+#[derive(Debug, Serialize)]
+struct MeBody {
+    tenant_id: String,
+    max_sandboxes: u32,
+}
+
+async fn me(State(state): State<AppState>, tenant: Tenant) -> Json<MeBody> {
+    Json(MeBody {
+        tenant_id: tenant.id,
+        max_sandboxes: state.limits.max_sandboxes,
+    })
 }
 
 async fn map_payload_too_large(response: Response) -> Response {
@@ -169,6 +184,85 @@ mod tests {
             v.get("max_pull_bytes").and_then(serde_json::Value::as_u64),
             Some(4_u64 * 1024 * 1024 * 1024),
             "max_pull_bytes"
+        );
+    }
+
+    #[tokio::test]
+    async fn me_without_bearer_is_401() {
+        let (_dir, app) = sample_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("unauthorized"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn me_returns_tenant_and_max_sandboxes() {
+        let (_dir, app) = sample_app();
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/me")
+                    .header(AUTHORIZATION, "Bearer secret1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "me");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.get("tenant_id").and_then(serde_json::Value::as_str),
+            Some("tenant1"),
+            "tenant_id"
+        );
+        assert_eq!(
+            v.get("max_sandboxes").and_then(serde_json::Value::as_u64),
+            Some(32),
+            "max_sandboxes"
+        );
+    }
+
+    #[tokio::test]
+    async fn me_two_keys_are_distinct_tenants() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let app = router(AppState::new(
+            vec![
+                ApiKey::new("a", "one").unwrap(),
+                ApiKey::new("b", "two").unwrap(),
+            ],
+            runtime,
+            Limits::default(),
+        ));
+        let res = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/me")
+                    .header(AUTHORIZATION, "Bearer two")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(res.status(), StatusCode::OK, "second key");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.get("tenant_id").and_then(serde_json::Value::as_str),
+            Some("b"),
+            "tenant_id"
         );
     }
 

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -798,6 +798,9 @@ mod tests {
                 "agent_id": "dead",
             }),
         );
+        if bux::HostInfo::probe().virtualization {
+            return;
+        }
         let res = send(
             h.app,
             "POST",
@@ -806,11 +809,9 @@ mod tests {
             Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":512}"#),
         )
         .await;
-        assert_ne!(
-            res.status(),
-            StatusCode::TOO_MANY_REQUESTS,
-            "dead pid must not count toward running RAM"
-        );
+        assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED, "no create");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("security_unavailable"), "code");
     }
 
     #[tokio::test]

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -18,7 +18,7 @@ use crate::error::{ApiError, JsonBody};
 use crate::ids::{sandbox_name, validate_agent_id, workspace_volume_name};
 use crate::state::AppState;
 
-const WORKSPACE_GUEST_PATH: &str = "/workspace";
+pub(crate) const WORKSPACE_GUEST_PATH: &str = "/workspace";
 const DEFAULT_AUTO_STOP_SECS: u64 = 1800;
 const STOP_WAIT: Duration = Duration::from_secs(10);
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
@@ -80,7 +80,7 @@ pub(crate) struct SandboxBody {
 }
 
 impl SandboxBody {
-    fn from_info(info: &VmInfo) -> Self {
+    pub(crate) fn from_info(info: &VmInfo) -> Self {
         Self {
             id: info.id.clone(),
             name: info.name.clone(),
@@ -465,7 +465,12 @@ pub(crate) fn load_owned(runtime: &Runtime, tenant: &str, id: &str) -> Result<Vm
     Ok(vm)
 }
 
-fn admit(state: &AppState, tenant: &str, ram_mib: u32, vcpus: u8) -> Result<(), ApiError> {
+pub(crate) fn admit(
+    state: &AppState,
+    tenant: &str,
+    ram_mib: u32,
+    vcpus: u8,
+) -> Result<(), ApiError> {
     if ram_mib == 0 {
         return Err(ApiError::invalid_config("ram_mib must be >= 1").with_field("ram_mib"));
     }

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -11,6 +11,7 @@ use bux::{
     EgressClass, NetworkSpec, Runtime, SecurityOptions, Status, Vm, VmInfo, VmOptions, VolumeMount,
 };
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::auth::Tenant;
 use crate::error::{ApiError, JsonBody};
@@ -29,9 +30,9 @@ pub(crate) fn routes() -> Router<AppState> {
         .route("/v1/sandboxes/{id}/start", post(start_one))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct CreateRequest {
+pub(crate) struct CreateRequest {
     agent_id: String,
     image: String,
     #[serde(default)]
@@ -57,8 +58,8 @@ struct CreateSpec {
     network: NetworkSpec,
 }
 
-#[derive(Debug, Serialize)]
-struct SandboxBody {
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct SandboxBody {
     id: String,
     name: Option<String>,
     agent_id: Option<String>,
@@ -67,7 +68,9 @@ struct SandboxBody {
     status: &'static str,
     ram_mib: u32,
     vcpus: u8,
+    #[schema(value_type = Object)]
     network: NetworkSpec,
+    #[schema(value_type = Object)]
     egress: EgressClass,
     isolation_note: &'static str,
     secrets_required: bool,
@@ -114,7 +117,17 @@ fn is_vm_id(id: &str) -> bool {
     id.len() == 12 && id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
 }
 
-async fn list(
+#[utoipa::path(
+    get,
+    path = "/v1/sandboxes",
+    operation_id = "listSandboxes",
+    tag = "Sandboxes",
+    responses(
+        (status = 200, description = "Sandboxes for this tenant", body = [SandboxBody]),
+        (status = 401, description = "Missing or invalid Bearer token")
+    )
+)]
+pub(crate) async fn list(
     State(state): State<AppState>,
     tenant: Tenant,
 ) -> Result<Json<Vec<SandboxBody>>, ApiError> {
@@ -127,7 +140,19 @@ async fn list(
     Ok(Json(body))
 }
 
-async fn get_one(
+#[utoipa::path(
+    get,
+    path = "/v1/sandboxes/{id}",
+    operation_id = "getSandbox",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    responses(
+        (status = 200, description = "Sandbox", body = SandboxBody),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant")
+    )
+)]
+pub(crate) async fn get_one(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -136,7 +161,23 @@ async fn get_one(
     Ok(Json(SandboxBody::from_info(&vm.info())))
 }
 
-async fn create(
+#[utoipa::path(
+    post,
+    path = "/v1/sandboxes",
+    operation_id = "createSandbox",
+    tag = "Sandboxes",
+    request_body = CreateRequest,
+    responses(
+        (status = 201, description = "Created", body = SandboxBody),
+        (status = 200, description = "Existing sandbox for this tenant and agent", body = SandboxBody),
+        (status = 400, description = "Invalid body or per-sandbox admission"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 409, description = "Name occupied or spec mismatch"),
+        (status = 412, description = "No hardware virtualization"),
+        (status = 429, description = "Count, running RAM, or disk cap")
+    )
+)]
+pub(crate) async fn create(
     State(state): State<AppState>,
     tenant: Tenant,
     JsonBody(req): JsonBody<CreateRequest>,
@@ -165,7 +206,20 @@ async fn create(
     create_new(&state, &tenant, name, req, &spec).await
 }
 
-async fn start_one(
+#[utoipa::path(
+    post,
+    path = "/v1/sandboxes/{id}/start",
+    operation_id = "startSandbox",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    responses(
+        (status = 200, description = "Started", body = SandboxBody),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant"),
+        (status = 409, description = "secrets_required or not stopped")
+    )
+)]
+pub(crate) async fn start_one(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -180,7 +234,19 @@ async fn start_one(
     Ok(Json(SandboxBody::from_info(&vm.info())))
 }
 
-async fn delete_one(
+#[utoipa::path(
+    delete,
+    path = "/v1/sandboxes/{id}",
+    operation_id = "deleteSandbox",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    responses(
+        (status = 204, description = "Removed, workspace volume deleted"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant")
+    )
+)]
+pub(crate) async fn delete_one(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -475,7 +541,12 @@ fn remove_workspace_volume(runtime: &Runtime, name: &str) -> Result<(), ApiError
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    reason = "tests"
+)]
 mod tests {
     use std::path::Path;
     use std::sync::Arc;

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -195,7 +195,9 @@ async fn delete_one(
     let mut vm = load_owned(&state.runtime, &tenant.id, &id)?;
     let info = vm.info();
     let volume = match (info.tenant_id.as_deref(), info.agent_id.as_deref()) {
-        (Some(t), Some(a)) => workspace_volume_name(t, a).ok(),
+        (Some(t), Some(a)) => {
+            Some(workspace_volume_name(t, a).map_err(|err| ApiError::internal(err.to_string()))?)
+        }
         _ => None,
     };
     stop_for_delete(&mut vm).await?;
@@ -335,29 +337,98 @@ fn remove_workspace_volume(runtime: &Runtime, name: &str) -> Result<(), ApiError
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
 mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+
     use super::*;
     use axum::Router;
     use axum::body::Body;
     use axum::http::header::AUTHORIZATION;
     use axum::http::{Request, header};
+    use rusqlite::params;
     use tower::ServiceExt;
 
     use crate::ApiKey;
     use crate::router::router;
     use crate::state::Limits;
 
-    fn test_app(limits: Limits) -> (tempfile::TempDir, Router) {
+    struct Harness {
+        dir: tempfile::TempDir,
+        runtime: Arc<Runtime>,
+        app: Router,
+    }
+
+    fn harness(limits: Limits) -> Harness {
         let dir = tempfile::tempdir().unwrap();
-        let runtime = Runtime::open(dir.path()).unwrap();
+        let opened = Runtime::open(dir.path()).unwrap();
         let state = AppState::new(
             vec![
                 ApiKey::new("tenant1", "secret1").unwrap(),
                 ApiKey::new("tenant2", "secret2").unwrap(),
             ],
-            runtime,
+            opened,
             limits,
         );
-        (dir, router(state))
+        let runtime = Arc::clone(&state.runtime);
+        let app = router(state);
+        Harness { dir, runtime, app }
+    }
+
+    fn test_app(limits: Limits) -> (tempfile::TempDir, Router) {
+        let h = harness(limits);
+        (h.dir, h.app)
+    }
+
+    fn open_db(data_dir: &Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(data_dir.join("bux.db")).unwrap();
+        conn.busy_timeout(Duration::from_secs(5)).unwrap();
+        conn
+    }
+
+    fn plant_vm(
+        data_dir: &Path,
+        id: &str,
+        name: &str,
+        pid: i32,
+        status: &str,
+        config: &serde_json::Value,
+    ) {
+        let socket = data_dir.join("socks").join(format!("{id}.sock"));
+        open_db(data_dir)
+            .execute(
+                "INSERT INTO vms (id, name, pid, image, socket, status, config, created_at)
+                 VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, 0)",
+                params![
+                    id,
+                    name,
+                    pid,
+                    socket.to_str().expect("socket utf-8"),
+                    status,
+                    config.to_string(),
+                ],
+            )
+            .unwrap();
+    }
+
+    fn dead_pid() -> i32 {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        drop(child.wait());
+        pid
+    }
+
+    fn attach_volume(data_dir: &Path, vm_id: &str, volume_id: &str) {
+        open_db(data_dir)
+            .execute(
+                "INSERT INTO vm_volumes (vm_id, volume_id, guest_path) VALUES (?1, ?2, ?3)",
+                params![vm_id, volume_id, WORKSPACE_GUEST_PATH],
+            )
+            .unwrap();
+    }
+
+    fn error_code(v: &serde_json::Value) -> Option<&str> {
+        v.pointer("/error/code").and_then(serde_json::Value::as_str)
     }
 
     async fn json_body(res: axum::response::Response) -> serde_json::Value {
@@ -670,30 +741,102 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn admission_running_ram_is_429() {
-        let limits = Limits {
-            max_running_ram_mib: 256,
+    async fn admission_running_ram_counts_live_vm_info() {
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let h = harness(Limits {
+            max_running_ram_mib: 1000,
             ..Limits::default()
-        };
-        let (_dir, app) = test_app(limits);
+        });
+        plant_vm(
+            h.dir.path(),
+            "cafebabe0001",
+            "a-tenant1-live",
+            pid,
+            "running",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 700,
+                "tenant_id": "tenant1",
+                "agent_id": "live",
+            }),
+        );
         let res = send(
-            app,
+            h.app,
             "POST",
             "/v1/sandboxes",
             Some("secret1"),
             Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":512}"#),
         )
         .await;
-        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "status");
+        drop(child.kill());
+        drop(child.wait());
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "live ram sum");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("resource_exhausted"), "code");
+    }
+
+    #[tokio::test]
+    async fn admission_running_ram_ignores_dead_pid() {
+        let h = harness(Limits {
+            max_running_ram_mib: 1000,
+            ..Limits::default()
+        });
+        plant_vm(
+            h.dir.path(),
+            "cafebabe0002",
+            "a-tenant1-dead",
+            dead_pid(),
+            "running",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 700,
+                "tenant_id": "tenant1",
+                "agent_id": "dead",
+            }),
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":512}"#),
+        )
+        .await;
+        assert_ne!(
+            res.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "dead pid must not count toward running RAM"
+        );
     }
 
     #[tokio::test]
     async fn admission_disk_is_429() {
-        let limits = Limits {
-            max_disk_bytes: 0,
-            ..Limits::default()
-        };
-        let (_dir, app) = test_app(limits);
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = Runtime::open(dir.path()).unwrap();
+        let disk = runtime.disk_usage().unwrap();
+        let data = runtime.data_dir_usage().unwrap();
+        assert!(
+            data > disk,
+            "data_dir_usage={data} must exceed disk_usage={disk}"
+        );
+        let cap = disk.saturating_add(1);
+        assert!(
+            cap <= data,
+            "cap {cap} must be in (disk_usage, data_dir_usage]"
+        );
+        let state = AppState::new(
+            vec![ApiKey::new("tenant1", "secret1").unwrap()],
+            runtime,
+            Limits {
+                max_disk_bytes: cap,
+                ..Limits::default()
+            },
+        );
+        let app = router(state);
         let res = send(
             app,
             "POST",
@@ -703,6 +846,304 @@ mod tests {
         )
         .await;
         assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "status");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("resource_exhausted"), "code");
+    }
+
+    #[tokio::test]
+    async fn same_tenant_post_returns_existing_without_create() {
+        const ID: &str = "abc123aaa001";
+        let h = harness(Limits::default());
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant1",
+                "agent_id": "a1",
+            }),
+        );
+        let created = send(
+            h.app.clone(),
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":2048}"#),
+        )
+        .await;
+        assert_eq!(created.status(), StatusCode::OK, "same tenant");
+        let body = json_body(created).await;
+        assert_eq!(body.get("id").and_then(serde_json::Value::as_str), Some(ID));
+        assert_eq!(
+            body.get("ram_mib").and_then(serde_json::Value::as_u64),
+            Some(512),
+            "must not compare or overwrite ram"
+        );
+
+        let got = send(
+            h.app.clone(),
+            "GET",
+            &format!("/v1/sandboxes/{ID}"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(got.status(), StatusCode::OK, "owner get");
+
+        let missing = send(
+            h.app.clone(),
+            "GET",
+            "/v1/sandboxes/ffffffffffff",
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        let other_get = send(
+            h.app.clone(),
+            "GET",
+            &format!("/v1/sandboxes/{ID}"),
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        let other_del = send(
+            h.app.clone(),
+            "DELETE",
+            &format!("/v1/sandboxes/{ID}"),
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND, "missing");
+        assert_eq!(other_get.status(), StatusCode::NOT_FOUND, "other get");
+        assert_eq!(other_del.status(), StatusCode::NOT_FOUND, "other delete");
+        let missing_json = json_body(missing).await;
+        assert_eq!(json_body(other_get).await, missing_json, "get envelope");
+        assert_eq!(json_body(other_del).await, missing_json, "delete envelope");
+
+        let list2 = send(
+            h.app.clone(),
+            "GET",
+            "/v1/sandboxes",
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            json_body(list2).await,
+            serde_json::json!([]),
+            "tenant2 list"
+        );
+        let list1 = send(
+            h.app,
+            "GET",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        let listed = json_body(list1).await;
+        let row = listed.as_array().and_then(|a| a.first());
+        assert_eq!(
+            row.and_then(|item| item.get("id"))
+                .and_then(serde_json::Value::as_str),
+            Some(ID),
+            "tenant1 list"
+        );
+    }
+
+    #[tokio::test]
+    async fn none_tenant_name_is_occupied() {
+        const ID: &str = "abc123aaa002";
+        let h = harness(Limits::default());
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": null,
+                "agent_id": "a1",
+            }),
+        );
+        let res = send(
+            h.app.clone(),
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "occupied");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("name_occupied"), "code");
+        assert_eq!(
+            v.pointer("/error/existing_id")
+                .and_then(serde_json::Value::as_str),
+            Some(ID),
+            "existing_id"
+        );
+        let list = send(
+            h.app,
+            "GET",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            json_body(list).await,
+            serde_json::json!([]),
+            "cli vm omitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn other_tenant_name_is_occupied() {
+        const ID: &str = "abc123aaa003";
+        let h = harness(Limits::default());
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant2",
+                "agent_id": "a1",
+            }),
+        );
+        let res = send(
+            h.app.clone(),
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "occupied");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("name_occupied"), "code");
+        assert_eq!(
+            v.pointer("/error/existing_id")
+                .and_then(serde_json::Value::as_str),
+            Some(ID),
+            "existing_id"
+        );
+        let list1 = send(
+            h.app.clone(),
+            "GET",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            json_body(list1).await,
+            serde_json::json!([]),
+            "owner is tenant2"
+        );
+        let list2 = send(
+            h.app,
+            "GET",
+            "/v1/sandboxes",
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        let listed = json_body(list2).await;
+        let row = listed.as_array().and_then(|a| a.first());
+        assert_eq!(
+            row.and_then(|item| item.get("id"))
+                .and_then(serde_json::Value::as_str),
+            Some(ID),
+            "tenant2 list"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_owned_removes_workspace_volume() {
+        const ID: &str = "abc123aaa004";
+        const VOL: &str = "ws-tenant1-a1";
+        let h = harness(Limits::default());
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant1",
+                "agent_id": "a1",
+            }),
+        );
+        let info = h.runtime.volumes().create(VOL).unwrap();
+        attach_volume(h.dir.path(), ID, &info.id);
+        let vol_dir = h.dir.path().join("volumes").join(VOL);
+        assert!(vol_dir.is_dir(), "volume dir planted");
+
+        let res = send(
+            h.app.clone(),
+            "DELETE",
+            &format!("/v1/sandboxes/{ID}"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NO_CONTENT, "delete");
+        assert!(
+            matches!(h.runtime.get_exact(ID), Err(bux::Error::NotFound(_))),
+            "row gone"
+        );
+        assert!(
+            matches!(h.runtime.volumes().get(VOL), Err(bux::Error::NotFound(_))),
+            "volume row gone"
+        );
+        assert!(!vol_dir.exists(), "volume directory gone");
+    }
+
+    #[tokio::test]
+    async fn delete_invalid_stored_ids_is_500() {
+        const ID: &str = "abc123aaa005";
+        let h = harness(Limits::default());
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant1",
+                "agent_id": "bad-id",
+            }),
+        );
+        let res = send(
+            h.app.clone(),
+            "DELETE",
+            &format!("/v1/sandboxes/{ID}"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            res.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "invalid ids"
+        );
+        assert!(h.runtime.get_exact(ID).is_ok(), "must not remove the VM");
     }
 
     #[tokio::test]
@@ -739,13 +1180,43 @@ mod tests {
     #[test]
     fn handlers_never_call_runtime_get() {
         let src = include_str!("sandboxes.rs");
+        let prod = src.split("#[cfg(test)]").next().expect("prod");
         let forbidden = concat!("runtime.get", "(");
-        for (i, line) in src.lines().enumerate() {
+        for (i, line) in prod.lines().enumerate() {
             assert!(
                 !line.contains(forbidden),
                 "HTTP must use get_exact/get_named, line {}: {line}",
                 i + 1
             );
         }
+        assert!(prod.contains("get_named"), "occupancy uses get_named");
+        assert!(prod.contains("get_exact"), "HTTP id uses get_exact");
+    }
+
+    #[test]
+    fn delete_removes_vm_before_volume() {
+        let src = include_str!("sandboxes.rs");
+        let prod = src.split("#[cfg(test)]").next().expect("prod");
+        let vm = prod.find("remove(&info.id)").expect("Runtime::remove");
+        let vol = prod.find("remove_workspace_volume").expect("volume remove");
+        assert!(
+            vm < vol,
+            "VM row must be removed before the workspace volume"
+        );
+    }
+
+    #[test]
+    fn admit_uses_data_dir_usage_not_disk_usage() {
+        let src = include_str!("sandboxes.rs");
+        let admit = src
+            .split("fn admit(")
+            .nth(1)
+            .and_then(|rest| rest.split("\nfn ").next())
+            .expect("admit");
+        assert!(admit.contains("data_dir_usage"), "disk cap");
+        assert!(
+            !admit.contains("disk_usage"),
+            "disk cap is data_dir_usage, not disk_usage"
+        );
     }
 }

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -244,7 +244,7 @@ fn create_miss_error(err: bux::Error) -> ApiError {
     }
 }
 
-fn load_owned(runtime: &Runtime, tenant: &str, id: &str) -> Result<Vm, ApiError> {
+pub(crate) fn load_owned(runtime: &Runtime, tenant: &str, id: &str) -> Result<Vm, ApiError> {
     if !is_vm_id(id) {
         return Err(ApiError::not_found());
     }

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -1,0 +1,751 @@
+//! Sandbox HTTP: list, create, exact-id get, DELETE (stop + remove + workspace volume).
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use axum::Json;
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::get;
+use bux::{
+    EgressClass, NetworkSpec, Runtime, SecurityOptions, Status, Vm, VmInfo, VmOptions, VolumeMount,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::Tenant;
+use crate::error::{ApiError, JsonBody};
+use crate::ids::{sandbox_name, validate_agent_id, workspace_volume_name};
+use crate::state::AppState;
+
+const WORKSPACE_GUEST_PATH: &str = "/workspace";
+const DEFAULT_AUTO_STOP_SECS: u64 = 1800;
+const STOP_WAIT: Duration = Duration::from_secs(10);
+const READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new()
+        .route("/v1/sandboxes", get(list).post(create))
+        .route("/v1/sandboxes/{id}", get(get_one).delete(delete_one))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateRequest {
+    agent_id: String,
+    image: String,
+    #[serde(default)]
+    vcpus: Option<u8>,
+    #[serde(default)]
+    ram_mib: Option<u32>,
+    #[serde(default)]
+    allow_net: Vec<String>,
+    #[serde(default)]
+    env: Vec<String>,
+    #[serde(default)]
+    workdir: Option<String>,
+    #[serde(default)]
+    auto_stop_secs: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxBody {
+    id: String,
+    name: Option<String>,
+    agent_id: Option<String>,
+    tenant_id: Option<String>,
+    image: Option<String>,
+    status: &'static str,
+    ram_mib: u32,
+    vcpus: u8,
+    network: NetworkSpec,
+    egress: EgressClass,
+    isolation_note: &'static str,
+    secrets_required: bool,
+    workload_env: Vec<String>,
+    workload_workdir: Option<String>,
+    created_at: u64,
+}
+
+impl SandboxBody {
+    fn from_info(info: &VmInfo) -> Self {
+        Self {
+            id: info.id.clone(),
+            name: info.name.clone(),
+            agent_id: info.agent_id.clone(),
+            tenant_id: info.tenant_id.clone(),
+            image: info.image.clone(),
+            status: status_str(info.status),
+            ram_mib: info.ram_mib,
+            vcpus: info.vcpus,
+            network: info.network.clone(),
+            egress: info.egress.clone(),
+            isolation_note: info.isolation_note,
+            secrets_required: info.secrets_required,
+            workload_env: info.workload_env.clone(),
+            workload_workdir: info.workload_workdir.clone(),
+            created_at: unix_secs(info.created_at),
+        }
+    }
+}
+
+const fn status_str(status: Status) -> &'static str {
+    match status {
+        Status::Running => "running",
+        Status::Stopping => "stopping",
+        Status::Stopped | _ => "stopped",
+    }
+}
+
+fn unix_secs(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+fn is_vm_id(id: &str) -> bool {
+    id.len() == 12 && id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+async fn list(
+    State(state): State<AppState>,
+    tenant: Tenant,
+) -> Result<Json<Vec<SandboxBody>>, ApiError> {
+    let infos = state.runtime.list().map_err(ApiError::from_engine)?;
+    let body = infos
+        .iter()
+        .filter(|vm| vm.tenant_id.as_deref() == Some(tenant.id.as_str()))
+        .map(SandboxBody::from_info)
+        .collect();
+    Ok(Json(body))
+}
+
+async fn get_one(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+) -> Result<Json<SandboxBody>, ApiError> {
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    Ok(Json(SandboxBody::from_info(&vm.info())))
+}
+
+async fn create(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    JsonBody(req): JsonBody<CreateRequest>,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    validate_agent_id(&req.agent_id)?;
+    if !req.allow_net.is_empty() {
+        return Err(ApiError::invalid_config("allow_net is not accepted").with_field("allow_net"));
+    }
+    let image = parse_image(&req.image)?;
+    let name = sandbox_name(&tenant.id, &req.agent_id)?;
+    let volume = workspace_volume_name(&tenant.id, &req.agent_id)?;
+
+    if let Some(vm) = state
+        .runtime
+        .get_named(&name)
+        .map_err(ApiError::from_engine)?
+    {
+        return existing_or_occupied(&tenant.id, &vm);
+    }
+
+    let ram_mib = req.ram_mib.unwrap_or(state.limits.default_ram_mib);
+    let vcpus = req.vcpus.unwrap_or(state.limits.default_vcpus);
+    admit(&state, &tenant.id, ram_mib, vcpus)?;
+
+    let mut opts = VmOptions::from_image(image)
+        .name(name.clone())
+        .agent_id(req.agent_id.clone())
+        .tenant_id(tenant.id.clone())
+        .detach(true)
+        .network(NetworkSpec::Disabled)
+        .volume(VolumeMount::named(volume, WORKSPACE_GUEST_PATH))
+        .auto_stop_secs(Some(req.auto_stop_secs.unwrap_or(DEFAULT_AUTO_STOP_SECS)))
+        .env(req.env)
+        .vcpus(vcpus)
+        .ram_mib(ram_mib)
+        .security(SecurityOptions::default())
+        .ready_timeout(READY_TIMEOUT);
+    if let Some(workdir) = req.workdir {
+        opts = opts.workdir(workdir);
+    }
+
+    match state.runtime.create(opts).await {
+        Ok(vm) => {
+            let info = vm.info();
+            tracing::info!(
+                tenant_id = %tenant.id,
+                agent_id = %req.agent_id,
+                id = %info.id,
+                "sandbox created"
+            );
+            Ok((StatusCode::CREATED, Json(SandboxBody::from_info(&info))))
+        }
+        Err(err) => match state.runtime.get_named(&name) {
+            Ok(Some(vm)) => existing_or_occupied(&tenant.id, &vm),
+            Ok(None) => Err(create_miss_error(err)),
+            Err(lookup) => Err(ApiError::from_engine(lookup)),
+        },
+    }
+}
+
+async fn delete_one(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+) -> Result<StatusCode, ApiError> {
+    let mut vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let info = vm.info();
+    let volume = match (info.tenant_id.as_deref(), info.agent_id.as_deref()) {
+        (Some(t), Some(a)) => workspace_volume_name(t, a).ok(),
+        _ => None,
+    };
+    stop_for_delete(&mut vm).await?;
+    if vm.info().status.is_active() {
+        vm.kill().map_err(ApiError::from_engine)?;
+    }
+    state
+        .runtime
+        .remove(&info.id)
+        .map_err(ApiError::from_engine)?;
+    if let Some(name) = volume {
+        remove_workspace_volume(&state.runtime, &name)?;
+    }
+    tracing::info!(
+        tenant_id = %tenant.id,
+        id = %info.id,
+        "sandbox deleted"
+    );
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn parse_image(image: &str) -> Result<String, ApiError> {
+    if image.is_empty() {
+        return Err(ApiError::invalid_config("image is required").with_field("image"));
+    }
+    bux::canonical_reference(image).map_err(|e| ApiError::invalid_config(e.to_string()))
+}
+
+fn existing_or_occupied(
+    tenant: &str,
+    vm: &Vm,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    let info = vm.info();
+    match info.tenant_id.as_deref() {
+        Some(id) if id == tenant => Ok((StatusCode::OK, Json(SandboxBody::from_info(&info)))),
+        _ => Err(ApiError::name_occupied(info.id)),
+    }
+}
+
+fn create_miss_error(err: bux::Error) -> ApiError {
+    match err {
+        bux::Error::Ambiguous(_) => ApiError::name_occupied_unknown(),
+        other => ApiError::from_engine(other),
+    }
+}
+
+fn load_owned(runtime: &Runtime, tenant: &str, id: &str) -> Result<Vm, ApiError> {
+    if !is_vm_id(id) {
+        return Err(ApiError::not_found());
+    }
+    let vm = match runtime.get_exact(id) {
+        Ok(vm) => vm,
+        Err(bux::Error::NotFound(_)) => return Err(ApiError::not_found()),
+        Err(err) => return Err(ApiError::from_engine(err)),
+    };
+    if vm.info().tenant_id.as_deref() != Some(tenant) {
+        return Err(ApiError::not_found());
+    }
+    Ok(vm)
+}
+
+fn admit(state: &AppState, tenant: &str, ram_mib: u32, vcpus: u8) -> Result<(), ApiError> {
+    if ram_mib == 0 {
+        return Err(ApiError::invalid_config("ram_mib must be >= 1").with_field("ram_mib"));
+    }
+    if vcpus == 0 {
+        return Err(ApiError::invalid_config("vcpus must be >= 1").with_field("vcpus"));
+    }
+    if ram_mib > state.limits.max_ram_mib {
+        return Err(
+            ApiError::invalid_config("ram_mib exceeds the per-sandbox maximum")
+                .with_field("ram_mib"),
+        );
+    }
+    if vcpus > state.limits.max_vcpus {
+        return Err(
+            ApiError::invalid_config("vcpus exceeds the per-sandbox maximum").with_field("vcpus"),
+        );
+    }
+    let infos = state.runtime.list().map_err(ApiError::from_engine)?;
+    let tenant_n = infos
+        .iter()
+        .filter(|vm| vm.tenant_id.as_deref() == Some(tenant))
+        .count();
+    if tenant_n >= usize_cap(state.limits.max_sandboxes) {
+        return Err(ApiError::resource_exhausted("tenant sandbox limit reached"));
+    }
+    if infos.len() >= usize_cap(state.limits.max_sandboxes_global) {
+        return Err(ApiError::resource_exhausted("global sandbox limit reached"));
+    }
+    let running: u64 = infos
+        .iter()
+        .filter(|vm| vm.status.is_active())
+        .map(|vm| u64::from(vm.ram_mib))
+        .sum();
+    if running.saturating_add(u64::from(ram_mib)) > u64::from(state.limits.max_running_ram_mib) {
+        return Err(ApiError::resource_exhausted("running RAM limit reached"));
+    }
+    let usage = state
+        .runtime
+        .data_dir_usage()
+        .map_err(|e| ApiError::from_engine(e.into()))?;
+    if usage >= state.limits.max_disk_bytes {
+        return Err(ApiError::resource_exhausted("disk limit reached"));
+    }
+    Ok(())
+}
+
+fn usize_cap(n: u32) -> usize {
+    usize::try_from(n).unwrap_or(usize::MAX)
+}
+
+async fn stop_for_delete(vm: &mut Vm) -> Result<(), ApiError> {
+    match vm.info().status {
+        Status::Running => {
+            if vm.stop_timeout(STOP_WAIT).await.is_err() {
+                vm.kill().map_err(ApiError::from_engine)?;
+            }
+        }
+        Status::Stopping => match tokio::time::timeout(STOP_WAIT, vm.wait()).await {
+            Ok(Ok(())) => {}
+            _ => vm.kill().map_err(ApiError::from_engine)?,
+        },
+        _ => {}
+    }
+    Ok(())
+}
+
+fn remove_workspace_volume(runtime: &Runtime, name: &str) -> Result<(), ApiError> {
+    match runtime.volumes().remove(name) {
+        Ok(()) | Err(bux::Error::NotFound(_)) => Ok(()),
+        Err(bux::Error::Busy(message)) => Err(ApiError::internal(message)),
+        Err(err) => Err(ApiError::from_engine(err)),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::{Request, header};
+    use tower::ServiceExt;
+
+    use crate::ApiKey;
+    use crate::router::router;
+    use crate::state::Limits;
+
+    fn test_app(limits: Limits) -> (tempfile::TempDir, Router) {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = Runtime::open(dir.path()).unwrap();
+        let state = AppState::new(
+            vec![
+                ApiKey::new("tenant1", "secret1").unwrap(),
+                ApiKey::new("tenant2", "secret2").unwrap(),
+            ],
+            runtime,
+            limits,
+        );
+        (dir, router(state))
+    }
+
+    async fn json_body(res: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        if bytes.is_empty() {
+            return serde_json::Value::Null;
+        }
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        token: Option<&str>,
+        body: Body,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        if method == "POST" {
+            builder = builder.header(header::CONTENT_TYPE, "application/json");
+        }
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn list_without_bearer_is_401() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(app, "GET", "/v1/sandboxes", None, Body::empty()).await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("unauthorized"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn list_empty_for_tenant() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(app, "GET", "/v1/sandboxes", Some("secret1"), Body::empty()).await;
+        assert_eq!(res.status(), StatusCode::OK, "status");
+        let v = json_body(res).await;
+        assert_eq!(v, serde_json::json!([]), "empty list");
+    }
+
+    #[tokio::test]
+    async fn get_missing_is_404_envelope() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789ab",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("not_found"),
+            "code"
+        );
+        assert!(
+            v.pointer("/error/existing_id").is_none(),
+            "no existing_id on 404"
+        );
+    }
+
+    #[tokio::test]
+    async fn get_non_hex_id_is_404() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/abcd",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "short id");
+    }
+
+    #[tokio::test]
+    async fn get_uppercase_hex_id_is_404() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "GET",
+            "/v1/sandboxes/0123456789AB",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "uppercase");
+    }
+
+    #[tokio::test]
+    async fn delete_missing_is_404() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "DELETE",
+            "/v1/sandboxes/0123456789ab",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("not_found"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_without_bearer_is_401() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            None,
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+    }
+
+    #[tokio::test]
+    async fn post_hyphen_agent_id_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a-b","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("invalid_config"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_missing_agent_id_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("invalid_config"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_unknown_field_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","bind":"/tmp"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+    }
+
+    #[tokio::test]
+    async fn post_allow_net_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","allow_net":["example.com"]}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("allow_net"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_invalid_image_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"not a ref"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+    }
+
+    #[tokio::test]
+    async fn admission_ram_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":4096}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("invalid_config"),
+            "code"
+        );
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("ram_mib"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn admission_vcpus_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","vcpus":8}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("vcpus"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn admission_zero_ram_is_400() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":0}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "zero ram");
+    }
+
+    #[tokio::test]
+    async fn admission_tenant_count_is_429() {
+        let limits = Limits {
+            max_sandboxes: 0,
+            ..Limits::default()
+        };
+        let (_dir, app) = test_app(limits);
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("resource_exhausted"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn admission_running_ram_is_429() {
+        let limits = Limits {
+            max_running_ram_mib: 256,
+            ..Limits::default()
+        };
+        let (_dir, app) = test_app(limits);
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":512}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "status");
+    }
+
+    #[tokio::test]
+    async fn admission_disk_is_429() {
+        let limits = Limits {
+            max_disk_bytes: 0,
+            ..Limits::default()
+        };
+        let (_dir, app) = test_app(limits);
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "status");
+    }
+
+    #[tokio::test]
+    async fn create_without_virtualization_is_412() {
+        if bux::HostInfo::probe().virtualization {
+            return;
+        }
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::PRECONDITION_FAILED, "status");
+        let v = json_body(res).await;
+        assert_eq!(
+            v.pointer("/error/code").and_then(serde_json::Value::as_str),
+            Some("security_unavailable"),
+            "code"
+        );
+    }
+
+    #[test]
+    fn vm_id_is_lowercase_12_hex() {
+        assert!(is_vm_id("0123456789ab"), "ok");
+        assert!(!is_vm_id("0123456789AB"), "upper");
+        assert!(!is_vm_id("0123456789abc"), "13");
+        assert!(!is_vm_id("xyzxyzxyzxyz"), "not hex");
+    }
+
+    #[test]
+    fn handlers_never_call_runtime_get() {
+        let src = include_str!("sandboxes.rs");
+        let forbidden = concat!("runtime.get", "(");
+        for (i, line) in src.lines().enumerate() {
+            assert!(
+                !line.contains(forbidden),
+                "HTTP must use get_exact/get_named, line {}: {line}",
+                i + 1
+            );
+        }
+    }
+}

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -1,4 +1,4 @@
-//! Sandbox HTTP: list, create, exact-id get, DELETE (stop + remove + workspace volume).
+//! Sandbox HTTP: list, get-or-create, exact-id get, start, DELETE.
 
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -6,7 +6,7 @@ use axum::Json;
 use axum::Router;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
-use axum::routing::get;
+use axum::routing::{get, post};
 use bux::{
     EgressClass, NetworkSpec, Runtime, SecurityOptions, Status, Vm, VmInfo, VmOptions, VolumeMount,
 };
@@ -26,6 +26,7 @@ pub(crate) fn routes() -> Router<AppState> {
     Router::new()
         .route("/v1/sandboxes", get(list).post(create))
         .route("/v1/sandboxes/{id}", get(get_one).delete(delete_one))
+        .route("/v1/sandboxes/{id}/start", post(start_one))
 }
 
 #[derive(Debug, Deserialize)]
@@ -40,11 +41,20 @@ struct CreateRequest {
     #[serde(default)]
     allow_net: Vec<String>,
     #[serde(default)]
+    unrestricted: bool,
+    #[serde(default)]
     env: Vec<String>,
     #[serde(default)]
     workdir: Option<String>,
     #[serde(default)]
     auto_stop_secs: Option<u64>,
+}
+
+struct CreateSpec {
+    image: String,
+    ram_mib: u32,
+    vcpus: u8,
+    network: NetworkSpec,
 }
 
 #[derive(Debug, Serialize)]
@@ -132,59 +142,42 @@ async fn create(
     JsonBody(req): JsonBody<CreateRequest>,
 ) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
     validate_agent_id(&req.agent_id)?;
-    if !req.allow_net.is_empty() {
-        return Err(ApiError::invalid_config("allow_net is not accepted").with_field("allow_net"));
-    }
-    let image = parse_image(&req.image)?;
+    let spec = CreateSpec {
+        image: parse_image(&req.image)?,
+        ram_mib: req.ram_mib.unwrap_or(state.limits.default_ram_mib),
+        vcpus: req.vcpus.unwrap_or(state.limits.default_vcpus),
+        network: translate_network(
+            &req.allow_net,
+            req.unrestricted,
+            state.allow_unrestricted_net,
+        )?,
+    };
     let name = sandbox_name(&tenant.id, &req.agent_id)?;
-    let volume = workspace_volume_name(&tenant.id, &req.agent_id)?;
 
     if let Some(vm) = state
         .runtime
         .get_named(&name)
         .map_err(ApiError::from_engine)?
     {
-        return existing_or_occupied(&tenant.id, &vm);
+        return existing_sandbox(&state.runtime, &tenant.id, &name, vm, &spec).await;
     }
 
-    let ram_mib = req.ram_mib.unwrap_or(state.limits.default_ram_mib);
-    let vcpus = req.vcpus.unwrap_or(state.limits.default_vcpus);
-    admit(&state, &tenant.id, ram_mib, vcpus)?;
+    create_new(&state, &tenant, name, req, &spec).await
+}
 
-    let mut opts = VmOptions::from_image(image)
-        .name(name.clone())
-        .agent_id(req.agent_id.clone())
-        .tenant_id(tenant.id.clone())
-        .detach(true)
-        .network(NetworkSpec::Disabled)
-        .volume(VolumeMount::named(volume, WORKSPACE_GUEST_PATH))
-        .auto_stop_secs(Some(req.auto_stop_secs.unwrap_or(DEFAULT_AUTO_STOP_SECS)))
-        .env(req.env)
-        .vcpus(vcpus)
-        .ram_mib(ram_mib)
-        .security(SecurityOptions::default())
-        .ready_timeout(READY_TIMEOUT);
-    if let Some(workdir) = req.workdir {
-        opts = opts.workdir(workdir);
+async fn start_one(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+) -> Result<Json<SandboxBody>, ApiError> {
+    let mut vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    if vm.info().secrets_required {
+        return Err(ApiError::from_engine(bux::Error::SecretsRequired));
     }
-
-    match state.runtime.create(opts).await {
-        Ok(vm) => {
-            let info = vm.info();
-            tracing::info!(
-                tenant_id = %tenant.id,
-                agent_id = %req.agent_id,
-                id = %info.id,
-                "sandbox created"
-            );
-            Ok((StatusCode::CREATED, Json(SandboxBody::from_info(&info))))
-        }
-        Err(err) => match state.runtime.get_named(&name) {
-            Ok(Some(vm)) => existing_or_occupied(&tenant.id, &vm),
-            Ok(None) => Err(create_miss_error(err)),
-            Err(lookup) => Err(ApiError::from_engine(lookup)),
-        },
-    }
+    vm.start(READY_TIMEOUT)
+        .await
+        .map_err(ApiError::from_engine)?;
+    Ok(Json(SandboxBody::from_info(&vm.info())))
 }
 
 async fn delete_one(
@@ -226,14 +219,161 @@ fn parse_image(image: &str) -> Result<String, ApiError> {
     bux::canonical_reference(image).map_err(|e| ApiError::invalid_config(e.to_string()))
 }
 
-fn existing_or_occupied(
+fn translate_network(
+    allow_net: &[String],
+    unrestricted: bool,
+    allow_unrestricted: bool,
+) -> Result<NetworkSpec, ApiError> {
+    if unrestricted {
+        if !allow_unrestricted {
+            return Err(ApiError::invalid_config(
+                "unrestricted network requires --allow-unrestricted-net",
+            )
+            .with_field("unrestricted"));
+        }
+        return Ok(NetworkSpec::Enabled {
+            allow_net: Vec::new(),
+        });
+    }
+    if allow_net.is_empty() {
+        Ok(NetworkSpec::Disabled)
+    } else {
+        Ok(NetworkSpec::Enabled {
+            allow_net: allow_net.to_vec(),
+        })
+    }
+}
+
+fn image_matches(stored: Option<&str>, canonical: &str) -> bool {
+    stored
+        .and_then(|label| bux::canonical_reference(label).ok())
+        .as_deref()
+        == Some(canonical)
+}
+
+fn spec_mismatch(info: &VmInfo, spec: &CreateSpec) -> Option<&'static str> {
+    if !image_matches(info.image.as_deref(), &spec.image) {
+        return Some("image");
+    }
+    if info.ram_mib != spec.ram_mib {
+        return Some("ram_mib");
+    }
+    if info.vcpus != spec.vcpus {
+        return Some("vcpus");
+    }
+    if info.network != spec.network {
+        return Some("network");
+    }
+    None
+}
+
+async fn existing_sandbox(
+    runtime: &Runtime,
     tenant: &str,
-    vm: &Vm,
+    name: &str,
+    vm: Vm,
+    spec: &CreateSpec,
 ) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
     let info = vm.info();
     match info.tenant_id.as_deref() {
-        Some(id) if id == tenant => Ok((StatusCode::OK, Json(SandboxBody::from_info(&info)))),
-        _ => Err(ApiError::name_occupied(info.id)),
+        Some(id) if id == tenant => {}
+        _ => return Err(ApiError::name_occupied(info.id)),
+    }
+    if info.secrets_required {
+        return Err(ApiError::from_engine(bux::Error::SecretsRequired));
+    }
+    if let Some(field) = spec_mismatch(&info, spec) {
+        return Err(ApiError::sandbox_exists(info.id, field));
+    }
+    resume_matching(runtime, name, vm).await
+}
+
+async fn resume_matching(
+    runtime: &Runtime,
+    name: &str,
+    vm: Vm,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    let vm = match vm.info().status {
+        Status::Stopping => wait_not_stopping(runtime, name).await?,
+        _ => vm,
+    };
+    match vm.info().status {
+        Status::Running => Ok((StatusCode::OK, Json(SandboxBody::from_info(&vm.info())))),
+        Status::Stopped => start_existing(vm).await,
+        Status::Stopping => Err(ApiError::still_stopping()),
+        _ => Err(ApiError::from_engine(bux::Error::InvalidState(
+            "sandbox is not running or stopped".into(),
+        ))),
+    }
+}
+
+async fn wait_not_stopping(runtime: &Runtime, name: &str) -> Result<Vm, ApiError> {
+    let deadline = tokio::time::sleep(STOP_WAIT);
+    tokio::pin!(deadline);
+    loop {
+        let Some(vm) = runtime.get_named(name).map_err(ApiError::from_engine)? else {
+            return Err(ApiError::not_found());
+        };
+        if vm.info().status != Status::Stopping {
+            return Ok(vm);
+        }
+        tokio::select! {
+            () = &mut deadline => return Err(ApiError::still_stopping()),
+            () = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
+    }
+}
+
+async fn start_existing(mut vm: Vm) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    vm.start(READY_TIMEOUT)
+        .await
+        .map_err(ApiError::from_engine)?;
+    Ok((StatusCode::OK, Json(SandboxBody::from_info(&vm.info()))))
+}
+
+async fn create_new(
+    state: &AppState,
+    tenant: &Tenant,
+    name: String,
+    req: CreateRequest,
+    spec: &CreateSpec,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    let volume = workspace_volume_name(&tenant.id, &req.agent_id)?;
+    admit(state, &tenant.id, spec.ram_mib, spec.vcpus)?;
+
+    let mut opts = VmOptions::from_image(spec.image.clone())
+        .name(name.clone())
+        .agent_id(req.agent_id.clone())
+        .tenant_id(tenant.id.clone())
+        .detach(true)
+        .network(spec.network.clone())
+        .volume(VolumeMount::named(volume, WORKSPACE_GUEST_PATH))
+        .auto_stop_secs(Some(req.auto_stop_secs.unwrap_or(DEFAULT_AUTO_STOP_SECS)))
+        .env(req.env)
+        .vcpus(spec.vcpus)
+        .ram_mib(spec.ram_mib)
+        .security(SecurityOptions::default())
+        .ready_timeout(READY_TIMEOUT);
+    if let Some(workdir) = req.workdir {
+        opts = opts.workdir(workdir);
+    }
+
+    match state.runtime.create(opts).await {
+        Ok(vm) => {
+            let info = vm.info();
+            tracing::info!(
+                tenant_id = %tenant.id,
+                agent_id = %req.agent_id,
+                id = %info.id,
+                "sandbox created"
+            );
+            Ok((StatusCode::CREATED, Json(SandboxBody::from_info(&info))))
+        }
+        Err(err) => match state.runtime.get_named(&name) {
+            Ok(Some(vm)) => existing_sandbox(&state.runtime, &tenant.id, &name, vm, spec).await,
+            Ok(None) => Err(create_miss_error(err)),
+            Err(lookup) => Err(ApiError::from_engine(lookup)),
+        },
     }
 }
 
@@ -360,6 +500,10 @@ mod tests {
     }
 
     fn harness(limits: Limits) -> Harness {
+        harness_cfg(limits, false)
+    }
+
+    fn harness_cfg(limits: Limits, unrestricted: bool) -> Harness {
         let dir = tempfile::tempdir().unwrap();
         let opened = Runtime::open(dir.path()).unwrap();
         let state = AppState::new(
@@ -369,7 +513,8 @@ mod tests {
             ],
             opened,
             limits,
-        );
+        )
+        .with_unrestricted_net(unrestricted);
         let runtime = Arc::clone(&state.runtime);
         let app = router(state);
         Harness { dir, runtime, app }
@@ -392,23 +537,43 @@ mod tests {
         name: &str,
         pid: i32,
         status: &str,
+        image: Option<&str>,
         config: &serde_json::Value,
     ) {
         let socket = data_dir.join("socks").join(format!("{id}.sock"));
         open_db(data_dir)
             .execute(
                 "INSERT INTO vms (id, name, pid, image, socket, status, config, created_at)
-                 VALUES (?1, ?2, ?3, NULL, ?4, ?5, ?6, 0)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)",
                 params![
                     id,
                     name,
                     pid,
+                    image,
                     socket.to_str().expect("socket utf-8"),
                     status,
                     config.to_string(),
                 ],
             )
             .unwrap();
+    }
+
+    fn alpine_image() -> String {
+        bux::canonical_reference("alpine").unwrap()
+    }
+
+    fn disabled_network() -> serde_json::Value {
+        serde_json::to_value(NetworkSpec::Disabled).unwrap()
+    }
+
+    fn owned_config(tenant: &str, agent: &str) -> serde_json::Value {
+        serde_json::json!({
+            "vcpus": 1,
+            "ram_mib": 512,
+            "tenant_id": tenant,
+            "agent_id": agent,
+            "network": disabled_network(),
+        })
     }
 
     fn dead_pid() -> i32 {
@@ -621,22 +786,23 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn post_allow_net_is_400() {
+    async fn post_unrestricted_without_flag_is_400() {
         let (_dir, app) = test_app(Limits::default());
         let res = send(
             app,
             "POST",
             "/v1/sandboxes",
             Some("secret1"),
-            Body::from(r#"{"agent_id":"a1","image":"alpine","allow_net":["example.com"]}"#),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","unrestricted":true}"#),
         )
         .await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST, "status");
         let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("invalid_config"), "code");
         assert_eq!(
             v.pointer("/error/field")
                 .and_then(serde_json::Value::as_str),
-            Some("allow_net"),
+            Some("unrestricted"),
             "field"
         );
     }
@@ -757,6 +923,7 @@ mod tests {
             "a-tenant1-live",
             pid,
             "running",
+            None,
             &serde_json::json!({
                 "vcpus": 1,
                 "ram_mib": 700,
@@ -791,6 +958,7 @@ mod tests {
             "a-tenant1-dead",
             dead_pid(),
             "running",
+            None,
             &serde_json::json!({
                 "vcpus": 1,
                 "ram_mib": 700,
@@ -852,37 +1020,39 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn same_tenant_post_returns_existing_without_create() {
+    async fn running_same_spec_is_200_and_other_tenant_404() {
         const ID: &str = "abc123aaa001";
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
         let h = harness(Limits::default());
+        let image = alpine_image();
         plant_vm(
             h.dir.path(),
             ID,
             "a-tenant1-a1",
-            dead_pid(),
-            "stopped",
-            &serde_json::json!({
-                "vcpus": 1,
-                "ram_mib": 512,
-                "tenant_id": "tenant1",
-                "agent_id": "a1",
-            }),
+            pid,
+            "running",
+            Some(image.as_str()),
+            &owned_config("tenant1", "a1"),
         );
         let created = send(
             h.app.clone(),
             "POST",
             "/v1/sandboxes",
             Some("secret1"),
-            Body::from(r#"{"agent_id":"a1","image":"alpine","ram_mib":2048}"#),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","env":["FOO=bar"],"workdir":"/tmp"}"#),
         )
         .await;
-        assert_eq!(created.status(), StatusCode::OK, "same tenant");
+        assert_eq!(created.status(), StatusCode::OK, "same spec running");
         let body = json_body(created).await;
         assert_eq!(body.get("id").and_then(serde_json::Value::as_str), Some(ID));
         assert_eq!(
             body.get("ram_mib").and_then(serde_json::Value::as_u64),
             Some(512),
-            "must not compare or overwrite ram"
+            "env/workdir are not conflict fields"
         );
 
         let got = send(
@@ -919,12 +1089,24 @@ mod tests {
             Body::empty(),
         )
         .await;
+        let other_start = send(
+            h.app.clone(),
+            "POST",
+            &format!("/v1/sandboxes/{ID}/start"),
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        drop(child.kill());
+        drop(child.wait());
         assert_eq!(missing.status(), StatusCode::NOT_FOUND, "missing");
         assert_eq!(other_get.status(), StatusCode::NOT_FOUND, "other get");
         assert_eq!(other_del.status(), StatusCode::NOT_FOUND, "other delete");
+        assert_eq!(other_start.status(), StatusCode::NOT_FOUND, "other start");
         let missing_json = json_body(missing).await;
         assert_eq!(json_body(other_get).await, missing_json, "get envelope");
         assert_eq!(json_body(other_del).await, missing_json, "delete envelope");
+        assert_eq!(json_body(other_start).await, missing_json, "start envelope");
 
         let list2 = send(
             h.app.clone(),
@@ -967,6 +1149,7 @@ mod tests {
             "a-tenant1-a1",
             dead_pid(),
             "stopped",
+            None,
             &serde_json::json!({
                 "vcpus": 1,
                 "ram_mib": 512,
@@ -1016,6 +1199,7 @@ mod tests {
             "a-tenant1-a1",
             dead_pid(),
             "stopped",
+            None,
             &serde_json::json!({
                 "vcpus": 1,
                 "ram_mib": 512,
@@ -1082,6 +1266,7 @@ mod tests {
             "a-tenant1-a1",
             dead_pid(),
             "stopped",
+            None,
             &serde_json::json!({
                 "vcpus": 1,
                 "ram_mib": 512,
@@ -1124,6 +1309,7 @@ mod tests {
             "a-tenant1-a1",
             dead_pid(),
             "stopped",
+            None,
             &serde_json::json!({
                 "vcpus": 1,
                 "ram_mib": 512,
@@ -1166,6 +1352,375 @@ mod tests {
         assert_eq!(
             v.pointer("/error/code").and_then(serde_json::Value::as_str),
             Some("security_unavailable"),
+            "code"
+        );
+    }
+
+    async fn post_conflict(body: &'static str) -> (StatusCode, serde_json::Value) {
+        const ID: &str = "abc123aaa010";
+        let h = harness(Limits::default());
+        let image = alpine_image();
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            Some(image.as_str()),
+            &owned_config("tenant1", "a1"),
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(body),
+        )
+        .await;
+        let status = res.status();
+        (status, json_body(res).await)
+    }
+
+    #[tokio::test]
+    async fn spec_mismatch_ram_is_sandbox_exists() {
+        let (status, v) =
+            post_conflict(r#"{"agent_id":"a1","image":"alpine","ram_mib":1024}"#).await;
+        assert_eq!(status, StatusCode::CONFLICT, "status");
+        assert_eq!(error_code(&v), Some("sandbox_exists"), "code");
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("ram_mib"),
+            "field"
+        );
+        assert_eq!(
+            v.pointer("/error/existing_id")
+                .and_then(serde_json::Value::as_str),
+            Some("abc123aaa010"),
+            "existing_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn spec_mismatch_vcpus_is_sandbox_exists() {
+        let (status, v) = post_conflict(r#"{"agent_id":"a1","image":"alpine","vcpus":2}"#).await;
+        assert_eq!(status, StatusCode::CONFLICT, "status");
+        assert_eq!(error_code(&v), Some("sandbox_exists"), "code");
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("vcpus"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn spec_mismatch_image_is_sandbox_exists() {
+        let (status, v) = post_conflict(r#"{"agent_id":"a1","image":"python:slim"}"#).await;
+        assert_eq!(status, StatusCode::CONFLICT, "status");
+        assert_eq!(error_code(&v), Some("sandbox_exists"), "code");
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("image"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn spec_mismatch_network_is_sandbox_exists() {
+        let (status, v) =
+            post_conflict(r#"{"agent_id":"a1","image":"alpine","allow_net":["example.com"]}"#)
+                .await;
+        assert_eq!(status, StatusCode::CONFLICT, "status");
+        assert_eq!(error_code(&v), Some("sandbox_exists"), "code");
+        assert_eq!(
+            v.pointer("/error/field")
+                .and_then(serde_json::Value::as_str),
+            Some("network"),
+            "field"
+        );
+    }
+
+    #[tokio::test]
+    async fn secrets_required_post_is_409() {
+        const ID: &str = "abc123aaa011";
+        let h = harness(Limits::default());
+        let image = alpine_image();
+        let mut config = owned_config("tenant1", "a1");
+        config["secrets_required"] = serde_json::json!(true);
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            Some(image.as_str()),
+            &config,
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "secrets");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("secrets_required"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn canonical_image_aliases_match() {
+        const ID: &str = "abc123aaa012";
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let h = harness(Limits::default());
+        let image = bux::canonical_reference("python:slim").unwrap();
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            pid,
+            "running",
+            Some(image.as_str()),
+            &owned_config("tenant1", "a1"),
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"python:slim"}"#),
+        )
+        .await;
+        drop(child.kill());
+        drop(child.wait());
+        assert_eq!(res.status(), StatusCode::OK, "canonical alias");
+        assert_eq!(
+            json_body(res)
+                .await
+                .get("id")
+                .and_then(serde_json::Value::as_str),
+            Some(ID),
+            "id"
+        );
+    }
+
+    #[tokio::test]
+    async fn allow_net_same_spec_running_is_200() {
+        const ID: &str = "abc123aaa013";
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let h = harness(Limits::default());
+        let image = alpine_image();
+        let mut config = owned_config("tenant1", "a1");
+        config["network"] = serde_json::to_value(NetworkSpec::Enabled {
+            allow_net: vec!["example.com".into()],
+        })
+        .unwrap();
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            pid,
+            "running",
+            Some(image.as_str()),
+            &config,
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","allow_net":["example.com"]}"#),
+        )
+        .await;
+        drop(child.kill());
+        drop(child.wait());
+        assert_eq!(res.status(), StatusCode::OK, "allow_net match");
+    }
+
+    #[tokio::test]
+    async fn unrestricted_with_flag_matches_empty_allow_net() {
+        const ID: &str = "abc123aaa014";
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let h = harness_cfg(Limits::default(), true);
+        let image = alpine_image();
+        let mut config = owned_config("tenant1", "a1");
+        config["network"] = serde_json::to_value(NetworkSpec::Enabled {
+            allow_net: Vec::new(),
+        })
+        .unwrap();
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            pid,
+            "running",
+            Some(image.as_str()),
+            &config,
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine","unrestricted":true}"#),
+        )
+        .await;
+        drop(child.kill());
+        drop(child.wait());
+        assert_eq!(res.status(), StatusCode::OK, "unrestricted match");
+    }
+
+    #[tokio::test]
+    async fn stopping_same_spec_times_out_503() {
+        const ID: &str = "abc123aaa015";
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let h = harness(Limits::default());
+        let image = alpine_image();
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            pid,
+            "stopping",
+            Some(image.as_str()),
+            &owned_config("tenant1", "a1"),
+        );
+        let res = send(
+            h.app,
+            "POST",
+            "/v1/sandboxes",
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a1","image":"alpine"}"#),
+        )
+        .await;
+        drop(child.kill());
+        drop(child.wait());
+        assert_eq!(
+            res.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "still stopping"
+        );
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("guest_unavailable"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_missing_is_404() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/start",
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "missing");
+        assert_eq!(error_code(&json_body(res).await), Some("not_found"), "code");
+    }
+
+    #[tokio::test]
+    async fn start_without_bearer_is_401() {
+        let (_dir, app) = test_app(Limits::default());
+        let res = send(
+            app,
+            "POST",
+            "/v1/sandboxes/0123456789ab/start",
+            None,
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+    }
+
+    #[tokio::test]
+    async fn start_secrets_required_is_409() {
+        const ID: &str = "abc123aaa016";
+        let h = harness(Limits::default());
+        let mut config = owned_config("tenant1", "a1");
+        config["secrets_required"] = serde_json::json!(true);
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            None,
+            &config,
+        );
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{ID}/start"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "secrets");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("secrets_required"),
+            "code"
+        );
+    }
+
+    #[tokio::test]
+    async fn start_running_is_invalid_state() {
+        const ID: &str = "abc123aaa017";
+        let mut child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        let h = harness(Limits::default());
+        plant_vm(
+            h.dir.path(),
+            ID,
+            "a-tenant1-a1",
+            pid,
+            "running",
+            None,
+            &owned_config("tenant1", "a1"),
+        );
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{ID}/start"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        drop(child.kill());
+        drop(child.wait());
+        assert_eq!(res.status(), StatusCode::CONFLICT, "already running");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("invalid_state"),
             "code"
         );
     }
@@ -1218,6 +1773,86 @@ mod tests {
         assert!(
             !admit.contains("disk_usage"),
             "disk cap is data_dir_usage, not disk_usage"
+        );
+    }
+
+    #[test]
+    fn translate_network_table() {
+        assert_eq!(
+            translate_network(&[], false, false).unwrap(),
+            NetworkSpec::Disabled,
+            "omit/empty"
+        );
+        assert_eq!(
+            translate_network(&["pypi.org".into()], false, false).unwrap(),
+            NetworkSpec::Enabled {
+                allow_net: vec!["pypi.org".into()],
+            },
+            "allow_net"
+        );
+        assert!(
+            translate_network(&[], true, false).is_err(),
+            "unrestricted without flag"
+        );
+        assert_eq!(
+            translate_network(&["ignored".into()], true, true).unwrap(),
+            NetworkSpec::Enabled {
+                allow_net: Vec::new(),
+            },
+            "unrestricted with flag"
+        );
+    }
+
+    #[test]
+    fn image_matches_canonical_aliases() {
+        let canonical = bux::canonical_reference("python:slim").unwrap();
+        assert!(image_matches(Some("python:slim"), &canonical), "short");
+        assert!(
+            image_matches(Some("docker.io/library/python:slim"), &canonical),
+            "long"
+        );
+        assert!(!image_matches(Some("alpine"), &canonical), "other");
+        assert!(!image_matches(None, &canonical), "missing");
+    }
+
+    #[test]
+    fn spec_mismatch_ignores_env_and_workdir() {
+        let spec = include_str!("sandboxes.rs")
+            .split("fn spec_mismatch(")
+            .nth(1)
+            .and_then(|rest| rest.split("\nasync fn ").next())
+            .expect("spec_mismatch");
+        assert!(spec.contains("image"), "image");
+        assert!(spec.contains("ram_mib"), "ram");
+        assert!(spec.contains("vcpus"), "vcpus");
+        assert!(spec.contains("network"), "network");
+        assert!(!spec.contains("env"), "env is not a conflict field");
+        assert!(!spec.contains("workdir"), "workdir is not a conflict field");
+    }
+
+    #[test]
+    fn stopped_same_spec_calls_start() {
+        let prod = include_str!("sandboxes.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(prod.contains("start(READY_TIMEOUT)"), "start ready 30s");
+        assert!(prod.contains("create_new"), "retry path after create");
+        assert!(prod.contains("existing_sandbox"), "conflict table");
+    }
+
+    #[test]
+    fn create_retries_get_named_once() {
+        let create_new = include_str!("sandboxes.rs")
+            .split("async fn create_new(")
+            .nth(1)
+            .and_then(|rest| rest.split("\nfn create_miss_error").next())
+            .expect("create_new");
+        let lookups = create_new.matches("get_named").count();
+        assert_eq!(lookups, 1, "retry get_named after create fail");
+        assert!(
+            create_new.contains("existing_sandbox"),
+            "then conflict table"
         );
     }
 }

--- a/crates/bux-serve/src/sandboxes.rs
+++ b/crates/bux-serve/src/sandboxes.rs
@@ -19,7 +19,7 @@ use crate::ids::{sandbox_name, validate_agent_id, workspace_volume_name};
 use crate::state::AppState;
 
 pub(crate) const WORKSPACE_GUEST_PATH: &str = "/workspace";
-const DEFAULT_AUTO_STOP_SECS: u64 = 1800;
+pub(crate) const DEFAULT_AUTO_STOP_SECS: u64 = 1800;
 const STOP_WAIT: Duration = Duration::from_secs(10);
 const READY_TIMEOUT: Duration = Duration::from_secs(30);
 

--- a/crates/bux-serve/src/snapshots.rs
+++ b/crates/bux-serve/src/snapshots.rs
@@ -1,0 +1,898 @@
+//! Snapshot, clone, and restore HTTP. Wraps engine snapshot/clone/restore.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::Json;
+use axum::Router;
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::routing::{delete, get, post};
+use bux::{Runtime, SnapshotInfo, Vm, VolumeMount};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::Tenant;
+use crate::error::{ApiError, JsonBody};
+use crate::ids::{sandbox_name, validate_agent_id, workspace_volume_name};
+use crate::sandboxes::{SandboxBody, WORKSPACE_GUEST_PATH, admit, load_owned};
+use crate::state::AppState;
+
+pub(crate) fn routes() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/v1/sandboxes/{id}/snapshots",
+            get(list_snapshots).post(create_snapshot),
+        )
+        .route(
+            "/v1/sandboxes/{id}/snapshots/{sid}",
+            delete(delete_snapshot),
+        )
+        .route(
+            "/v1/sandboxes/{id}/snapshots/{sid}/restore",
+            post(restore_snapshot),
+        )
+        .route("/v1/sandboxes/{id}/clone", post(clone_one))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateSnapshotRequest {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AgentRequest {
+    agent_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotBody {
+    id: String,
+    vm_id: String,
+    name: Option<String>,
+    disk_bytes: u64,
+    created_at: u64,
+}
+
+impl SnapshotBody {
+    fn from_info(info: &SnapshotInfo) -> Self {
+        Self {
+            id: info.id.clone(),
+            vm_id: info.vm_id.clone(),
+            name: info.name.clone(),
+            disk_bytes: info.disk_bytes,
+            created_at: unix_secs(info.created_at),
+        }
+    }
+}
+
+fn unix_secs(t: SystemTime) -> u64 {
+    t.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
+}
+
+async fn list_snapshots(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+) -> Result<Json<Vec<SnapshotBody>>, ApiError> {
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let snaps = vm.list_snapshots().map_err(ApiError::from_engine)?;
+    Ok(Json(snaps.iter().map(SnapshotBody::from_info).collect()))
+}
+
+async fn create_snapshot(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+    JsonBody(req): JsonBody<CreateSnapshotRequest>,
+) -> Result<(StatusCode, Json<SnapshotBody>), ApiError> {
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let name = req.name.as_deref().filter(|n| !n.is_empty());
+    let info = vm
+        .create_snapshot(name)
+        .await
+        .map_err(ApiError::from_engine)?;
+    tracing::info!(
+        tenant_id = %tenant.id,
+        vm_id = %id,
+        snapshot_id = %info.id,
+        "snapshot created"
+    );
+    Ok((StatusCode::CREATED, Json(SnapshotBody::from_info(&info))))
+}
+
+async fn delete_snapshot(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path((id, sid)): Path<(String, String)>,
+) -> Result<StatusCode, ApiError> {
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let _snap = owned_snapshot(&vm, &id, &sid)?;
+    vm.delete_snapshot(&sid).map_err(ApiError::from_engine)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn restore_snapshot(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path((id, sid)): Path<(String, String)>,
+    JsonBody(req): JsonBody<AgentRequest>,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    validate_agent_id(&req.agent_id)?;
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let snap = owned_snapshot(&vm, &id, &sid)?;
+    let info = vm.info();
+    let name = prepare_spawn(&state, &tenant.id, &req.agent_id, info.ram_mib, info.vcpus)?;
+    let restored = state
+        .runtime
+        .restore(&snap.id, Some(name))
+        .await
+        .map_err(ApiError::from_engine)?;
+    finish_spawn(&state.runtime, &tenant, &req.agent_id, &restored)
+}
+
+async fn clone_one(
+    State(state): State<AppState>,
+    tenant: Tenant,
+    Path(id): Path<String>,
+    JsonBody(req): JsonBody<AgentRequest>,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    validate_agent_id(&req.agent_id)?;
+    let vm = load_owned(&state.runtime, &tenant.id, &id)?;
+    let info = vm.info();
+    let name = prepare_spawn(&state, &tenant.id, &req.agent_id, info.ram_mib, info.vcpus)?;
+    let cloned = Runtime::clone(&state.runtime, &info.id, Some(name))
+        .await
+        .map_err(ApiError::from_engine)?;
+    finish_spawn(&state.runtime, &tenant, &req.agent_id, &cloned)
+}
+
+fn prepare_spawn(
+    state: &AppState,
+    tenant_id: &str,
+    agent_id: &str,
+    ram_mib: u32,
+    vcpus: u8,
+) -> Result<String, ApiError> {
+    let name = sandbox_name(tenant_id, agent_id)?;
+    reject_occupied(&state.runtime, &name)?;
+    admit(state, tenant_id, ram_mib, vcpus)?;
+    Ok(name)
+}
+
+fn finish_spawn(
+    runtime: &Runtime,
+    tenant: &Tenant,
+    agent_id: &str,
+    vm: &Vm,
+) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    let info = vm.info();
+    attach_workspace(runtime, &tenant.id, agent_id, &info.id)?;
+    tracing::info!(
+        tenant_id = %tenant.id,
+        agent_id,
+        id = %info.id,
+        "sandbox cloned or restored"
+    );
+    Ok((StatusCode::CREATED, Json(SandboxBody::from_info(&info))))
+}
+
+fn owned_snapshot(vm: &Vm, vm_id: &str, sid: &str) -> Result<SnapshotInfo, ApiError> {
+    let snaps = vm.list_snapshots().map_err(ApiError::from_engine)?;
+    let snap = snaps
+        .into_iter()
+        .find(|s| s.id == sid)
+        .ok_or_else(ApiError::not_found)?;
+    if snap.vm_id != vm_id {
+        return Err(ApiError::not_found());
+    }
+    Ok(snap)
+}
+
+fn reject_occupied(runtime: &Runtime, name: &str) -> Result<(), ApiError> {
+    if let Some(vm) = runtime.get_named(name).map_err(ApiError::from_engine)? {
+        return Err(ApiError::name_occupied(vm.info().id));
+    }
+    Ok(())
+}
+
+/// Engine clone/restore do not copy source volumes. HTTP clones always have a
+/// unique agent, so attach `ws-{tenant}-{agent}` after create if create did not.
+fn attach_workspace(
+    runtime: &Runtime,
+    tenant_id: &str,
+    agent_id: &str,
+    vm_id: &str,
+) -> Result<(), ApiError> {
+    let name = workspace_volume_name(tenant_id, agent_id)?;
+    let resolved = runtime
+        .volumes()
+        .resolve_mounts(&[VolumeMount::named(name, WORKSPACE_GUEST_PATH)])
+        .map_err(ApiError::from_engine)?;
+    runtime
+        .volumes()
+        .link_vm(vm_id, &resolved)
+        .map_err(ApiError::from_engine)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, reason = "tests")]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::header::AUTHORIZATION;
+    use axum::http::{Request, header};
+    use rusqlite::params;
+    use tower::ServiceExt;
+
+    use crate::ApiKey;
+    use crate::router::router;
+    use crate::state::Limits;
+
+    struct Harness {
+        dir: tempfile::TempDir,
+        runtime: Arc<Runtime>,
+        app: Router,
+    }
+
+    fn harness(limits: Limits) -> Harness {
+        let dir = tempfile::tempdir().unwrap();
+        let opened = Runtime::open(dir.path()).unwrap();
+        let state = AppState::new(
+            vec![
+                ApiKey::new("tenant1", "secret1").unwrap(),
+                ApiKey::new("tenant2", "secret2").unwrap(),
+            ],
+            opened,
+            limits,
+        );
+        let runtime = Arc::clone(&state.runtime);
+        let app = router(state);
+        Harness { dir, runtime, app }
+    }
+
+    fn open_db(data_dir: &Path) -> rusqlite::Connection {
+        let conn = rusqlite::Connection::open(data_dir.join("bux.db")).unwrap();
+        conn.busy_timeout(Duration::from_secs(5)).unwrap();
+        conn
+    }
+
+    fn plant_vm(
+        data_dir: &Path,
+        id: &str,
+        name: &str,
+        pid: i32,
+        status: &str,
+        config: &serde_json::Value,
+    ) {
+        let socket = data_dir.join("socks").join(format!("{id}.sock"));
+        open_db(data_dir)
+            .execute(
+                "INSERT INTO vms (id, name, pid, image, socket, status, config, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0)",
+                params![
+                    id,
+                    name,
+                    pid,
+                    Option::<String>::None,
+                    socket.to_str().expect("socket utf-8"),
+                    status,
+                    config.to_string(),
+                ],
+            )
+            .unwrap();
+    }
+
+    fn plant_snapshot(
+        data_dir: &Path,
+        id: &str,
+        vm_id: &str,
+        name: Option<&str>,
+        disk_path: &str,
+        disk_bytes: i64,
+    ) {
+        open_db(data_dir)
+            .execute(
+                "INSERT INTO snapshots (id, vm_id, name, disk_path, disk_bytes, created_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, 0)",
+                params![id, vm_id, name, disk_path, disk_bytes],
+            )
+            .unwrap();
+    }
+
+    fn owned_config(tenant: &str, agent: &str) -> serde_json::Value {
+        serde_json::json!({
+            "vcpus": 1,
+            "ram_mib": 512,
+            "tenant_id": tenant,
+            "agent_id": agent,
+        })
+    }
+
+    fn dead_pid() -> i32 {
+        let mut child = std::process::Command::new("true").spawn().unwrap();
+        let pid = i32::try_from(child.id()).unwrap();
+        drop(child.wait());
+        pid
+    }
+
+    fn error_code(v: &serde_json::Value) -> Option<&str> {
+        v.pointer("/error/code").and_then(serde_json::Value::as_str)
+    }
+
+    async fn json_body(res: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(res.into_body(), 64 * 1024)
+            .await
+            .expect("body");
+        if bytes.is_empty() {
+            return serde_json::Value::Null;
+        }
+        serde_json::from_slice(&bytes).expect("json")
+    }
+
+    async fn send(
+        app: Router,
+        method: &str,
+        uri: &str,
+        token: Option<&str>,
+        body: Body,
+    ) -> axum::response::Response {
+        let mut builder = Request::builder().method(method).uri(uri);
+        if let Some(token) = token {
+            builder = builder.header(AUTHORIZATION, format!("Bearer {token}"));
+        }
+        if method == "POST" {
+            builder = builder.header(header::CONTENT_TYPE, "application/json");
+        }
+        app.oneshot(builder.body(body).unwrap()).await.unwrap()
+    }
+
+    const SRC: &str = "abc123aaa001";
+    const OTHER: &str = "abc123aaa002";
+    const SNAP: &str = "snap00000001";
+
+    fn plant_owned_stopped(h: &Harness, id: &str, agent: &str) {
+        plant_vm(
+            h.dir.path(),
+            id,
+            &format!("a-tenant1-{agent}"),
+            dead_pid(),
+            "stopped",
+            &owned_config("tenant1", agent),
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshots_without_bearer_is_401() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            None,
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "status");
+        assert_eq!(error_code(&json_body(res).await), Some("unauthorized"));
+    }
+
+    #[tokio::test]
+    async fn snapshots_missing_sandbox_is_404() {
+        let h = harness(Limits::default());
+        let res = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "missing");
+        assert_eq!(error_code(&json_body(res).await), Some("not_found"));
+    }
+
+    #[tokio::test]
+    async fn snapshots_other_tenant_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let missing = send(
+            h.app.clone(),
+            "GET",
+            "/v1/sandboxes/ffffffffffff",
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        let other = send(
+            h.app.clone(),
+            "GET",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        let other_post = send(
+            h.app.clone(),
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret2"),
+            Body::from("{}"),
+        )
+        .await;
+        let other_clone = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret2"),
+            Body::from(r#"{"agent_id":"c1"}"#),
+        )
+        .await;
+        assert_eq!(missing.status(), StatusCode::NOT_FOUND, "missing");
+        assert_eq!(other.status(), StatusCode::NOT_FOUND, "other list");
+        assert_eq!(other_post.status(), StatusCode::NOT_FOUND, "other create");
+        assert_eq!(other_clone.status(), StatusCode::NOT_FOUND, "other clone");
+        let envelope = json_body(missing).await;
+        assert_eq!(json_body(other).await, envelope, "list envelope");
+        assert_eq!(json_body(other_post).await, envelope, "create envelope");
+        assert_eq!(json_body(other_clone).await, envelope, "clone envelope");
+    }
+
+    #[tokio::test]
+    async fn list_planted_snapshot_omits_disk_path() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(
+            h.dir.path(),
+            SNAP,
+            SRC,
+            Some("s1"),
+            "/secret/host/snap.qcow2",
+            42,
+        );
+        let res = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::OK, "list");
+        let v = json_body(res).await;
+        let row = v.as_array().and_then(|a| a.first()).expect("one snap");
+        assert_eq!(
+            row.get("id").and_then(serde_json::Value::as_str),
+            Some(SNAP)
+        );
+        assert_eq!(
+            row.get("vm_id").and_then(serde_json::Value::as_str),
+            Some(SRC)
+        );
+        assert_eq!(
+            row.get("name").and_then(serde_json::Value::as_str),
+            Some("s1")
+        );
+        assert_eq!(
+            row.get("disk_bytes").and_then(serde_json::Value::as_u64),
+            Some(42)
+        );
+        assert!(row.get("disk_path").is_none(), "host path must not leak");
+        assert!(
+            row.get("created_at")
+                .and_then(serde_json::Value::as_u64)
+                .is_some()
+        );
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_without_overlay_is_409() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::from("{}"),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "no overlay");
+        assert_eq!(error_code(&json_body(res).await), Some("invalid_state"));
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_copies_overlay_without_hypervisor() {
+        let h = harness(Limits::default());
+        let overlay = h.dir.path().join("overlay.qcow2");
+        std::fs::write(&overlay, b"qcow-bytes").unwrap();
+        plant_vm(
+            h.dir.path(),
+            SRC,
+            "a-tenant1-a1",
+            dead_pid(),
+            "stopped",
+            &serde_json::json!({
+                "vcpus": 1,
+                "ram_mib": 512,
+                "tenant_id": "tenant1",
+                "agent_id": "a1",
+                "root_disk": overlay.to_str().expect("utf-8"),
+            }),
+        );
+        let res = send(
+            h.app.clone(),
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::from(r#"{"name":"marker"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CREATED, "created");
+        let v = json_body(res).await;
+        assert!(v.get("disk_path").is_none(), "omit host path");
+        assert_eq!(
+            v.get("name").and_then(serde_json::Value::as_str),
+            Some("marker")
+        );
+        assert_eq!(
+            v.get("disk_bytes").and_then(serde_json::Value::as_u64),
+            Some(10)
+        );
+        assert_eq!(
+            v.get("vm_id").and_then(serde_json::Value::as_str),
+            Some(SRC)
+        );
+        let sid = v.get("id").and_then(serde_json::Value::as_str).expect("id");
+        assert!(!sid.is_empty(), "snapshot id");
+
+        let after_create = send(
+            h.app.clone(),
+            "GET",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        let rows = json_body(after_create).await;
+        assert_eq!(rows.as_array().map(Vec::len), Some(1), "listed");
+
+        let del = send(
+            h.app.clone(),
+            "DELETE",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{sid}"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(del.status(), StatusCode::NO_CONTENT, "deleted");
+        let after_delete = send(
+            h.app,
+            "GET",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(
+            json_body(after_delete).await,
+            serde_json::json!([]),
+            "empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_snapshot_wrong_vm_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_owned_stopped(&h, OTHER, "a2");
+        plant_snapshot(h.dir.path(), SNAP, OTHER, Some("x"), "/tmp/x.qcow2", 1);
+        let res = send(
+            h.app.clone(),
+            "DELETE",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "foreign snap");
+        assert_eq!(error_code(&json_body(res).await), Some("not_found"));
+        assert!(
+            h.runtime
+                .get_exact(OTHER)
+                .unwrap()
+                .list_snapshots()
+                .unwrap()
+                .iter()
+                .any(|s| s.id == SNAP),
+            "must not delete the other VM's snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_snapshot_other_tenant_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(h.dir.path(), SNAP, SRC, Some("s"), "/tmp/s.qcow2", 1);
+        let res = send(
+            h.app,
+            "DELETE",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}"),
+            Some("secret2"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "other tenant");
+    }
+
+    #[tokio::test]
+    async fn restore_missing_snapshot_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}/restore"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"r1"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "missing snap");
+    }
+
+    #[tokio::test]
+    async fn restore_wrong_vm_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_owned_stopped(&h, OTHER, "a2");
+        plant_snapshot(h.dir.path(), SNAP, OTHER, Some("x"), "/tmp/x.qcow2", 1);
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}/restore"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"r1"}"#),
+        )
+        .await;
+        assert_eq!(
+            res.status(),
+            StatusCode::NOT_FOUND,
+            "snap belongs elsewhere"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_after_source_delete_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(h.dir.path(), SNAP, SRC, Some("s"), "/tmp/s.qcow2", 1);
+        let del = send(
+            h.app.clone(),
+            "DELETE",
+            &format!("/v1/sandboxes/{SRC}"),
+            Some("secret1"),
+            Body::empty(),
+        )
+        .await;
+        assert_eq!(del.status(), StatusCode::NO_CONTENT, "source gone");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}/restore"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"r1"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "CASCADE");
+        assert_eq!(error_code(&json_body(res).await), Some("not_found"));
+    }
+
+    #[tokio::test]
+    async fn restore_and_clone_require_agent_id() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(h.dir.path(), SNAP, SRC, Some("s"), "/tmp/s.qcow2", 1);
+        let restore = send(
+            h.app.clone(),
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}/restore"),
+            Some("secret1"),
+            Body::from("{}"),
+        )
+        .await;
+        let clone = send(
+            h.app.clone(),
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret1"),
+            Body::from("{}"),
+        )
+        .await;
+        let hyphen = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"a-b"}"#),
+        )
+        .await;
+        assert_eq!(restore.status(), StatusCode::BAD_REQUEST, "restore body");
+        assert_eq!(clone.status(), StatusCode::BAD_REQUEST, "clone body");
+        assert_eq!(hyphen.status(), StatusCode::BAD_REQUEST, "hyphen agent");
+        assert_eq!(error_code(&json_body(hyphen).await), Some("invalid_config"));
+    }
+
+    #[tokio::test]
+    async fn clone_unknown_field_is_400() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"c1","bind":"/tmp"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "unknown field");
+    }
+
+    #[tokio::test]
+    async fn clone_name_occupied_is_409() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_owned_stopped(&h, OTHER, "dst");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"dst"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "occupied");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("name_occupied"));
+        assert_eq!(
+            v.pointer("/error/existing_id")
+                .and_then(serde_json::Value::as_str),
+            Some(OTHER)
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_admission_count_is_429() {
+        let h = harness(Limits {
+            max_sandboxes: 1,
+            ..Limits::default()
+        });
+        plant_owned_stopped(&h, SRC, "a1");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"c1"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "count");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("resource_exhausted")
+        );
+    }
+
+    #[tokio::test]
+    async fn clone_admission_running_ram_is_429() {
+        let h = harness(Limits {
+            max_running_ram_mib: 100,
+            ..Limits::default()
+        });
+        plant_owned_stopped(&h, SRC, "a1");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/clone"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"c1"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "ram");
+        assert_eq!(
+            error_code(&json_body(res).await),
+            Some("resource_exhausted")
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_admission_is_429() {
+        let h = harness(Limits {
+            max_sandboxes: 1,
+            ..Limits::default()
+        });
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(h.dir.path(), SNAP, SRC, Some("s"), "/tmp/s.qcow2", 1);
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}/restore"),
+            Some("secret1"),
+            Body::from(r#"{"agent_id":"r1"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::TOO_MANY_REQUESTS, "count");
+    }
+
+    #[tokio::test]
+    async fn restore_other_tenant_is_404() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(h.dir.path(), SNAP, SRC, Some("s"), "/tmp/s.qcow2", 1);
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots/{SNAP}/restore"),
+            Some("secret2"),
+            Body::from(r#"{"agent_id":"r1"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::NOT_FOUND, "other tenant");
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_unknown_field_is_400() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::from(r#"{"name":"s","disk_path":"/tmp"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_REQUEST, "unknown field");
+    }
+
+    #[test]
+    fn handlers_never_call_runtime_get() {
+        let prod = include_str!("snapshots.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        let forbidden = concat!("runtime.get", "(");
+        for (i, line) in prod.lines().enumerate() {
+            assert!(
+                !line.contains(forbidden),
+                "HTTP must use get_exact via load_owned, line {}: {line}",
+                i + 1
+            );
+        }
+        assert!(prod.contains("load_owned"), "ownership via load_owned");
+        assert!(
+            prod.contains("Runtime::clone"),
+            "Arc::clone would drop source id"
+        );
+    }
+
+    #[test]
+    fn snapshot_json_type_has_no_disk_path_field() {
+        let body = SnapshotBody {
+            id: "s".into(),
+            vm_id: "v".into(),
+            name: None,
+            disk_bytes: 0,
+            created_at: 0,
+        };
+        let v = serde_json::to_value(&body).unwrap();
+        assert!(v.get("disk_path").is_none(), "serde omit");
+        assert!(v.get("id").is_some());
+        assert!(v.get("disk_bytes").is_some());
+    }
+}

--- a/crates/bux-serve/src/snapshots.rs
+++ b/crates/bux-serve/src/snapshots.rs
@@ -9,11 +9,14 @@ use axum::http::StatusCode;
 use axum::routing::{delete, get, post};
 use bux::{Runtime, SnapshotInfo, Vm, VolumeMount};
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
 use crate::auth::Tenant;
 use crate::error::{ApiError, JsonBody};
 use crate::ids::{sandbox_name, validate_agent_id, workspace_volume_name};
-use crate::sandboxes::{SandboxBody, WORKSPACE_GUEST_PATH, admit, load_owned};
+use crate::sandboxes::{
+    DEFAULT_AUTO_STOP_SECS, SandboxBody, WORKSPACE_GUEST_PATH, admit, load_owned,
+};
 use crate::state::AppState;
 
 pub(crate) fn routes() -> Router<AppState> {
@@ -33,21 +36,21 @@ pub(crate) fn routes() -> Router<AppState> {
         .route("/v1/sandboxes/{id}/clone", post(clone_one))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct CreateSnapshotRequest {
+pub(crate) struct CreateSnapshotRequest {
     #[serde(default)]
     name: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
-struct AgentRequest {
+pub(crate) struct AgentRequest {
     agent_id: String,
 }
 
-#[derive(Debug, Serialize)]
-struct SnapshotBody {
+#[derive(Debug, Serialize, ToSchema)]
+pub(crate) struct SnapshotBody {
     id: String,
     vm_id: String,
     name: Option<String>,
@@ -71,7 +74,19 @@ fn unix_secs(t: SystemTime) -> u64 {
     t.duration_since(UNIX_EPOCH).unwrap_or_default().as_secs()
 }
 
-async fn list_snapshots(
+#[utoipa::path(
+    get,
+    path = "/v1/sandboxes/{id}/snapshots",
+    operation_id = "listSnapshots",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    responses(
+        (status = 200, description = "Snapshots for this sandbox", body = [SnapshotBody]),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant")
+    )
+)]
+pub(crate) async fn list_snapshots(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -81,7 +96,22 @@ async fn list_snapshots(
     Ok(Json(snaps.iter().map(SnapshotBody::from_info).collect()))
 }
 
-async fn create_snapshot(
+#[utoipa::path(
+    post,
+    path = "/v1/sandboxes/{id}/snapshots",
+    operation_id = "createSnapshot",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    request_body = CreateSnapshotRequest,
+    responses(
+        (status = 201, description = "Created", body = SnapshotBody),
+        (status = 400, description = "Invalid body"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant"),
+        (status = 409, description = "Duplicate name or no overlay")
+    )
+)]
+pub(crate) async fn create_snapshot(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -112,7 +142,22 @@ async fn create_snapshot(
     Ok((StatusCode::CREATED, Json(SnapshotBody::from_info(&info))))
 }
 
-async fn delete_snapshot(
+#[utoipa::path(
+    delete,
+    path = "/v1/sandboxes/{id}/snapshots/{sid}",
+    operation_id = "deleteSnapshot",
+    tag = "Sandboxes",
+    params(
+        ("id" = String, Path, description = "Exact 12-char hex sandbox id"),
+        ("sid" = String, Path, description = "Snapshot id")
+    ),
+    responses(
+        (status = 204, description = "Deleted"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing, other tenant, or snapshot belongs elsewhere")
+    )
+)]
+pub(crate) async fn delete_snapshot(
     State(state): State<AppState>,
     tenant: Tenant,
     Path((id, sid)): Path<(String, String)>,
@@ -123,7 +168,27 @@ async fn delete_snapshot(
     Ok(StatusCode::NO_CONTENT)
 }
 
-async fn restore_snapshot(
+#[utoipa::path(
+    post,
+    path = "/v1/sandboxes/{id}/snapshots/{sid}/restore",
+    operation_id = "restoreSnapshot",
+    tag = "Sandboxes",
+    params(
+        ("id" = String, Path, description = "Exact 12-char hex sandbox id"),
+        ("sid" = String, Path, description = "Snapshot id")
+    ),
+    request_body = AgentRequest,
+    responses(
+        (status = 201, description = "Restored sandbox", body = SandboxBody),
+        (status = 400, description = "Invalid body"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing, other tenant, or snapshot belongs elsewhere"),
+        (status = 409, description = "Name occupied"),
+        (status = 412, description = "No hardware virtualization"),
+        (status = 429, description = "Count, running RAM, or disk cap")
+    )
+)]
+pub(crate) async fn restore_snapshot(
     State(state): State<AppState>,
     tenant: Tenant,
     Path((id, sid)): Path<(String, String)>,
@@ -141,7 +206,24 @@ async fn restore_snapshot(
     finish_spawn(&state.runtime, &tenant, &req.agent_id, &restored)
 }
 
-async fn clone_one(
+#[utoipa::path(
+    post,
+    path = "/v1/sandboxes/{id}/clone",
+    operation_id = "cloneSandbox",
+    tag = "Sandboxes",
+    params(("id" = String, Path, description = "Exact 12-char hex sandbox id")),
+    request_body = AgentRequest,
+    responses(
+        (status = 201, description = "Cloned sandbox", body = SandboxBody),
+        (status = 400, description = "Invalid body"),
+        (status = 401, description = "Missing or invalid Bearer token"),
+        (status = 404, description = "Missing or other tenant"),
+        (status = 409, description = "Name occupied"),
+        (status = 412, description = "No hardware virtualization"),
+        (status = 429, description = "Count, running RAM, or disk cap")
+    )
+)]
+pub(crate) async fn clone_one(
     State(state): State<AppState>,
     tenant: Tenant,
     Path(id): Path<String>,
@@ -177,6 +259,8 @@ fn finish_spawn(
     agent_id: &str,
     vm: &Vm,
 ) -> Result<(StatusCode, Json<SandboxBody>), ApiError> {
+    vm.set_auto_stop_secs(Some(DEFAULT_AUTO_STOP_SECS))
+        .map_err(ApiError::from_engine)?;
     let info = vm.info();
     attach_workspace(runtime, &tenant.id, agent_id, &info.id)?;
     tracing::info!(
@@ -961,6 +1045,32 @@ mod tests {
     }
 
     #[test]
+    fn finish_spawn_sets_http_auto_stop_secs() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let vm = h.runtime.get_exact(SRC).unwrap();
+        let tenant = Tenant {
+            id: "tenant1".into(),
+        };
+        let (status, _) = finish_spawn(&h.runtime, &tenant, "a1", &vm).unwrap();
+        assert_eq!(status, StatusCode::CREATED, "spawned");
+        let cfg: serde_json::Value = serde_json::from_str(
+            &open_db(h.dir.path())
+                .query_row("SELECT config FROM vms WHERE id = ?1", [SRC], |row| {
+                    row.get::<_, String>(0)
+                })
+                .unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            cfg.get("auto_stop_secs")
+                .and_then(serde_json::Value::as_u64),
+            Some(DEFAULT_AUTO_STOP_SECS),
+            "HTTP clone/restore must idle-stop"
+        );
+    }
+
+    #[test]
     fn handlers_never_call_runtime_get() {
         let prod = include_str!("snapshots.rs")
             .split("#[cfg(test)]")
@@ -978,6 +1088,10 @@ mod tests {
         assert!(
             prod.contains("Runtime::clone"),
             "Arc::clone would drop source id"
+        );
+        assert!(
+            prod.contains("set_auto_stop_secs"),
+            "clone/restore must persist HTTP idle-stop"
         );
     }
 

--- a/crates/bux-serve/src/snapshots.rs
+++ b/crates/bux-serve/src/snapshots.rs
@@ -89,10 +89,20 @@ async fn create_snapshot(
 ) -> Result<(StatusCode, Json<SnapshotBody>), ApiError> {
     let vm = load_owned(&state.runtime, &tenant.id, &id)?;
     let name = req.name.as_deref().filter(|n| !n.is_empty());
-    let info = vm
-        .create_snapshot(name)
-        .await
-        .map_err(ApiError::from_engine)?;
+    if let Some(n) = name {
+        reject_snapshot_name(&vm, n)?;
+    }
+    let info = match vm.create_snapshot(name).await {
+        Ok(info) => info,
+        Err(err) => {
+            if let Some(n) = name
+                && snapshot_name_taken(&vm, n)?
+            {
+                return Err(duplicate_snapshot_name());
+            }
+            return Err(ApiError::from_engine(err));
+        }
+    };
     tracing::info!(
         tenant_id = %tenant.id,
         vm_id = %id,
@@ -124,11 +134,10 @@ async fn restore_snapshot(
     let snap = owned_snapshot(&vm, &id, &sid)?;
     let info = vm.info();
     let name = prepare_spawn(&state, &tenant.id, &req.agent_id, info.ram_mib, info.vcpus)?;
-    let restored = state
-        .runtime
-        .restore(&snap.id, Some(name))
-        .await
-        .map_err(ApiError::from_engine)?;
+    let restored = match state.runtime.restore(&snap.id, Some(name.clone())).await {
+        Ok(created) => created,
+        Err(err) => return Err(spawn_create_error(&state.runtime, &name, err)),
+    };
     finish_spawn(&state.runtime, &tenant, &req.agent_id, &restored)
 }
 
@@ -142,9 +151,10 @@ async fn clone_one(
     let vm = load_owned(&state.runtime, &tenant.id, &id)?;
     let info = vm.info();
     let name = prepare_spawn(&state, &tenant.id, &req.agent_id, info.ram_mib, info.vcpus)?;
-    let cloned = Runtime::clone(&state.runtime, &info.id, Some(name))
-        .await
-        .map_err(ApiError::from_engine)?;
+    let cloned = match Runtime::clone(&state.runtime, &info.id, Some(name.clone())).await {
+        Ok(created) => created,
+        Err(err) => return Err(spawn_create_error(&state.runtime, &name, err)),
+    };
     finish_spawn(&state.runtime, &tenant, &req.agent_id, &cloned)
 }
 
@@ -197,6 +207,36 @@ fn reject_occupied(runtime: &Runtime, name: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
+/// UNIQUE `vms.name` after a racing clone/restore is occupancy, not 500.
+fn spawn_create_error(runtime: &Runtime, name: &str, err: bux::Error) -> ApiError {
+    match runtime.get_named(name) {
+        Ok(Some(vm)) => ApiError::name_occupied(vm.info().id),
+        Ok(None) => ApiError::from_engine(err),
+        Err(lookup) => ApiError::from_engine(lookup),
+    }
+}
+
+fn reject_snapshot_name(vm: &Vm, name: &str) -> Result<(), ApiError> {
+    if snapshot_name_taken(vm, name)? {
+        return Err(duplicate_snapshot_name());
+    }
+    Ok(())
+}
+
+fn snapshot_name_taken(vm: &Vm, name: &str) -> Result<bool, ApiError> {
+    Ok(vm
+        .list_snapshots()
+        .map_err(ApiError::from_engine)?
+        .iter()
+        .any(|s| s.name.as_deref() == Some(name)))
+}
+
+fn duplicate_snapshot_name() -> ApiError {
+    ApiError::from_engine(bux::Error::InvalidState(
+        "snapshot name already exists".into(),
+    ))
+}
+
 /// Engine clone/restore do not copy source volumes. HTTP clones always have a
 /// unique agent, so attach `ws-{tenant}-{agent}` after create if create did not.
 fn attach_workspace(
@@ -228,6 +268,7 @@ mod tests {
     use axum::body::Body;
     use axum::http::header::AUTHORIZATION;
     use axum::http::{Request, header};
+    use axum::response::IntoResponse;
     use rusqlite::params;
     use tower::ServiceExt;
 
@@ -489,6 +530,30 @@ mod tests {
                 .and_then(serde_json::Value::as_u64)
                 .is_some()
         );
+    }
+
+    #[tokio::test]
+    async fn create_snapshot_duplicate_name_is_409() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        plant_snapshot(
+            h.dir.path(),
+            SNAP,
+            SRC,
+            Some("checkpoint"),
+            "/tmp/s.qcow2",
+            1,
+        );
+        let res = send(
+            h.app,
+            "POST",
+            &format!("/v1/sandboxes/{SRC}/snapshots"),
+            Some("secret1"),
+            Body::from(r#"{"name":"checkpoint"}"#),
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::CONFLICT, "duplicate name");
+        assert_eq!(error_code(&json_body(res).await), Some("invalid_state"));
     }
 
     #[tokio::test]
@@ -858,6 +923,41 @@ mod tests {
         )
         .await;
         assert_eq!(res.status(), StatusCode::BAD_REQUEST, "unknown field");
+    }
+
+    #[tokio::test]
+    async fn spawn_create_error_occupied_is_409_not_500() {
+        let h = harness(Limits::default());
+        plant_owned_stopped(&h, SRC, "a1");
+        let err = spawn_create_error(
+            &h.runtime,
+            "a-tenant1-a1",
+            bux::Error::InvalidConfig("UNIQUE".into()),
+        );
+        let res = err.into_response();
+        assert_eq!(res.status(), StatusCode::CONFLICT, "occupied");
+        let v = json_body(res).await;
+        assert_eq!(error_code(&v), Some("name_occupied"));
+        assert_eq!(
+            v.pointer("/error/existing_id")
+                .and_then(serde_json::Value::as_str),
+            Some(SRC)
+        );
+    }
+
+    #[test]
+    fn spawn_create_error_missing_keeps_engine_status() {
+        let h = harness(Limits::default());
+        let err = spawn_create_error(
+            &h.runtime,
+            "a-tenant1-missing",
+            bux::Error::SecurityUnavailable("no hardware virtualization".into()),
+        );
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::PRECONDITION_FAILED,
+            "still 412 when name is free"
+        );
     }
 
     #[test]

--- a/crates/bux-serve/src/state.rs
+++ b/crates/bux-serve/src/state.rs
@@ -1,0 +1,126 @@
+//! Worker process state: API keys, exclusive [`bux::Runtime`], admission limits.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::ApiKey;
+
+/// Server-enforced create caps and request defaults.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Limits {
+    /// Maximum sandboxes for one tenant.
+    pub max_sandboxes: u32,
+    /// Maximum sandboxes on this worker (all tenants).
+    pub max_sandboxes_global: u32,
+    /// Maximum RAM per sandbox (MiB). Exceeded → 400.
+    pub max_ram_mib: u32,
+    /// Maximum vCPUs per sandbox. Exceeded → 400.
+    pub max_vcpus: u8,
+    /// Maximum sum of Running+Stopping RAM plus the new request (MiB). Exceeded → 429.
+    pub max_running_ram_mib: u32,
+    /// Maximum recursive data-dir usage (bytes). Exceeded → 429.
+    pub max_disk_bytes: u64,
+    /// `ram_mib` when the create body omits it.
+    pub default_ram_mib: u32,
+    /// `vcpus` when the create body omits it.
+    pub default_vcpus: u8,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_sandboxes: 32,
+            max_sandboxes_global: 32,
+            max_ram_mib: 2048,
+            max_vcpus: 4,
+            max_running_ram_mib: 8192,
+            max_disk_bytes: 32_u64 * 1024 * 1024 * 1024,
+            default_ram_mib: 512,
+            default_vcpus: 1,
+        }
+    }
+}
+
+/// Shared axum state. One [`bux::Runtime`] (one exclusive flock) per process.
+#[derive(Clone, Debug)]
+pub(crate) struct AppState {
+    keys: Arc<[ApiKey]>,
+    pub(crate) runtime: Arc<bux::Runtime>,
+    pub(crate) limits: Limits,
+}
+
+impl AppState {
+    pub(crate) fn new(keys: Vec<ApiKey>, runtime: bux::Runtime, limits: Limits) -> Self {
+        Self {
+            keys: keys.into(),
+            runtime: Arc::new(runtime),
+            limits,
+        }
+    }
+
+    /// Compare `token` to every key secret (no early return). Last match wins.
+    pub(crate) fn tenant_for_bearer(&self, token: &str) -> Option<&str> {
+        let token = token.as_bytes();
+        let mut found = None;
+        for key in self.keys.iter() {
+            if constant_time_eq(key.secret_bytes(), token) {
+                found = Some(key.id());
+            }
+        }
+        found
+    }
+}
+
+/// Pad to at least this many bytes so unequal lengths are not a `zip` min-len oracle.
+const CT_EQ_MIN_ITERS: usize = 256;
+
+pub(crate) fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let mut acc = u8::from(left.len() != right.len());
+    let n = left.len().max(right.len()).max(CT_EQ_MIN_ITERS);
+    for i in 0..n {
+        acc |= left.get(i).copied().unwrap_or(0) ^ right.get(i).copied().unwrap_or(0);
+    }
+    acc == 0
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tenant_for_bearer_last_match_wins() {
+        let dir = tempfile::tempdir().unwrap();
+        let runtime = bux::Runtime::open(dir.path()).unwrap();
+        let state = AppState::new(
+            vec![
+                ApiKey::new("first", "shared").unwrap(),
+                ApiKey::new("second", "shared").unwrap(),
+            ],
+            runtime,
+            Limits::default(),
+        );
+        assert_eq!(
+            state.tenant_for_bearer("shared"),
+            Some("second"),
+            "must walk every key"
+        );
+    }
+
+    #[test]
+    fn constant_time_eq_cases() {
+        assert!(constant_time_eq(b"abc", b"abc"), "eq");
+        assert!(!constant_time_eq(b"abc", b"abd"), "neq");
+        assert!(!constant_time_eq(b"abc", b"ab"), "len");
+        assert!(constant_time_eq(b"", b""), "empty");
+    }
+
+    #[test]
+    fn default_disk_cap_is_32_gib() {
+        assert_eq!(
+            Limits::default().max_disk_bytes,
+            32_u64 * 1024 * 1024 * 1024
+        );
+    }
+}

--- a/crates/bux-serve/src/state.rs
+++ b/crates/bux-serve/src/state.rs
@@ -3,11 +3,12 @@
 use std::sync::Arc;
 
 use serde::Serialize;
+use utoipa::ToSchema;
 
 use crate::ApiKey;
 
 /// Server-enforced create caps and request defaults.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, ToSchema)]
 pub struct Limits {
     /// Maximum sandboxes for one tenant.
     pub max_sandboxes: u32,

--- a/crates/bux-serve/src/state.rs
+++ b/crates/bux-serve/src/state.rs
@@ -21,6 +21,12 @@ pub struct Limits {
     pub max_running_ram_mib: u32,
     /// Maximum recursive data-dir usage (bytes). Exceeded → 429.
     pub max_disk_bytes: u64,
+    /// Maximum compressed pull size (bytes). Exceeded → 413.
+    pub max_pull_bytes: u64,
+    /// Maximum collected stdout or stderr per exec (bytes). Exceeded → truncate.
+    pub max_exec_output_bytes: u64,
+    /// Registry pull deadline (seconds).
+    pub pull_timeout_secs: u64,
     /// `ram_mib` when the create body omits it.
     pub default_ram_mib: u32,
     /// `vcpus` when the create body omits it.
@@ -36,6 +42,9 @@ impl Default for Limits {
             max_vcpus: 4,
             max_running_ram_mib: 8192,
             max_disk_bytes: 32_u64 * 1024 * 1024 * 1024,
+            max_pull_bytes: 4_u64 * 1024 * 1024 * 1024,
+            max_exec_output_bytes: 1024 * 1024,
+            pull_timeout_secs: 300,
             default_ram_mib: 512,
             default_vcpus: 1,
         }
@@ -122,5 +131,13 @@ mod tests {
             Limits::default().max_disk_bytes,
             32_u64 * 1024 * 1024 * 1024
         );
+    }
+
+    #[test]
+    fn default_pull_and_exec_caps() {
+        let limits = Limits::default();
+        assert_eq!(limits.max_pull_bytes, 4_u64 * 1024 * 1024 * 1024);
+        assert_eq!(limits.max_exec_output_bytes, 1024 * 1024);
+        assert_eq!(limits.pull_timeout_secs, 300);
     }
 }

--- a/crates/bux-serve/src/state.rs
+++ b/crates/bux-serve/src/state.rs
@@ -57,6 +57,7 @@ pub(crate) struct AppState {
     keys: Arc<[ApiKey]>,
     pub(crate) runtime: Arc<bux::Runtime>,
     pub(crate) limits: Limits,
+    pub(crate) allow_unrestricted_net: bool,
 }
 
 impl AppState {
@@ -65,7 +66,15 @@ impl AppState {
             keys: keys.into(),
             runtime: Arc::new(runtime),
             limits,
+            allow_unrestricted_net: false,
         }
+    }
+
+    /// Permit `"unrestricted": true` on create.
+    #[must_use]
+    pub(crate) const fn with_unrestricted_net(mut self, allow: bool) -> Self {
+        self.allow_unrestricted_net = allow;
+        self
     }
 
     /// Compare `token` to every key secret (no early return). Last match wins.

--- a/crates/bux/src/lib.rs
+++ b/crates/bux/src/lib.rs
@@ -58,7 +58,7 @@ mod volumes;
 mod watchdog;
 
 #[cfg(unix)]
-pub use bux_oci::RegistryAuth;
+pub use bux_oci::{RegistryAuth, canonical_reference};
 pub use bux_proto::ExecStart;
 #[cfg(unix)]
 pub use client::{ExecHandle, ExecOutput, PongInfo};

--- a/crates/bux/src/options.rs
+++ b/crates/bux/src/options.rs
@@ -94,6 +94,10 @@ pub struct VmOptions {
     pub image: ImageRef,
     /// Optional unique name.
     pub name: Option<String>,
+    /// Optional agent identity.
+    pub agent_id: Option<String>,
+    /// Optional tenant identity.
+    pub tenant_id: Option<String>,
     /// vCPUs (default 1).
     pub vcpus: u8,
     /// RAM in MiB (default 512).
@@ -139,6 +143,8 @@ impl VmOptions {
         Self {
             image: image.into(),
             name: None,
+            agent_id: None,
+            tenant_id: None,
             vcpus: 1,
             ram_mib: 512,
             ports: Vec::new(),
@@ -162,6 +168,20 @@ impl VmOptions {
     #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
+        self
+    }
+
+    /// Set agent id.
+    #[must_use]
+    pub fn agent_id(mut self, id: impl Into<String>) -> Self {
+        self.agent_id = Some(id.into());
+        self
+    }
+
+    /// Set tenant id.
+    #[must_use]
+    pub fn tenant_id(mut self, id: impl Into<String>) -> Self {
+        self.tenant_id = Some(id.into());
         self
     }
 
@@ -322,6 +342,8 @@ mod tests {
         assert!(o.env.is_empty());
         assert!(o.workdir.is_none());
         assert!(o.user.is_none());
+        assert!(o.agent_id.is_none());
+        assert!(o.tenant_id.is_none());
         assert!(!o.auto_remove);
         assert!(!o.detach);
     }
@@ -330,6 +352,8 @@ mod tests {
     fn fluent_chain() {
         let o = VmOptions::from_image("alpine")
             .name("n1")
+            .agent_id("agt")
+            .tenant_id("ten")
             .vcpus(2)
             .ram_mib(1024)
             .port("8080:80")
@@ -340,6 +364,8 @@ mod tests {
             .auto_remove(true)
             .detach(true);
         assert_eq!(o.name.as_deref(), Some("n1"));
+        assert_eq!(o.agent_id.as_deref(), Some("agt"));
+        assert_eq!(o.tenant_id.as_deref(), Some("ten"));
         assert_eq!(o.vcpus, 2);
         assert_eq!(o.ram_mib, 1024);
         assert_eq!(o.ports, vec!["8080:80"]);

--- a/crates/bux/src/runtime/boot/mod.rs
+++ b/crates/bux/src/runtime/boot/mod.rs
@@ -246,6 +246,7 @@ fn config_from_options(
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
+    use super::super::RuntimeOptions;
     use super::*;
     use crate::secrets::Secret;
 
@@ -302,5 +303,57 @@ mod tests {
         assert_eq!(cfg.ram_mib, 1024);
         assert_eq!(cfg.workload_env, vec!["A=1"]);
         assert_eq!(cfg.workload_workdir.as_deref(), Some("/work"));
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "ext4 lock must outlive resolve_image"
+    )]
+    fn resolve_oci_image_label_is_canonical() {
+        let _ext4 = crate::guest::EXT4_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let planted = crate::guest::test_static_guest_elf(b"PLANT-GUEST-ELF!");
+        let files = tempfile::tempdir().unwrap();
+        let guest = files.path().join("planted-guest");
+        std::fs::write(&guest, planted).unwrap();
+
+        let data = tempfile::tempdir().unwrap();
+        let rt = Runtime::open_with(RuntimeOptions {
+            data_dir: data.path().to_path_buf(),
+            shim_path: None,
+            guest_path: Some(guest),
+            registry_auth: bux_oci::RegistryAuth::Anonymous,
+        })
+        .unwrap();
+
+        let digest = "sha256:testdigest";
+        let canonical = "docker.io/library/python:slim";
+        let rootfs = data.path().join("rootfs").join("sha256-testdigest");
+        std::fs::create_dir_all(&rootfs).unwrap();
+        std::fs::write(rootfs.join("placeholder"), b"root").unwrap();
+        let conn = rusqlite::Connection::open(data.path().join("images.db")).unwrap();
+        conn.execute(
+            "INSERT INTO images (reference, digest, size, config) VALUES (?1, ?2, 0, '{}')",
+            rusqlite::params![canonical, digest],
+        )
+        .unwrap();
+
+        let resolved = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(resolve_image(
+                &rt,
+                &ImageRef::Oci("python:slim".into()),
+                &|_| {},
+            ))
+            .unwrap();
+        assert_eq!(
+            resolved.image_label.as_deref(),
+            Some(canonical),
+            "create must persist PullResult.reference, not the raw request string"
+        );
     }
 }

--- a/crates/bux/src/runtime/boot/mod.rs
+++ b/crates/bux/src/runtime/boot/mod.rs
@@ -158,7 +158,7 @@ async fn resolve_image(
             let oci_cfg = pull.config.clone();
 
             on_progress("building ext4 base disk");
-            let image_label = reference.clone();
+            let image_label = pull.reference.clone();
             let base_path = {
                 let disk = rt.disk().clone();
                 let rootfs = pull.rootfs.clone();
@@ -237,6 +237,8 @@ fn config_from_options(
         auto_delete_secs: opts.auto_delete_secs,
         last_activity_at: Some(std::time::SystemTime::now()),
         detach: opts.detach,
+        agent_id: opts.agent_id.clone(),
+        tenant_id: opts.tenant_id.clone(),
         ..VmConfig::default()
     }
 }
@@ -282,5 +284,23 @@ mod tests {
         assert!(matches!(err, crate::Error::SecurityUnavailable(_)));
         assert_eq!(err.to_string(), "no hardware virtualization (KVM / HVF)");
         assert!(require_virtualization(true).is_ok());
+    }
+
+    #[test]
+    fn config_from_options_copies_identity() {
+        let opts = VmOptions::from_image("alpine")
+            .agent_id("agt")
+            .tenant_id("ten")
+            .vcpus(2)
+            .ram_mib(1024)
+            .env(["A=1"])
+            .workdir("/work");
+        let cfg = config_from_options(&opts, None, None, vec![]);
+        assert_eq!(cfg.agent_id.as_deref(), Some("agt"));
+        assert_eq!(cfg.tenant_id.as_deref(), Some("ten"));
+        assert_eq!(cfg.vcpus, 2);
+        assert_eq!(cfg.ram_mib, 1024);
+        assert_eq!(cfg.workload_env, vec!["A=1"]);
+        assert_eq!(cfg.workload_workdir.as_deref(), Some("/work"));
     }
 }

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -417,6 +417,9 @@ impl Runtime {
     /// `auto_remove`, and `tenant_id`. Always `detach: true` so CLI/`Runtime`
     /// Drop does not SIGTERM the clone (same process model as `bux create`).
     ///
+    /// `source_id` is the exact primary key (not name, not prefix). CLI
+    /// resolves name/prefix with [`Self::get`] first.
+    ///
     /// `agent_id` is set from `name` when that name is the serve unique form
     /// `a-{tenant_id}-{agent}`. If `name` is `None` (CLI), `agent_id` stays
     /// `None`. Source volumes are not copied; a new `ws-{tenant}-{agent}`
@@ -429,24 +432,23 @@ impl Runtime {
     ///
     /// Returns an error if the source is missing, flatten fails, or create fails.
     pub async fn clone(&self, source_id: &str, name: Option<String>) -> Result<Vm> {
-        let source = self.get(source_id)?;
-        let source_state = source.stored();
+        let opts = self.clone_prepare(source_id, name)?;
+        let handle = self.create(opts).await?;
+        info!(source_id, clone_id = %handle.stored().id, "VM cloned");
+        Ok(handle)
+    }
 
+    /// Exact-id lookup + flatten overlay into `bases/clone-{id}.qcow2` + clone-shaped options.
+    fn clone_prepare(&self, source_id: &str, name: Option<String>) -> Result<VmOptions> {
+        let source = self.get_exact(source_id)?;
+        let source_state = source.stored();
         let clone_id = crate::state::gen_id();
         let clone_base = self
             .disk
             .bases_dir()
             .join(format!("clone-{clone_id}.qcow2"));
         self.disk.flatten_vm_disk(&source_state.id, &clone_base)?;
-
-        let opts = clone_vm_options(&source_state.config, name, clone_base);
-        let handle = self.create(opts).await?;
-        info!(
-            source_id = %source_state.id,
-            clone_id = %handle.stored().id,
-            "VM cloned"
-        );
-        Ok(handle)
+        Ok(clone_vm_options(&source_state.config, name, clone_base))
     }
 
     /// Restore a VM from a snapshot: flatten the snapshot overlay into a new
@@ -459,9 +461,9 @@ impl Runtime {
     /// Not copied: ports, volumes, secrets, security, command, env, workdir,
     /// user, auto-stop/delete, ready timeout, or name (unless `name` is passed).
     ///
-    /// Requires the source VM row. After [`Self::remove`] of the source,
-    /// snapshot rows are dropped (`ON DELETE CASCADE`) and this returns
-    /// [`crate::Error::NotFound`].
+    /// Requires the source VM row, loaded by exact `snapshots.vm_id` (not
+    /// name/prefix). After [`Self::remove`] of the source, snapshot rows are
+    /// dropped (`ON DELETE CASCADE`) and this returns [`crate::Error::NotFound`].
     ///
     /// # Errors
     ///
@@ -489,7 +491,7 @@ impl Runtime {
                 "snapshot disk missing: {snapshot_id}"
             )));
         }
-        let source = self.get(&snap.vm_id)?;
+        let source = self.get_exact(&snap.vm_id)?;
         restore_vm_options(&self.disk, snap_disk, &source.stored().config, name)
     }
 
@@ -970,6 +972,10 @@ mod tests {
         assert!(opts.agent_id.is_none(), "non-serve name leaves agent unset");
         assert!(opts.volumes.is_empty(), "source volumes are not copied");
         assert!(
+            opts.auto_stop_secs.is_none(),
+            "engine clone leaves idle policy off"
+        );
+        assert!(
             matches!(&opts.image, ImageRef::BaseDisk(p) if p == Path::new("/tmp/clone.qcow2")),
             "clone image must be the flattened base"
         );
@@ -1150,6 +1156,129 @@ mod tests {
                 "flattened restore base must be standalone"
             );
         }
+    }
+
+    #[test]
+    fn restore_prepare_uses_exact_source_id_not_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let src_id = "srcsnap000003";
+        let decoy_id = "decoy00000001";
+        let snap_raw = rt.disk.bases_dir().join("snap.raw");
+        fs::write(&snap_raw, vec![0xBB; 4096]).unwrap();
+        let snap_ovl = rt
+            .disk
+            .create_overlay(&snap_raw, crate::disk::DiskFormat::Raw, "snap-src")
+            .unwrap();
+        let snap_path = dir.path().join("snapshots").join("snap1.qcow2");
+        fs::copy(&snap_ovl, &snap_path).unwrap();
+        insert_cfg(
+            &rt,
+            src_id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                ram_mib: 512,
+                ..VmConfig::default()
+            },
+        );
+        rt.db
+            .insert(&VmState {
+                id: decoy_id.to_owned(),
+                name: Some(src_id.to_owned()),
+                pid: wait_dead_pid(),
+                image: None,
+                socket: rt.socks_dir.join(format!("{decoy_id}.sock")),
+                status: Status::Stopped,
+                config: VmConfig {
+                    ram_mib: 2048,
+                    ..VmConfig::default()
+                },
+                created_at: SystemTime::now(),
+            })
+            .unwrap();
+        rt.db
+            .insert_snapshot(&crate::state::SnapshotRow {
+                id: "snap1".into(),
+                vm_id: src_id.into(),
+                name: Some("s".into()),
+                disk_path: snap_path.to_string_lossy().into_owned(),
+                disk_bytes: 4096,
+                created_at: SystemTime::now(),
+            })
+            .unwrap();
+        let by_name = rt.get(src_id).unwrap();
+        assert_eq!(by_name.stored().id, decoy_id, "get prefers name");
+        let opts = rt.restore_prepare("snap1", None).unwrap();
+        assert_eq!(
+            opts.ram_mib, 512,
+            "restore source is snapshot vm_id, not a VM named that id"
+        );
+    }
+
+    #[test]
+    fn clone_prepare_uses_exact_source_id_not_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let src_id = "srcclone00001";
+        let decoy_id = "decoy00000002";
+        let live_raw = rt.disk.bases_dir().join("live.raw");
+        fs::write(&live_raw, vec![0xAA; 8192]).unwrap();
+        rt.disk
+            .create_overlay(&live_raw, crate::disk::DiskFormat::Raw, src_id)
+            .unwrap();
+        insert_cfg(
+            &rt,
+            src_id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                ram_mib: 512,
+                ..VmConfig::default()
+            },
+        );
+        rt.db
+            .insert(&VmState {
+                id: decoy_id.to_owned(),
+                name: Some(src_id.to_owned()),
+                pid: wait_dead_pid(),
+                image: None,
+                socket: rt.socks_dir.join(format!("{decoy_id}.sock")),
+                status: Status::Stopped,
+                config: VmConfig {
+                    ram_mib: 2048,
+                    ..VmConfig::default()
+                },
+                created_at: SystemTime::now(),
+            })
+            .unwrap();
+        let by_name = rt.get(src_id).unwrap();
+        assert_eq!(by_name.stored().id, decoy_id, "get prefers name");
+        let opts = rt.clone_prepare(src_id, None).unwrap();
+        assert_eq!(
+            opts.ram_mib, 512,
+            "clone source is exact id, not a VM named that id"
+        );
+        assert!(
+            opts.auto_stop_secs.is_none(),
+            "engine clone leaves idle policy off"
+        );
+    }
+
+    #[test]
+    fn clone_and_restore_prepare_call_get_exact() {
+        let prod = include_str!("mod.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .expect("prod");
+        assert!(
+            prod.contains("self.get_exact(source_id)"),
+            "clone_prepare must use get_exact"
+        );
+        assert!(
+            prod.contains("self.get_exact(&snap.vm_id)"),
+            "restore_prepare must use get_exact"
+        );
     }
 
     #[test]

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -414,8 +414,13 @@ impl Runtime {
     /// detached VM.
     ///
     /// Copied from the source: overlay contents, `vcpus`, `ram_mib`, `network`,
-    /// and `auto_remove`. Always `detach: true` so CLI/`Runtime` Drop does not
-    /// SIGTERM the clone (same process model as `bux create`).
+    /// `auto_remove`, and `tenant_id`. Always `detach: true` so CLI/`Runtime`
+    /// Drop does not SIGTERM the clone (same process model as `bux create`).
+    ///
+    /// `agent_id` is set from `name` when that name is the serve unique form
+    /// `a-{tenant_id}-{agent}`. If `name` is `None` (CLI), `agent_id` stays
+    /// `None`. Source volumes are not copied; a new `ws-{tenant}-{agent}`
+    /// volume is attached when both ids are known.
     ///
     /// Not copied: ports, volumes, secrets, security, command, env, workdir,
     /// user, auto-stop/delete, ready timeout, or name (unless `name` is passed).
@@ -448,7 +453,8 @@ impl Runtime {
     /// base, then boot a detached VM (same disk recipe as [`Self::clone`]).
     ///
     /// Copied from the source VM: overlay contents (via the snapshot file),
-    /// `vcpus`, `ram_mib`, `network`, and `auto_remove`. Always `detach: true`.
+    /// `vcpus`, `ram_mib`, `network`, `auto_remove`, and `tenant_id`. Always
+    /// `detach: true`. `agent_id` follows the same name rule as [`Self::clone`].
     ///
     /// Not copied: ports, volumes, secrets, security, command, env, workdir,
     /// user, auto-stop/delete, ready timeout, or name (unless `name` is passed).
@@ -673,7 +679,13 @@ fn restore_vm_options(
 }
 
 /// Create-options for a disk-clone or snapshot-restore: copy
-/// `vcpus`/`ram_mib`/`network`/`auto_remove`; always detach.
+/// `vcpus`/`ram_mib`/`network`/`auto_remove`/`tenant_id`; always detach.
+///
+/// Serve always passes `a-{tenant}-{agent}`. That form is injective (`-` is
+/// not in the id alphabet), so `agent_id` can be recovered from `name`.
+/// CLI names are optional and unconstrained; missing/`None` leaves `agent_id`
+/// unset. Source volumes are not copied; a new workspace volume is attached
+/// only when tenant and agent are both known so HTTP clones stay isolated.
 #[must_use]
 fn clone_vm_options(config: &VmConfig, name: Option<String>, clone_base: PathBuf) -> VmOptions {
     let mut opts = VmOptions::from_image(ImageRef::BaseDisk(clone_base))
@@ -682,10 +694,29 @@ fn clone_vm_options(config: &VmConfig, name: Option<String>, clone_base: PathBuf
         .auto_remove(config.auto_remove)
         .detach(true) // durable disk-clone; CLI drop must not SIGTERM
         .network(config.network.clone());
+    if let Some(tenant) = config.tenant_id.as_deref() {
+        opts = opts.tenant_id(tenant.to_owned());
+        if let Some(agent) = name
+            .as_deref()
+            .and_then(|n| agent_id_from_sandbox_name(tenant, n))
+        {
+            opts = opts
+                .agent_id(agent.to_owned())
+                .named_volume(format!("ws-{tenant}-{agent}"), "/workspace");
+        }
+    }
     if let Some(n) = name {
         opts = opts.name(n);
     }
     opts
+}
+
+/// Parse `agent` from serve unique name `a-{tenant}-{agent}`.
+fn agent_id_from_sandbox_name<'a>(tenant_id: &str, name: &'a str) -> Option<&'a str> {
+    name.strip_prefix("a-")?
+        .strip_prefix(tenant_id)?
+        .strip_prefix('-')
+        .filter(|agent| !agent.is_empty())
 }
 
 impl Drop for Runtime {
@@ -739,6 +770,7 @@ mod tests {
     use crate::options::NetworkSpec;
     use crate::secrets::{LiveSecrets, StartOptions};
     use crate::state::VmConfig;
+    use crate::volumes::{VolumeMount, VolumeSource};
     use bux_oci::RegistryAuth;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
@@ -934,10 +966,77 @@ mod tests {
         assert!(opts.auto_remove);
         assert_eq!(opts.name.as_deref(), Some("n"));
         assert_eq!(opts.network, NetworkSpec::Disabled);
+        assert!(opts.tenant_id.is_none(), "CLI source has no tenant");
+        assert!(opts.agent_id.is_none(), "non-serve name leaves agent unset");
+        assert!(opts.volumes.is_empty(), "source volumes are not copied");
         assert!(
             matches!(&opts.image, ImageRef::BaseDisk(p) if p == Path::new("/tmp/clone.qcow2")),
             "clone image must be the flattened base"
         );
+    }
+
+    #[test]
+    fn clone_vm_options_copies_tenant_and_agent_from_serve_name() {
+        let source = VmConfig {
+            tenant_id: Some("ten1".into()),
+            agent_id: Some("old".into()),
+            vcpus: 2,
+            ram_mib: 1024,
+            network: NetworkSpec::Disabled,
+            ..VmConfig::default()
+        };
+        let opts = clone_vm_options(
+            &source,
+            Some("a-ten1-newagt".into()),
+            PathBuf::from("/tmp/clone.qcow2"),
+        );
+        assert_eq!(opts.tenant_id.as_deref(), Some("ten1"));
+        assert_eq!(opts.agent_id.as_deref(), Some("newagt"));
+        assert_eq!(opts.name.as_deref(), Some("a-ten1-newagt"));
+        assert_eq!(
+            opts.volumes,
+            vec![VolumeMount::named("ws-ten1-newagt", "/workspace")],
+            "new workspace, not the source volume"
+        );
+        assert!(
+            matches!(
+                opts.volumes.first().map(|m| &m.source),
+                Some(VolumeSource::Named { name }) if name == "ws-ten1-newagt"
+            ),
+            "named volume"
+        );
+    }
+
+    #[test]
+    fn clone_vm_options_none_name_leaves_agent_none() {
+        let source = VmConfig {
+            tenant_id: Some("ten1".into()),
+            agent_id: Some("old".into()),
+            ..VmConfig::default()
+        };
+        let opts = clone_vm_options(&source, None, PathBuf::from("/tmp/clone.qcow2"));
+        assert_eq!(opts.tenant_id.as_deref(), Some("ten1"), "tenant is copied");
+        assert!(opts.agent_id.is_none(), "CLI name None keeps agent unset");
+        assert!(opts.name.is_none());
+        assert!(opts.volumes.is_empty(), "no agent → no workspace volume");
+    }
+
+    #[test]
+    fn clone_vm_options_custom_name_does_not_invent_agent() {
+        let source = VmConfig {
+            tenant_id: Some("ten1".into()),
+            agent_id: Some("old".into()),
+            ..VmConfig::default()
+        };
+        let opts = clone_vm_options(
+            &source,
+            Some("custom".into()),
+            PathBuf::from("/tmp/c.qcow2"),
+        );
+        assert_eq!(opts.tenant_id.as_deref(), Some("ten1"));
+        assert!(opts.agent_id.is_none(), "unparseable name");
+        assert_eq!(opts.name.as_deref(), Some("custom"));
+        assert!(opts.volumes.is_empty());
     }
 
     #[test]

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -358,6 +358,33 @@ impl Runtime {
         self.disk.disk_usage()
     }
 
+    /// Recursive sum of regular file sizes under the runtime data directory.
+    ///
+    /// Distinct from [`Self::disk_usage`], which is non-recursive bases+overlays only.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a directory cannot be read or a file cannot be stat'd.
+    pub fn data_dir_usage(&self) -> io::Result<u64> {
+        dir_tree_size(self.data_dir())
+    }
+
+    /// Data directory this runtime was opened on (parent of `socks/`).
+    fn data_dir(&self) -> &Path {
+        self.socks_dir.parent().unwrap_or(&self.socks_dir)
+    }
+
+    /// Compressed layer bytes from the image manifest, before layer blob download.
+    ///
+    /// Uses this runtime's OCI handle.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the reference is invalid or the registry request fails.
+    pub async fn manifest_compressed_bytes(&self, image: &str) -> Result<u64> {
+        Ok(self.oci.manifest_compressed_bytes(image).await?)
+    }
+
     /// Garbage-collects orphaned base disk images (`ref_count` <= 0).
     ///
     /// Returns the number of base images removed.
@@ -521,15 +548,37 @@ impl Runtime {
     ///
     /// Returns an error if the VM is not found or the database query fails.
     pub fn get(&self, id_or_name: &str) -> Result<Vm> {
-        let mut state = if let Some(s) = self.db.get_by_name(id_or_name)? {
+        let state = if let Some(s) = self.db.get_by_name(id_or_name)? {
             s
         } else {
             self.db.get_by_id_prefix(id_or_name)?
         };
+        Ok(self.handle(state))
+    }
 
+    /// Exact primary-key lookup (`WHERE id = ?1`). Never prefix, never name.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::Error::NotFound`] if no row has this id. Never
+    /// [`crate::Error::Ambiguous`].
+    pub fn get_exact(&self, id: &str) -> Result<Vm> {
+        Ok(self.handle(self.db.get_by_id(id)?))
+    }
+
+    /// Exact unique-name lookup (`WHERE name = ?1`). Never prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database query fails. Missing name is `Ok(None)`.
+    pub fn get_named(&self, name: &str) -> Result<Option<Vm>> {
+        Ok(self.db.get_by_name(name)?.map(|state| self.handle(state)))
+    }
+
+    /// Reconcile liveness and wrap a stored row as a handle.
+    fn handle(&self, mut state: VmState) -> Vm {
         self.reconcile_dead_pid(&mut state);
-
-        Ok(Vm::new(
+        Vm::new(
             state,
             Arc::clone(&self.db),
             self.disk.clone(),
@@ -541,7 +590,7 @@ impl Runtime {
             self.volumes.clone(),
             self.shim_path.clone(),
             self.guest_path.clone(),
-        ))
+        )
     }
 
     /// Renames a VM.
@@ -645,6 +694,38 @@ impl Drop for Runtime {
     }
 }
 
+/// Recursive sum of regular file sizes under `dir`.
+fn dir_tree_size(dir: &Path) -> io::Result<u64> {
+    let mut total = 0_u64;
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(path) = stack.pop() {
+        let entries = match fs::read_dir(&path) {
+            Ok(entries) => entries,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+        for entry in entries {
+            let entry = entry?;
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e),
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+            } else if file_type.is_file() {
+                let meta = match entry.metadata() {
+                    Ok(m) => m,
+                    Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+                    Err(e) => return Err(e),
+                };
+                total += meta.len();
+            }
+        }
+    }
+    Ok(total)
+}
+
 #[cfg(test)]
 #[allow(
     clippy::unwrap_used,
@@ -656,14 +737,14 @@ mod tests {
     use super::*;
     use crate::events::{AuditEventKind, RingBufferListener};
     use crate::options::NetworkSpec;
-    use crate::secrets::LiveSecrets;
+    use crate::secrets::{LiveSecrets, StartOptions};
     use crate::state::VmConfig;
     use bux_oci::RegistryAuth;
     use std::fs;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::Arc;
-    use std::time::SystemTime;
+    use std::time::{Duration, SystemTime};
 
     fn insert_running(rt: &Runtime, id: &str, pid: i32) {
         insert_running_cfg(rt, id, pid, VmConfig::default());
@@ -1375,6 +1456,194 @@ mod tests {
             u32::from(inode.i_mode) & 0o777,
             0o555,
             "managed-base guest inode must be 0555"
+        );
+    }
+
+    #[test]
+    fn canonical_reference_reexport_library_alias() {
+        let short = crate::canonical_reference("python:slim").unwrap();
+        let long = crate::canonical_reference("docker.io/library/python:slim").unwrap();
+        assert_eq!(
+            short, long,
+            "python:slim and docker.io/library/python:slim must canonicalize equally"
+        );
+        assert_eq!(
+            short, "docker.io/library/python:slim",
+            "canonical form must be the docker.io library reference"
+        );
+    }
+
+    #[test]
+    fn get_exact_does_not_prefix_match() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        insert_cfg(
+            &rt,
+            "abc123def456",
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig::default(),
+        );
+        insert_cfg(
+            &rt,
+            "abc999000111",
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig::default(),
+        );
+
+        let hit = rt.get_exact("abc123def456").unwrap();
+        assert_eq!(hit.info().id, "abc123def456", "full id must resolve");
+
+        let prefix = rt.get_exact("abc").unwrap_err();
+        assert!(
+            matches!(prefix, crate::Error::NotFound(_)),
+            "get_exact must not prefix-match, got {prefix}"
+        );
+        assert!(
+            !matches!(prefix, crate::Error::Ambiguous(_)),
+            "get_exact must never be Ambiguous, got {prefix}"
+        );
+
+        let unique = rt.get("abc123def456").unwrap();
+        assert_eq!(unique.info().id, "abc123def456");
+        let via_prefix = rt.get("abc123def").unwrap();
+        assert_eq!(
+            via_prefix.info().id,
+            "abc123def456",
+            "Runtime::get still prefix-matches unique ids"
+        );
+    }
+
+    #[test]
+    fn get_named_is_exact_name_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        insert_cfg(
+            &rt,
+            "namedvm000001",
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig::default(),
+        );
+        rt.db.update_name("namedvm000001", Some("alpha")).unwrap();
+
+        let hit = rt.get_named("alpha").unwrap();
+        assert!(hit.is_some(), "exact name must resolve");
+        assert_eq!(hit.unwrap().info().id, "namedvm000001");
+        assert!(
+            rt.get_named("alp").unwrap().is_none(),
+            "get_named must not prefix-match"
+        );
+        assert!(
+            rt.get_named("namedvm000001").unwrap().is_none(),
+            "get_named must not look up by id"
+        );
+    }
+
+    #[test]
+    fn data_dir_usage_counts_volumes_file_disk_usage_misses() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let payload = vec![0_u8; 65_536];
+        let vol_dir = dir.path().join("volumes").join("ws-t-a");
+        fs::create_dir_all(&vol_dir).unwrap();
+        fs::write(vol_dir.join("blob"), &payload).unwrap();
+
+        let disk = rt.disk_usage().unwrap();
+        let usage = rt.data_dir_usage().unwrap();
+        assert!(
+            usage >= disk + payload.len() as u64,
+            "data_dir_usage={usage} must include volumes/ blob; disk_usage={disk}"
+        );
+        assert!(
+            usage > disk,
+            "data_dir_usage must exceed non-recursive bases+overlays"
+        );
+    }
+
+    #[test]
+    fn start_with_stamps_activity_so_sweep_skips_idle_stop() {
+        let dir = tempfile::tempdir().unwrap();
+        let shim = dir.path().join("dummy-shim");
+        fs::write(&shim, b"#!/bin/sh\nexec /bin/sleep 30\n").unwrap();
+        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+        let overlay = dir.path().join("overlay.raw");
+        fs::write(&overlay, b"not-qcow").unwrap();
+
+        let rt = Runtime::open_with(RuntimeOptions {
+            data_dir: dir.path().join("rt"),
+            shim_path: Some(shim),
+            guest_path: None,
+            registry_auth: RegistryAuth::Anonymous,
+        })
+        .unwrap();
+
+        let id = "idleclock0001";
+        insert_cfg(
+            &rt,
+            id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                auto_stop_secs: Some(1),
+                last_activity_at: Some(SystemTime::UNIX_EPOCH),
+                detach: true,
+                network: NetworkSpec::Disabled,
+                root_disk: Some(overlay.to_string_lossy().into_owned()),
+                security: crate::security::SecurityOptions::default()
+                    .jailer(false)
+                    .landlock(false),
+                ..VmConfig::default()
+            },
+        );
+
+        let mut vm = rt.get_exact(id).unwrap();
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(vm.start_with(StartOptions {
+                ready_timeout: Some(Duration::ZERO),
+                secrets: Vec::new(),
+            }))
+            .unwrap();
+
+        let report = rt.sweep().unwrap();
+        assert_eq!(
+            report.stopped, 0,
+            "start_with must persist last_activity_at so sweep does not auto-stop"
+        );
+        assert_eq!(report.deleted, 0, "sweep must not delete the restarted VM");
+        drop(vm.kill());
+    }
+
+    #[test]
+    fn touch_activity_persists_last_activity_at() {
+        let dir = tempfile::tempdir().unwrap();
+        let rt = Runtime::open(dir.path()).unwrap();
+        let id = "touchact000001";
+        insert_cfg(
+            &rt,
+            id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                last_activity_at: Some(SystemTime::UNIX_EPOCH),
+                ..VmConfig::default()
+            },
+        );
+        rt.get_exact(id).unwrap().touch_activity().unwrap();
+        let last = rt
+            .db
+            .get_by_id(id)
+            .unwrap()
+            .config
+            .last_activity_at
+            .unwrap();
+        assert!(
+            last > SystemTime::UNIX_EPOCH,
+            "touch_activity must persist last_activity_at"
         );
     }
 }

--- a/crates/bux/src/runtime/mod.rs
+++ b/crates/bux/src/runtime/mod.rs
@@ -797,6 +797,43 @@ mod tests {
         i32::try_from(child.id()).unwrap()
     }
 
+    fn dummy_offline_runtime() -> (tempfile::TempDir, Runtime, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let shim = dir.path().join("dummy-shim");
+        fs::write(&shim, b"#!/bin/sh\nexec /bin/sleep 30\n").unwrap();
+        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
+        let overlay = dir.path().join("overlay.raw");
+        fs::write(&overlay, b"not-qcow").unwrap();
+        let rt = Runtime::open_with(RuntimeOptions {
+            data_dir: dir.path().join("rt"),
+            shim_path: Some(shim),
+            guest_path: None,
+            registry_auth: RegistryAuth::Anonymous,
+        })
+        .unwrap();
+        (dir, rt, overlay)
+    }
+
+    fn insert_idle_stopped(rt: &Runtime, overlay: &Path, id: &str) {
+        insert_cfg(
+            rt,
+            id,
+            wait_dead_pid(),
+            Status::Stopped,
+            VmConfig {
+                auto_stop_secs: Some(1),
+                last_activity_at: Some(SystemTime::UNIX_EPOCH),
+                detach: true,
+                network: NetworkSpec::Disabled,
+                root_disk: Some(overlay.to_string_lossy().into_owned()),
+                security: crate::security::SecurityOptions::default()
+                    .jailer(false)
+                    .landlock(false),
+                ..VmConfig::default()
+            },
+        );
+    }
+
     #[test]
     fn list_preserves_live_pid() {
         let dir = tempfile::tempdir().unwrap();
@@ -1491,6 +1528,7 @@ mod tests {
             Status::Stopped,
             VmConfig::default(),
         );
+        rt.db.update_name("abc123def456", Some("alpha")).unwrap();
 
         let hit = rt.get_exact("abc123def456").unwrap();
         assert_eq!(hit.info().id, "abc123def456", "full id must resolve");
@@ -1505,13 +1543,31 @@ mod tests {
             "get_exact must never be Ambiguous, got {prefix}"
         );
 
-        let unique = rt.get("abc123def456").unwrap();
-        assert_eq!(unique.info().id, "abc123def456");
+        let unique_prefix = rt.get_exact("abc123def").unwrap_err();
+        assert!(
+            matches!(unique_prefix, crate::Error::NotFound(_)),
+            "get_exact must not accept a unique prefix, got {unique_prefix}"
+        );
+        assert!(
+            !matches!(unique_prefix, crate::Error::Ambiguous(_)),
+            "unique prefix must be NotFound, not Ambiguous, got {unique_prefix}"
+        );
         let via_prefix = rt.get("abc123def").unwrap();
         assert_eq!(
             via_prefix.info().id,
             "abc123def456",
             "Runtime::get still prefix-matches unique ids"
+        );
+
+        let by_name = rt.get_exact("alpha").unwrap_err();
+        assert!(
+            matches!(by_name, crate::Error::NotFound(_)),
+            "get_exact must not look up vms.name, got {by_name}"
+        );
+        assert_eq!(
+            rt.get("alpha").unwrap().info().id,
+            "abc123def456",
+            "Runtime::get still resolves exact names"
         );
     }
 
@@ -1545,58 +1601,31 @@ mod tests {
     fn data_dir_usage_counts_volumes_file_disk_usage_misses() {
         let dir = tempfile::tempdir().unwrap();
         let rt = Runtime::open(dir.path()).unwrap();
+        let disk_before = rt.disk_usage().unwrap();
+        let usage_before = rt.data_dir_usage().unwrap();
+
         let payload = vec![0_u8; 65_536];
         let vol_dir = dir.path().join("volumes").join("ws-t-a");
         fs::create_dir_all(&vol_dir).unwrap();
         fs::write(vol_dir.join("blob"), &payload).unwrap();
 
-        let disk = rt.disk_usage().unwrap();
-        let usage = rt.data_dir_usage().unwrap();
-        assert!(
-            usage >= disk + payload.len() as u64,
-            "data_dir_usage={usage} must include volumes/ blob; disk_usage={disk}"
+        let disk_after = rt.disk_usage().unwrap();
+        let usage_after = rt.data_dir_usage().unwrap();
+        assert_eq!(
+            disk_after, disk_before,
+            "disk_usage must not count volumes/ files"
         );
         assert!(
-            usage > disk,
-            "data_dir_usage must exceed non-recursive bases+overlays"
+            usage_after >= usage_before + payload.len() as u64,
+            "data_dir_usage delta must include the volumes/ blob: before={usage_before} after={usage_after}"
         );
     }
 
     #[test]
     fn start_with_stamps_activity_so_sweep_skips_idle_stop() {
-        let dir = tempfile::tempdir().unwrap();
-        let shim = dir.path().join("dummy-shim");
-        fs::write(&shim, b"#!/bin/sh\nexec /bin/sleep 30\n").unwrap();
-        fs::set_permissions(&shim, fs::Permissions::from_mode(0o755)).unwrap();
-        let overlay = dir.path().join("overlay.raw");
-        fs::write(&overlay, b"not-qcow").unwrap();
-
-        let rt = Runtime::open_with(RuntimeOptions {
-            data_dir: dir.path().join("rt"),
-            shim_path: Some(shim),
-            guest_path: None,
-            registry_auth: RegistryAuth::Anonymous,
-        })
-        .unwrap();
-
+        let (_dir, rt, overlay) = dummy_offline_runtime();
         let id = "idleclock0001";
-        insert_cfg(
-            &rt,
-            id,
-            wait_dead_pid(),
-            Status::Stopped,
-            VmConfig {
-                auto_stop_secs: Some(1),
-                last_activity_at: Some(SystemTime::UNIX_EPOCH),
-                detach: true,
-                network: NetworkSpec::Disabled,
-                root_disk: Some(overlay.to_string_lossy().into_owned()),
-                security: crate::security::SecurityOptions::default()
-                    .jailer(false)
-                    .landlock(false),
-                ..VmConfig::default()
-            },
-        );
+        insert_idle_stopped(&rt, &overlay, id);
 
         let mut vm = rt.get_exact(id).unwrap();
         tokio::runtime::Builder::new_current_thread()
@@ -1616,6 +1645,40 @@ mod tests {
         );
         assert_eq!(report.deleted, 0, "sweep must not delete the restarted VM");
         drop(vm.kill());
+    }
+
+    #[test]
+    fn start_with_failed_ready_does_not_stamp_activity() {
+        let (_dir, rt, overlay) = dummy_offline_runtime();
+        let id = "idlefail00001";
+        insert_idle_stopped(&rt, &overlay, id);
+
+        let mut vm = rt.get_exact(id).unwrap();
+        let err = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(vm.start_with(StartOptions {
+                ready_timeout: Some(Duration::from_millis(50)),
+                secrets: Vec::new(),
+            }))
+            .unwrap_err();
+        assert!(
+            matches!(err, crate::Error::GuestUnavailable(_)),
+            "dummy shim cannot handshake, got {err}"
+        );
+        let last = rt
+            .db
+            .get_by_id(id)
+            .unwrap()
+            .config
+            .last_activity_at
+            .unwrap();
+        assert_eq!(
+            last,
+            SystemTime::UNIX_EPOCH,
+            "failed ready must not persist last_activity_at"
+        );
     }
 
     #[test]

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -341,11 +341,6 @@ impl Vm {
     ///
     /// Returns an error if the database update fails.
     pub fn touch_activity(&self) -> Result<()> {
-        self.touch_activity_local()
-    }
-
-    /// Persist activity timestamp for idle auto-stop / auto-delete.
-    fn touch_activity_local(&self) -> Result<()> {
         let mut cfg = self.state.config.clone();
         cfg.last_activity_at = Some(SystemTime::now());
         cfg.last_error = None;
@@ -463,7 +458,7 @@ impl Vm {
         let req = self.with_workload_defaults(req);
         let cmd = req.cmd.clone();
         let handle = self.client.exec(req).await?;
-        drop(self.touch_activity_local());
+        drop(self.touch_activity());
         self.events
             .emit(AuditEvent::now(AuditEventKind::ExecStarted {
                 vm_id: self.state.id.clone(),
@@ -482,7 +477,7 @@ impl Vm {
         let req = self.with_workload_defaults(req);
         let cmd = req.cmd.clone();
         let output = self.client.exec_output(req).await?;
-        drop(self.touch_activity_local());
+        drop(self.touch_activity());
         self.events
             .emit(AuditEvent::now(AuditEventKind::ExecStarted {
                 vm_id: self.state.id.clone(),

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -110,6 +110,20 @@ pub struct VmInfo {
     pub created_at: SystemTime,
     /// Optional first command (OCI ENTRYPOINT+CMD or CLI override).
     pub workload_cmd: Vec<String>,
+    /// Optional agent identity.
+    pub agent_id: Option<String>,
+    /// Optional tenant identity.
+    pub tenant_id: Option<String>,
+    /// RAM in MiB.
+    pub ram_mib: u32,
+    /// vCPU count.
+    pub vcpus: u8,
+    /// Whether restart/exec needs secret re-supply.
+    pub secrets_required: bool,
+    /// Workload env defaults (`KEY=VALUE`) after OCI merge.
+    pub workload_env: Vec<String>,
+    /// Workload working directory after OCI merge.
+    pub workload_workdir: Option<String>,
 }
 
 impl VmInfo {
@@ -138,6 +152,13 @@ impl VmInfo {
             last_error: state.config.last_error.clone(),
             created_at: state.created_at,
             workload_cmd: state.config.workload_cmd.clone(),
+            agent_id: state.config.agent_id.clone(),
+            tenant_id: state.config.tenant_id.clone(),
+            ram_mib: state.config.ram_mib,
+            vcpus: state.config.vcpus,
+            secrets_required: state.config.secrets_required,
+            workload_env: state.config.workload_env.clone(),
+            workload_workdir: state.config.workload_workdir.clone(),
         }
     }
 }
@@ -312,6 +333,15 @@ impl Vm {
     #[must_use]
     pub fn last_error(&self) -> Option<&str> {
         self.state.config.last_error.as_deref()
+    }
+
+    /// Persist `last_activity_at = now` for idle auto-stop / auto-delete.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database update fails.
+    pub fn touch_activity(&self) -> Result<()> {
+        self.touch_activity_local()
     }
 
     /// Persist activity timestamp for idle auto-stop / auto-delete.
@@ -597,6 +627,7 @@ impl Vm {
             }
             return Err(e);
         }
+        self.touch_activity()?;
         Ok(())
     }
 
@@ -923,5 +954,35 @@ mod tests {
             json["egress"],
             serde_json::json!({ "allow": ["example.com", "10.0.0.0/8"] })
         );
+    }
+
+    #[test]
+    fn from_stored_copies_identity_and_resources() {
+        let info = VmInfo::from_stored(&VmState {
+            id: "aabbccddeeff".into(),
+            name: Some("n1".into()),
+            pid: 1,
+            image: Some("docker.io/library/python:slim".into()),
+            socket: PathBuf::from("/tmp/x.sock"),
+            status: Status::Stopped,
+            config: VmConfig {
+                ram_mib: 1024,
+                vcpus: 2,
+                secrets_required: true,
+                agent_id: Some("agt".into()),
+                tenant_id: Some("ten".into()),
+                workload_env: vec!["A=1".into()],
+                workload_workdir: Some("/work".into()),
+                ..VmConfig::default()
+            },
+            created_at: SystemTime::UNIX_EPOCH,
+        });
+        assert_eq!(info.agent_id.as_deref(), Some("agt"));
+        assert_eq!(info.tenant_id.as_deref(), Some("ten"));
+        assert_eq!(info.ram_mib, 1024);
+        assert_eq!(info.vcpus, 2);
+        assert!(info.secrets_required);
+        assert_eq!(info.workload_env, vec!["A=1"]);
+        assert_eq!(info.workload_workdir.as_deref(), Some("/work"));
     }
 }

--- a/crates/bux/src/runtime/vm.rs
+++ b/crates/bux/src/runtime/vm.rs
@@ -347,6 +347,18 @@ impl Vm {
         self.db.update_config(&self.state.id, &cfg)
     }
 
+    /// Persist idle auto-stop. HTTP clone/restore apply the worker default;
+    /// engine clone leaves `None` so CLI clones stay policy-off.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the database update fails.
+    pub fn set_auto_stop_secs(&self, secs: Option<u64>) -> Result<()> {
+        let mut cfg = self.state.config.clone();
+        cfg.auto_stop_secs = secs;
+        self.db.update_config(&self.state.id, &cfg)
+    }
+
     /// Apply stored workload defaults to an exec request (caller overrides win).
     #[must_use]
     pub fn with_workload_defaults(&self, req: ExecStart) -> ExecStart {

--- a/crates/bux/src/state/db.rs
+++ b/crates/bux/src/state/db.rs
@@ -212,6 +212,22 @@ impl StateDb {
         Ok(())
     }
 
+    /// Finds a VM by exact primary key (`WHERE id = ?1`). Never prefix.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::NotFound`] if no row has this id.
+    pub(crate) fn get_by_id(&self, id: &str) -> Result<VmState> {
+        let conn = self.lock();
+        conn.query_row("SELECT * FROM vms WHERE id = ?1", params![id], row_to_state)
+            .map_err(|e| match e {
+                rusqlite::Error::QueryReturnedNoRows => {
+                    Error::NotFound(format!("no VM matching '{id}'"))
+                }
+                other => Error::Db(other),
+            })
+    }
+
     /// Finds a VM by exact name.
     ///
     /// # Errors

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -327,7 +327,8 @@ pub(crate) fn gen_id() -> String {
             .unwrap_or_default()
             .as_nanos(),
     );
-    format!("{:012x}", h.finish())
+    // {:012x} is minimum width; mask to 48 bits so the hex is always exactly 12.
+    format!("{:012x}", h.finish() & 0xffff_ffff_ffff_u64)
 }
 
 #[cfg(unix)]
@@ -611,6 +612,32 @@ mod tests {
         assert!(
             cfg.tenant_id.is_none(),
             "missing tenant_id must deserialize as None"
+        );
+    }
+
+    #[test]
+    fn gen_id_is_exactly_12_lowercase_hex() {
+        for _ in 0..256 {
+            let id = gen_id();
+            assert_eq!(
+                id.len(),
+                12,
+                "gen_id must emit exactly 12 hex chars, got {id:?}"
+            );
+            assert!(
+                id.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f')),
+                "gen_id must be lowercase hex, got {id:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn format_012x_of_2_pow_48_is_length_13() {
+        // {:012x} of 2^48 is 13 chars; dropping the gen_id mask would emit >12.
+        assert_eq!(
+            format!("{:012x}", 1u64 << 48).len(),
+            13,
+            "unmasked 2^48 must format wider than 12 so the mask stays required"
         );
     }
 }

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -210,6 +210,14 @@ pub(crate) struct VmConfig {
     /// Detached VM: no watchdog, no parent-death, Runtime Drop does not SIGTERM.
     #[serde(default)]
     pub detach: bool,
+
+    /// Optional agent identity.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+
+    /// Optional tenant identity.
+    #[serde(default)]
+    pub tenant_id: Option<String>,
 }
 
 impl Default for VmConfig {
@@ -242,6 +250,8 @@ impl Default for VmConfig {
             last_activity_at: None,
             last_error: None,
             detach: false,
+            agent_id: None,
+            tenant_id: None,
         }
     }
 }
@@ -408,6 +418,24 @@ mod tests {
     }
 
     #[test]
+    fn get_by_id_is_exact_only() {
+        let db = open_test_db();
+        db.insert(&test_vm("abc123def456", None)).unwrap();
+        db.insert(&test_vm("abc999000111", None)).unwrap();
+
+        assert_eq!(db.get_by_id("abc123def456").unwrap().id, "abc123def456");
+        let err = db.get_by_id("abc").unwrap_err();
+        assert!(
+            matches!(err, crate::Error::NotFound(_)),
+            "exact id lookup must not prefix-match, got {err:?}"
+        );
+        assert!(
+            !matches!(err, crate::Error::Ambiguous(_)),
+            "exact id lookup must not be Ambiguous, got {err:?}"
+        );
+    }
+
+    #[test]
     fn ambiguous_prefix() {
         let db = open_test_db();
         db.insert(&test_vm("abc111", None)).unwrap();
@@ -554,5 +582,18 @@ mod tests {
 
         db.delete_base_disk("bd1").unwrap();
         assert!(db.get_base_disk_by_digest("sha256:abc").unwrap().is_none());
+    }
+
+    #[test]
+    fn vmconfig_json_defaults_identity_fields() {
+        let cfg: VmConfig = serde_json::from_str(r#"{"vcpus":1,"ram_mib":512}"#).unwrap();
+        assert!(
+            cfg.agent_id.is_none(),
+            "missing agent_id must deserialize as None"
+        );
+        assert!(
+            cfg.tenant_id.is_none(),
+            "missing tenant_id must deserialize as None"
+        );
     }
 }

--- a/crates/bux/src/state/mod.rs
+++ b/crates/bux/src/state/mod.rs
@@ -420,18 +420,35 @@ mod tests {
     #[test]
     fn get_by_id_is_exact_only() {
         let db = open_test_db();
-        db.insert(&test_vm("abc123def456", None)).unwrap();
+        db.insert(&test_vm("abc123def456", Some("alpha"))).unwrap();
         db.insert(&test_vm("abc999000111", None)).unwrap();
 
         assert_eq!(db.get_by_id("abc123def456").unwrap().id, "abc123def456");
-        let err = db.get_by_id("abc").unwrap_err();
+        let ambiguous_prefix = db.get_by_id("abc").unwrap_err();
         assert!(
-            matches!(err, crate::Error::NotFound(_)),
-            "exact id lookup must not prefix-match, got {err:?}"
+            matches!(ambiguous_prefix, crate::Error::NotFound(_)),
+            "exact id lookup must not prefix-match, got {ambiguous_prefix:?}"
         );
         assert!(
-            !matches!(err, crate::Error::Ambiguous(_)),
-            "exact id lookup must not be Ambiguous, got {err:?}"
+            !matches!(ambiguous_prefix, crate::Error::Ambiguous(_)),
+            "exact id lookup must not be Ambiguous, got {ambiguous_prefix:?}"
+        );
+
+        let unique_prefix = db.get_by_id("abc123def").unwrap_err();
+        assert!(
+            matches!(unique_prefix, crate::Error::NotFound(_)),
+            "unique prefix must not match, got {unique_prefix:?}"
+        );
+        assert_eq!(
+            db.get_by_id_prefix("abc123def").unwrap().id,
+            "abc123def456",
+            "prefix API still resolves a unique prefix"
+        );
+
+        let by_name = db.get_by_id("alpha").unwrap_err();
+        assert!(
+            matches!(by_name, crate::Error::NotFound(_)),
+            "exact id lookup must not use vms.name, got {by_name:?}"
         );
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ Engine (this workspace):
 | Crate | Role |
 |-------|------|
 | `bux` | `Runtime` / `Vm` / `VmOptions`. Exclusive `bux.lock`. Schema v5. Daemonless. |
-| `bux-cli` | Operator CLI (`run`/`create`/`exec`/…) and `bux serve`. Binary name `bux`. |
+| `bux-cli` | Operator CLI (`run`/`create`/`exec`/…). Binary name `bux`. `serve` is 1.0, not in 0.8.0. |
 | `bux-shim` | `ShimConfig` apply to libkrun. Never starts gvproxy. |
 | `bux-shim-bin` | Process that `krun_start_enter`. gvproxy in-process when networked. Seccomp **after** `GvproxyInstance::new`. |
 | `bux-guest` | Static musl ELF, PID 1, protocol stamp `bux-guest-protocol-v10`. |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,7 +35,7 @@ Engine (this workspace):
 | Crate | Role |
 |-------|------|
 | `bux` | `Runtime` / `Vm` / `VmOptions`. Exclusive `bux.lock`. Schema v5. Daemonless. |
-| `bux-cli` | Operator CLI (`run`/`create`/`exec`/…). Binary name `bux`. `serve` is 1.0, not in 0.8.0. |
+| `bux-cli` | Operator CLI (`run`/`create`/`exec`/`serve`). Binary name `bux`. Serve is in this 0.8.0 workspace; the product tag is not 1.0. |
 | `bux-shim` | `ShimConfig` apply to libkrun. Never starts gvproxy. |
 | `bux-shim-bin` | Process that `krun_start_enter`. gvproxy in-process when networked. Seccomp **after** `GvproxyInstance::new`. |
 | `bux-guest` | Static musl ELF, PID 1, protocol stamp `bux-guest-protocol-v10`. |
@@ -47,9 +47,10 @@ Engine (this workspace):
 | `bux-gvproxy` | gvisor-tap-vsock **0.8.9**. Virtio-net + MITM. |
 | `bux-jail` / `bux-bwrap` / `bux-landlock` / `bux-seccomp` | Linux: bwrap PID/IPC/UTS + Landlock fail-closed + seccomp TSYNC. Darwin: seatbelt. `bux-bwrap` crate **0.2.0** downloads bubblewrap **0.12.0**. |
 
-HTTP lives in `bux-serve`, **not** in `crates/bux`. Embedders keep
-`Runtime::open` without an HTTP stack. Serve is a client of the public
-`Runtime` / `Vm` API the same way the CLI is.
+HTTP lives in `bux-serve` (this 0.8.0 workspace; the product tag is not
+1.0), **not** in `crates/bux`. Embedders keep `Runtime::open` without an
+HTTP stack. Serve is a client of the public `Runtime` / `Vm` API the same
+way the CLI is.
 
 Not in this product: dashboard, NestJS control plane, Go FFI runner,
 OpenTelemetry collector, language SDKs, GPU/VNC, Windows, in-guest OCI
@@ -191,4 +192,5 @@ Workers remain `bux serve`. Image bases are per-worker.
 
 - [security-model.md](security-model.md)
 - [serve.md](serve.md)
+- [native-deps.md](native-deps.md)
 - [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,194 @@
+# Architecture
+
+Source of truth is this document, then the code under `crates/`. Workspace
+version is **0.8.0**. Protocol is postcard **v10**. SQLite `user_version` is
+**5** (no migrations; wipe `BUX_HOME` on mismatch).
+
+The product is a **hosted per-agent sandbox** (`bux serve`). The engine is
+libkrun. Library-only 1.0 is revoked. Local notes that defined REST as a
+non-goal are not this repo.
+
+## Spine
+
+```text
+validate → require_virtualization → oci.ensure → ext4 base + inject guest 0555
+  → volumes → spawn_config (QCOW2 overlay, ShimConfig JSON 0600, jail.spawn)
+  → wait_ready (postcard Hello::Control Ping on vsock :1024)
+```
+
+Code: `crates/bux/src/runtime/boot/mod.rs` `create`.
+
+```text
+OCI image → ext4 base + QCOW2 overlay → jailed bux-shim
+  → libkrun (KVM / HVF) → static bux-guest PID 1
+  → postcard v10 over vsock
+```
+
+The shim never calls TSI `krun_set_port_map`. Offline VMs use
+`disable_implicit_vsock` + `add_vsock(0)`. Every virtio-fs share is
+`krun_add_virtiofs3(..., shm_size=0, read_only)`.
+
+## Crate map
+
+Engine (this workspace):
+
+| Crate | Role |
+|-------|------|
+| `bux` | `Runtime` / `Vm` / `VmOptions`. Exclusive `bux.lock`. Schema v5. Daemonless. |
+| `bux-cli` | Operator CLI (`run`/`create`/`exec`/…) and `bux serve`. Binary name `bux`. |
+| `bux-shim` | `ShimConfig` apply to libkrun. Never starts gvproxy. |
+| `bux-shim-bin` | Process that `krun_start_enter`. gvproxy in-process when networked. Seccomp **after** `GvproxyInstance::new`. |
+| `bux-guest` | Static musl ELF, PID 1, protocol stamp `bux-guest-protocol-v10`. |
+| `bux-proto` | Postcard v10. Per-op connection. `ControlReq` is Ping/Shutdown/Quiesce/Thaw only. |
+| `bux-oci` | `oci-client` pull; `images.db` + content-addressed `layers/` `configs/` `rootfs/`. |
+| `bux-e2fs` | Ext4 base images. |
+| `bux-qcow2` | Overlay / flatten. |
+| `bux-krun` | libkrun **1.19.4** / libkrunfw **5.5.0** FFI. |
+| `bux-gvproxy` | gvisor-tap-vsock **0.8.9**. Virtio-net + MITM. |
+| `bux-jail` / `bux-bwrap` / `bux-landlock` / `bux-seccomp` | Linux: bwrap PID/IPC/UTS + Landlock fail-closed + seccomp TSYNC. Darwin: seatbelt. `bux-bwrap` crate **0.2.0** downloads bubblewrap **0.12.0**. |
+
+HTTP lives in `bux-serve`, **not** in `crates/bux`. Embedders keep
+`Runtime::open` without an HTTP stack. Serve is a client of the public
+`Runtime` / `Vm` API the same way the CLI is.
+
+Not in this product: dashboard, NestJS control plane, Go FFI runner,
+OpenTelemetry collector, language SDKs, GPU/VNC, Windows, in-guest OCI
+runtime.
+
+## Worker process
+
+Single-node **is** the first production topology: one KVM box, one
+`bux serve`, N agents, N VMs.
+
+```text
+bux serve start
+  Runtime::open(BUX_HOME)     # Busy if another process holds the flock
+  bind each --listen (TCP and/or unix://)
+  sweep loop
+  SIGTERM → drain → unlink unix socket → drop Runtime
+            detached VMs keep running (shim child, detach=true)
+```
+
+`Runtime::open` takes `FlockArg::LockExclusiveNonblock`. Two processes cannot
+share `BUX_HOME`. Hosted means **one worker process owns one data dir**.
+CLI verbs that open a Runtime cannot run during serve.
+
+API-created VMs are `detach: true` (same as `bux create`). Serve Drop must
+not SIGTERM sandboxes. Restart reattaches live detached VMs (`Runtime::open`
+recovery).
+
+A sandbox **is** a `Vm`. No parallel sandbox type. Identity is
+`(tenant_id, agent_id)` → injective VM name `a-{tenant}-{agent}`. `-` is the
+separator only; it is not in the id alphabet `[A-Za-z0-9._]`. Workspace volume
+is `ws-{tenant}-{agent}`, not the VM name.
+
+HTTP `{id}` is the exact 12-char hex primary key. Prefix lookup (`Runtime::get`)
+is CLI-only.
+
+## Isolation layers
+
+```text
+                    untrusted (one agent)
+┌─────────────────────────────────────────────┐
+│ guest kernel (libkrunfw)                    │
+│  bux-guest PID 1 + that agent's execs       │  Phase A, single owner
+│  /workspace ← ws-{tenant}-{agent}           │
+└──────────────────┬──────────────────────────┘
+                   │ virtio blk, fs, vsock, net
+┌──────────────────▼──────────────────────────┐
+│ bux-shim + optional gvproxy                 │
+│  seccomp (Linux) · Landlock · bwrap/seatbelt│
+└──────────────────┬──────────────────────────┘
+                   │ Unix sockets, overlay, volumes
+┌──────────────────▼──────────────────────────┐
+│ bux serve (trusted)                         │
+│  SQLite, OCI cache, API keys                │
+└─────────────────────────────────────────────┘
+```
+
+| Layer | Mechanism |
+|-------|-----------|
+| Versus host | Guest kernel + KVM / HVF. `require_virtualization` before image resolve. |
+| Versus other agents | Separate VM, overlay `disks/vms/{id}.qcow2`, volume `ws-{tenant}-{agent}`, gvproxy sockets. |
+| Versus shim escape | Linux: bwrap + Landlock fail-closed + seccomp. Darwin: seatbelt. VM is the real fence. |
+| Versus unrestricted egress | HTTP omit/`[]` → `NetworkSpec::Disabled`. CLI empty allow-list stays unrestricted. |
+| Versus host binds | HTTP: named volume only. CLI may bind; sensitive prefixes denied unless `allow_sensitive`. |
+
+Do not put two agents in one guest.
+
+## Network
+
+Guest topology (`crates/bux-proto/src/net.rs`):
+
+| | Value |
+|--|--------|
+| Subnet | `192.168.127.0/24` |
+| Gateway / DNS | `192.168.127.1` |
+| Guest | `192.168.127.2` (per-VM isolated gvproxy) |
+| MAC | `5a:94:ef:e4:0c:ee` |
+| Agent vsock | port **1024** |
+
+`allow_net` is gvproxy DNS + SNI/Host/CIDR, not a package-manager profile.
+Hostnames and `*.suffix` get DNS zones; everything else sinkholes to
+`0.0.0.0`. IPs/CIDRs skip DNS and hit TCP allow. TLS is matched on SNI/Host.
+UDP is not published. A working pip install needs every hostname the client
+will resolve (e.g. `pypi.org` **and** `files.pythonhosted.org`).
+
+## Filesystem
+
+| Store | Path | Lifetime |
+|-------|------|----------|
+| OCI blobs | `{data_dir}/layers`, `configs`, `rootfs`, `images.db` | until image delete (layers refcounted; bases not) |
+| Ext4 base | `{data_dir}/disks/bases/{digest}.raw` | shared read-only backing; leftover after rmi is expected |
+| Overlay | `{data_dir}/disks/vms/{id}.qcow2` | per VM; deleted in `Runtime::remove` |
+| Workspace | `{data_dir}/volumes/{name}/` | named volume; HTTP DELETE of a sandbox removes `ws-{tenant}-{agent}` |
+| Snapshots | `{data_dir}/snapshots/{sid}.qcow2` | disk overlay copy; `ON DELETE CASCADE` on source VM |
+| Socks | `{data_dir}/socks/{id}` + `.stderr` + `.exit` | per VM |
+
+Empty overlay is ~256 KiB.
+
+## Guest protocol
+
+Per-op connection. Concurrent execs do not share a mux. `Hello`: Control,
+Exec, FileRead, FileWrite, CopyIn, CopyOut. A protocol bump is a guest ELF
+rebuild + `guest-<40-char-sha>` Release + Darwin fetch.
+
+## Native / guest / product tags
+
+Independent tag families. Serve does not retag libkrun.
+
+| Tag | Asset |
+|-----|--------|
+| `krun-v1.19.4` | `bux-deps-{target}.tar.gz` (libkrun 1.19.4 + libkrunfw 5.5.0) |
+| `e2fs-v1.47.4` | `bux-e2fs-{target}.tar.gz` |
+| `bwrap-v0.12.0` | `bux-bwrap-{target}.tar.gz` (Linux) |
+| `guest-<40-char-sha>` | static musl `bux-guest-<triple>` for **that** commit |
+| `v*.*.*` | product tarball: `bux`, `bux-shim`, guest ELF, `libkrun*` |
+
+URLs:
+
+```text
+https://github.com/qntx/bux/releases/download/krun-v1.19.4/bux-deps-{target}.tar.gz
+https://github.com/qntx/bux/releases/download/e2fs-v1.47.4/bux-e2fs-{target}.tar.gz
+https://github.com/qntx/bux/releases/download/bwrap-v0.12.0/bux-bwrap-{target}.tar.gz
+```
+
+A native pin bump retags **that** native tag on the PR SHA, waits for all
+matrix assets, then merges. Never merge-then-tag. `PROTOCOL_VERSION` bump
+tags `guest-<sha>` on that commit before Darwin FULL, then a product `v*`.
+
+CD (`cd.yml`) ships three host tarballs: `x86_64-unknown-linux-gnu`,
+`aarch64-unknown-linux-gnu`, `aarch64-apple-darwin`. No Windows. Guest
+builds are `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl`.
+
+## Control plane
+
+1.0 live is one Linux machine with `/dev/kvm`, extract the tarball,
+`./bux serve start`. Multi-worker coordinator is after that loop is boring.
+Workers remain `bux serve`. Image bases are per-worker.
+
+## See also
+
+- [security-model.md](security-model.md)
+- [serve.md](serve.md)
+- [CONTRIBUTING.md](../CONTRIBUTING.md)

--- a/docs/native-deps.md
+++ b/docs/native-deps.md
@@ -1,0 +1,281 @@
+# Native libraries
+
+Prebuilt libkrun / libkrunfw, e2fsprogs, and (Linux) bubblewrap are GitHub
+Release tarballs. `build.rs` downloads them with ureq. gvproxy is compiled
+from in-tree Go (`gvproxy-bridge`), not a Release.
+
+Product README is not this document. Rpath, capture-env, and the FULL
+checklist stay in [`CONTRIBUTING.md`](../CONTRIBUTING.md) — do not copy them
+here.
+
+## Pins
+
+Keep `build.rs` constants and the matching workflow `env:` in lockstep.
+
+| Component | Pin | Workflow | Tag / URL key |
+| --- | --- | --- | --- |
+| libkrun | 1.19.4 | `.github/workflows/krun-build.yml` | `krun-v1.19.4` |
+| libkrunfw | 5.5.0 | same tarball as libkrun | (not its own tag) |
+| e2fsprogs | 1.47.4 | `.github/workflows/e2fs-build.yml` | `e2fs-v1.47.4` |
+| bubblewrap | 0.12.0 | `.github/workflows/bwrap-build.yml` | `bwrap-v0.12.0` |
+| gvproxy | 0.8.9 | in-tree `gvproxy-bridge/go.mod` | none |
+
+Soname majors stay **1** (libkrun) and **5** (libkrunfw). Crate versions
+(`bux-krun` 0.2.0, …) are not the tag.
+
+Clone and headers: [`libkrun/libkrun`](https://github.com/libkrun/libkrun),
+not `qntx/libkrun` (404). Firmware assets:
+[`libkrun/libkrunfw`](https://github.com/libkrun/libkrunfw). `containers/libkrun`
+redirects; pin the live org.
+
+`publish-krun` / `publish-e2fs` / `publish-bwrap` are already deleted. Native
+tags attach assets only. Do not re-add `cargo publish` to these workflows.
+
+## Toolchain
+
+- rustc **1.97.1** (`rust-toolchain.toml`, `.github/workflows/ci.yml`)
+- Go for `bux-gvproxy` (`build.rs` `go build -buildmode=c-archive`)
+- C toolchain for libkrun / e2fs / qcow2 native deps
+- Darwin: `codesign` (shim entitlements + ad-hoc libkrun). `Makefile` `sign`
+  target. `crates/bux-shim/bux-shim.entitlements` includes
+  `disable-library-validation` so the shim can load ad-hoc libkrun.
+- Linux `patchelf` only in GHA (`krun-build.yml`), not on the operator laptop.
+
+Linux embedder `$ORIGIN` rustflags: [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## URL scheme
+
+One scheme. No crate-version URL. No dual GET.
+
+```
+https://github.com/qntx/bux/releases/download/krun-v{LIBKRUN_VERSION}/bux-deps-{target}.tar.gz
+https://github.com/qntx/bux/releases/download/e2fs-v{E2FSPROGS_VERSION}/bux-e2fs-{target}.tar.gz
+https://github.com/qntx/bux/releases/download/bwrap-v{BUBBLEWRAP_VERSION}/bux-bwrap-{target}.tar.gz
+```
+
+`BUX_DEPS_VERSION` / `BUX_E2FS_VERSION` / `BUX_BWRAP_VERSION` override that
+native version string and default to the pin constant, not `CARGO_PKG_VERSION`.
+
+`LIBKRUN_VERSION` must remain a real `libkrun/libkrun` git tag (`v1.19.4`).
+`krun-build.yml` clones `--branch v${LIBKRUN_VERSION}`; bindgen fetches
+`https://raw.githubusercontent.com/libkrun/libkrun/v{LIBKRUN_VERSION}/include/libkrun.h`.
+Do not invent `1.19.4.1` as `LIBKRUN_VERSION`. A later firmware-only bump
+needs a **separate** Release identifier used only in the download URL / `git
+tag`; do not reuse `krun-v1.19.4`.
+
+## Offline
+
+| Variable | Meaning |
+| --- | --- |
+| `BUX_DEPS_DIR` | Directory of unrewritten `libkrun` / `libkrunfw` dylibs (or `.so`). Skips krun download. |
+| `BUX_E2FS_DIR` | Directory with `lib/` (or the `.a` files) and headers. Skips e2fs download. |
+| `BUX_BWRAP_DIR` | Directory containing a `bwrap` binary. Skips bwrap download (Linux). |
+
+These are local paths, not a second URL. Air-gapped / iterating on a local
+`make install` uses them. Darwin `bux-bwrap` does not download (Linux-only).
+
+## Compile from cold
+
+Unset `BUX_DEPS_DIR` / `BUX_E2FS_DIR` / `BUX_BWRAP_DIR`. First
+`cargo build -p bux-cli -p bux-shim-bin` downloads `krun-v1.19.4` and
+`e2fs-v1.47.4` and compiles gvproxy from Go.
+
+Measured on this machine, 2026-08-26, Darwin arm64, after `krun-v1.19.4` /
+`e2fs-v1.47.4` assets existed:
+
+```
+[bux-krun 0.2.0] bux-krun: downloading https://github.com/qntx/bux/releases/download/krun-v1.19.4/bux-deps-aarch64-apple-darwin.tar.gz
+```
+
+```
+otool -L target/debug/libkrun.dylib
+@loader_path/libkrun.dylib (compatibility version 1.0.0, current version 1.19.0)
+```
+
+```
+[bux-e2fs 0.2.0] bux-e2fs: downloading https://github.com/qntx/bux/releases/download/e2fs-v1.47.4/bux-e2fs-aarch64-apple-darwin.tar.gz
+```
+
+`cargo build -p bux-cli -p bux-shim-bin` Finished after the krun 1.19 fetch.
+Cargo warned that no Linux `bux-guest` binary was found
+(`aarch64-unknown-linux-musl`). No musl guest ELF on this host. Darwin does
+not compile the guest. That is not a `BUX_E2E_FULL` record.
+
+Releases that exist (same date):
+
+- `krun-v1.19.4`: `bux-deps-aarch64-apple-darwin.tar.gz`,
+  `bux-deps-x86_64-unknown-linux-gnu.tar.gz`,
+  `bux-deps-aarch64-unknown-linux-gnu.tar.gz`
+- `e2fs-v1.47.4`: three `bux-e2fs-*.tar.gz` (same triples)
+- `bwrap-v0.12.0`: two Linux `bux-bwrap-*.tar.gz` (no Darwin)
+
+Darwin `cargo build -p bux-bwrap` does not fetch.
+
+## Bindgen before assets exist
+
+`cargo check -p bux-krun --features regenerate` is **not** header-only.
+`build.rs` still calls `obtain_libraries` on Darwin/Linux, which GETs
+`krun-v{LIBKRUN_VERSION}` and **404s until the Release exists**.
+
+Point `BUX_DEPS_DIR` at an **unrewritten** extract (`$OUT_DIR/lib` from a
+prior download, or a fresh unpack of `bux-deps-*.tar.gz`). Do **not** point
+it at `target/debug` after the Darwin rewrite: those staged copies already
+have `LC_RPATH @loader_path`, and `install_name_tool -add_rpath @loader_path`
+panics on the duplicate.
+
+```sh
+# before krun-v1.19.4 assets exist — unrewritten extract, not target/debug
+export BUX_DEPS_DIR=/path/to/unrewritten/lib
+BUX_UPDATE_BINDINGS=1 cargo check -p bux-krun --features regenerate
+```
+
+Requires libclang. Commit `crates/bux-krun/src/bindings.rs`. After assets
+exist: `unset BUX_DEPS_DIR` and clean-fetch (below). Same pattern for e2fs
+with `BUX_E2FS_DIR` if headers moved.
+
+## Tag the PR SHA, then merge
+
+**Never merge-then-tag.** Pin + URL switch in one commit 404s
+`ci-rust.yml --workspace` and `e2e-host.yml` (`cargo build -p bux-cli`) until
+the Release exists. There is no dual-URL bridge. That 404 is a PR-branch
+problem until assets land; it must never be a `main` problem.
+
+Order for **each** native PR (krun / e2fs / bwrap):
+
+1. Land files on the PR branch. Local compile and bindgen use existing blobs
+   via `BUX_*_DIR` (unrewritten).
+2. Push the PR. Do not expect CI green yet.
+3. Tag **that PR SHA**. Tag trigger does not require `main`. The tagged
+   commit must already contain the new workflow pins and no `publish-*` job.
+
+   ```bash
+   SHA=$(git rev-parse HEAD)
+   git tag krun-v1.19.4 "$SHA"
+   git push origin krun-v1.19.4
+   ```
+
+4. Wait until `gh release view` lists **all** matrix assets (krun/e2fs: three
+   tarballs; bwrap: two Linux). Select the native-build run with
+   `gh run list --workflow … --commit "$SHA"` and `event==push`. Do not use
+   `--limit 1`.
+5. `gh run rerun --failed` of failed `pull_request`/`push` CI, then
+   `gh run watch --exit-status`. Locally: `unset BUX_*_DIR`; `cargo clean -p …`;
+   `cargo build -vv` must log the new URL.
+6. Merge **only when `ci` and `e2e-host` are green**. Do not squash-retag.
+   Do not move the native tag onto an empty-commit retry SHA.
+
+`workflow_dispatch` on a **branch** is an optional compile dry-run (artifacts
+only; `release` job is `if: startsWith(github.ref, 'refs/tags/…')`). It does
+not unblock CI. Do not watch a branch dispatch and then `cargo build` as if
+the Release existed.
+
+### Wait helper
+
+Do not `gh run list --limit 1`. `--commit "$SHA"` scopes the list; 20×5s
+covers a slow enqueue after `git push origin <tag>`.
+
+```bash
+# SHA=$(git rev-parse HEAD) on the PR commit that was tagged
+# after: git tag krun-v1.19.4 "$SHA" && git push origin krun-v1.19.4
+for i in $(seq 1 20); do
+  RUN_ID=$(gh run list --repo qntx/bux --workflow krun-build.yml --commit "$SHA" \
+    --json databaseId,event \
+    --jq '.[] | select(.event=="push") | .databaseId' | head -1)
+  [ -n "$RUN_ID" ] && break
+  sleep 5
+done
+if [ -z "$RUN_ID" ]; then
+  RUN_ID=$(gh run list --repo qntx/bux --workflow krun-build.yml \
+    --json databaseId,headBranch,event \
+    --jq '.[] | select(.headBranch=="krun-v1.19.4" and .event=="push") | .databaseId' | head -1)
+fi
+if [ -z "$RUN_ID" ]; then
+  gh workflow run krun-build.yml --ref krun-v1.19.4
+  for i in $(seq 1 20); do
+    RUN_ID=$(gh run list --repo qntx/bux --workflow krun-build.yml \
+      --json databaseId,event,headBranch \
+      --jq '.[] | select(.headBranch=="krun-v1.19.4" and .event=="workflow_dispatch") | .databaseId' | head -1)
+    [ -n "$RUN_ID" ] && break
+    sleep 5
+  done
+fi
+[ -n "$RUN_ID" ]
+gh run watch --repo qntx/bux --exit-status "$RUN_ID"
+ASSETS=$(gh release view krun-v1.19.4 --repo qntx/bux --json assets --jq '.assets[].name')
+echo "$ASSETS"
+echo "$ASSETS" | grep -qx 'bux-deps-aarch64-apple-darwin.tar.gz'
+echo "$ASSETS" | grep -qx 'bux-deps-x86_64-unknown-linux-gnu.tar.gz'
+echo "$ASSETS" | grep -qx 'bux-deps-aarch64-unknown-linux-gnu.tar.gz'
+```
+
+Same helper for `e2fs-build.yml` / `e2fs-v1.47.4` (assert
+`bux-e2fs-{aarch64-apple-darwin,x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu}.tar.gz`)
+and `bwrap-build.yml` / `bwrap-v0.12.0` (assert
+`bux-bwrap-{x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu}.tar.gz`).
+`event==push` excludes an optional branch `workflow_dispatch` dry-run on the
+same SHA.
+
+### Re-run failed PR CI
+
+`ci.yml` and `e2e-host.yml` are `on: pull_request` / `push: branches: [main]`
+only — not `workflow_dispatch`. Failed 404 runs stay failed until rerun or a
+new head SHA.
+
+```bash
+FAILED=$(gh run list --repo qntx/bux --commit "$SHA" \
+  --json databaseId,conclusion,event \
+  --jq '.[] | select(.conclusion=="failure" and (.event=="pull_request" or .event=="push")) | .databaseId')
+for id in $FAILED; do
+  gh run rerun --repo qntx/bux "$id" --failed
+done
+for id in $FAILED; do
+  gh run watch --repo qntx/bux --exit-status "$id"
+done
+```
+
+`gh run watch --exit-status` is the merge gate: both `ci` and `e2e-host` must
+exit 0.
+
+If `gh run rerun` is unavailable, empty-commit on the PR branch and watch CI
+on the **new** HEAD. Do **not** `git tag -f` / move the native tag onto that
+empty commit.
+
+### Local verify after assets exist
+
+```bash
+unset BUX_DEPS_DIR BUX_DEPS_VERSION
+cargo clean -p bux-krun
+cargo build -p bux-krun -vv
+# must log:
+# bux-krun: downloading https://github.com/qntx/bux/releases/download/krun-v1.19.4/bux-deps-{target}.tar.gz
+# Darwin: otool -L target/debug/libkrun.dylib  → current version 1.19.x, not 1.17
+cargo build -p bux-cli -p bux-shim-bin
+```
+
+Same for e2fs (`e2fs-v1.47.4`). bwrap verify is Linux-only.
+
+## Failure modes
+
+| Failure | What to do |
+| --- | --- |
+| 404 on PR CI until assets exist | Expected. Tag the PR SHA; wait; `gh run rerun`; never merge-then-tag. Do **not** add a second URL. |
+| One matrix leg red (`fail-fast: false`) | `release` `needs: build` already blocks a partial Release. Fix the leg. Do not hand-upload two of three tarballs. |
+| Tag exists, assets incomplete | Delete the GitHub Release, fix, new commit. Moving tags is last resort. |
+| Watching the wrong GHA run (`--limit 1` / branch dispatch) | `--commit "$SHA"` and `event==push`; assert Release asset names. |
+| Darwin `BUX_DEPS_DIR=$PWD/target/debug` after rewrite | Duplicate `LC_RPATH` panic. Use the unrewritten extract. |
+| `cargo publish` leftover | Jobs already deleted. Do not restore them. |
+| Native tag run never appears in `gh run list --commit` | 20×5s; then tag name; then `gh workflow run --ref <tag>`. Abort if still empty. |
+
+## Guest ELF / FULL
+
+Darwin guest fetch: [`scripts/e2e/fetch-guest.sh`](../scripts/e2e/fetch-guest.sh)
+(procedure in [`CONTRIBUTING.md`](../CONTRIBUTING.md)). Release tag
+`guest-<40-char-sha>` attaches `bux-guest-<triple>`. Darwin does not compile
+musl. FULL needs `BUX_GUEST_PATH` from that script or a Linux
+`aarch64-unknown-linux-musl` / `x86_64-unknown-linux-musl` build.
+
+This Apple Silicon host (2026-08-26): `kern.hv_support=1`, **no** musl
+`bux-guest` ELF. Host CI (`.github/workflows/e2e-host.yml`) forces
+`BUX_E2E_FULL=0`. Do not invent a green FULL record. CONTRIBUTING HVF
+rows are pre-v10 and are not ship proof. Linux KVM FULL stays empty until
+an operator records a v10 run (OS, arch, date, image digest).

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,190 @@
+# Security model
+
+Source of truth is the code on this tree (workspace **0.8.0**). This document
+describes **current** engine isolation and the hosted-worker threat model.
+It supersedes local gitignored notes that claimed `create` does not fail-closed
+on virtualization and that Landlock `/dev` is a RW tree.
+
+## Threat model
+
+| Actor | Trust | Goal if hostile |
+|-------|-------|-----------------|
+| Operator | Trusted | Runs the worker, sets API keys, `--allow-unrestricted-net` |
+| Tenant (API key holder) | Semi-trusted | Must not escape the VM, must not see other tenants’ sandboxes, must not bind-mount host paths |
+| Agent / guest image / exec | Untrusted | Escape, host creds, cross-agent read, egress beyond `allow_net` |
+| Registry | Digest-addressed cache | Tamper layers |
+| Host operator / embedder (CLI / `Runtime`) | Trusted | Sets `allow_net`, volumes, jail flags |
+
+Isolation **versus the host** is the hardware VM (Linux KVM / macOS HVF) plus
+the shim jail. Isolation **between agents** is one VM per agent. Isolation
+**between execs in one VM** is not a guarantee (Phase A). Compromise of a
+workload is compromise of that guest’s filesystem. The hardware boundary vs
+the host still holds.
+
+Out of scope: Windows, GPU, TEE, in-guest namespaces, browser/VNC.
+
+## Host boundary (engine, this tree)
+
+`bux-shim` is the process that applies `ShimConfig` and `krun_start_enter`.
+The product library never process-takeovers libkrun on the embedder thread.
+
+- **Hypervisor:** libkrun on KVM (`/dev/kvm`) or Hypervisor.framework
+  (`kern.hv_support`). `HostInfo::probe()` records `virtualization`. `create`
+  calls `require_virtualization` **before** `resolve_image`
+  (`crates/bux/src/runtime/boot/mod.rs`). Missing virt is
+  `Error::SecurityUnavailable` (`"no hardware virtualization (KVM / HVF)"`).
+  HTTP maps that to **412**.
+- **Jailer:** `SecurityOptions.jailer` defaults **on**. Linux: bubblewrap
+  (PID/IPC/UTS) plus Landlock, fail-closed unless `allow_degraded`. macOS:
+  `sandbox-exec` Seatbelt, deny-default. Inspect persists `SecurityStatus`
+  from the last successful spawn (`sandbox`, `landlock`, `mac`).
+- **Landlock `/dev`:** `/dev` is read/traverse only. RW leaves that exist:
+  `/dev/kvm`, `/dev/null`, `/dev/zero`, `/dev/urandom`, `/dev/random`,
+  `/dev/shm` (`crates/bux-jail/src/landlock_setup.rs`). `PathBeneath` is
+  recursive, so `/dev` itself is never RW. Do not `allow_path_and_parent` RW
+  on a `/dev/*` leaf.
+- **Seccomp:** `bux-shim-bin` installs the default BPF filter on Linux
+  `x86_64`/`aarch64` **after** `GvproxyInstance::new` (TSYNC inherits to Go
+  threads). Darwin is a no-op. Unit asserts order
+  (`crates/bux-shim-bin/src/main.rs`).
+- **Virtio-fs:** every share uses `krun_add_virtiofs3(tag, path, shm_size=0,
+  read_only)`. `VolumeMount.read_only` / CLI `:ro` is a device flag, not a
+  guest remount. FFI error fails create.
+
+`bux system info` / `HostInfo` is the probe surface. It does not open
+`Runtime` (flock-free).
+
+Guest ELF is static musl, no `PT_INTERP`, injected at mode `0555`. Shim
+config JSON is unlinked after read.
+
+## Phase A
+
+Guest agent is PID 1. Workload is `exec` through that agent. Concurrent execs
+share the guest rootfs and kernel namespaces with the agent.
+
+Inspect / `VmInfo.isolation_note` is always `PHASE_A_LIMITS`
+(`crates/bux/src/process.rs`):
+
+> Phase A: workload processes share the guest rootfs and kernel namespaces
+> with the agent; concurrent execs are not mutually isolated; compromise of a
+> workload is compromise of the agent filesystem. Hardware boundary vs host
+> still holds.
+
+Protocol is postcard **v10**. `ControlReq` is Ping/Shutdown/Quiesce/Thaw
+only. Concurrent execs sharing the guest is acceptable **because** the guest
+has one owner (one agent per VM).
+
+## Egress (labeled)
+
+CLI / engine default create network is `NetworkSpec::Enabled { allow_net: [] }`.
+
+| `network` | Meaning |
+|-----------|---------|
+| `Enabled { allow_net: [] }` | **Unrestricted** guest egress through gvproxy virtio-net |
+| `Enabled { allow_net: [...] }` | Default-deny except listed IP / CIDR / hostname / `*.suffix`. Gateway and guest TAP IPs always allowed |
+| `Disabled` | No virtio-net. Guest has no `eth0`. Ports and secrets are invalid |
+
+Empty allow-list is unrestricted **on the engine type**. Inspect JSON
+serializes `network` (`NetworkSpec`) and `VmInfo.egress`
+(`"unrestricted"` / `"disabled"` / `{ "allow": [...] }`).
+
+HTTP translation (permanent; not a 1.1 enum):
+
+| Request | Engine |
+|---------|--------|
+| `allow_net` omitted or `[]` | `NetworkSpec::Disabled` |
+| `allow_net` non-empty | `NetworkSpec::Enabled { allow_net }` |
+| `"unrestricted": true` without `--allow-unrestricted-net` | 400 |
+| `"unrestricted": true` with that flag | `Enabled { allow_net: [] }` |
+
+`allow_net` is DNS+SNI/Host/CIDR. It is not “PyPI works.” UDP is not
+published. Host port publish is off on the API; engine `ports.rs` stays for
+CLI. Bind `0.0.0.0` only; UDP publish is rejected.
+
+The shim never calls TSI `set_port_map`. Offline VMs use
+`disable_implicit_vsock` + `add_vsock(0)`.
+
+## Volumes
+
+Bind mounts and named volumes (`{data_dir}/volumes/{name}/`) are virtio-fs
+shares. Guest path is validated. Host-root and credential prefixes
+(`/etc/shadow`, `~/.ssh`, `~/.aws`, …) are denied unless `allow_sensitive`.
+
+HTTP does not expose bind mounts. Named volume `ws-{tenant}-{agent}` at
+`/workspace`. `-` is not in the id alphabet, so `ws-{tenant}-{agent}` is
+injective. Occupied name (other tenant / CLI) is 409 `name_occupied`.
+
+## Secrets
+
+`Secret` values are memory-only on `Runtime`. They must not appear in
+`bux.db` or guest `/proc/1/environ`. `Debug` redacts the value. After Runtime
+process death, restart requires `StartOptions.secrets`.
+
+CLI `--secret` is visible on host `/proc/<pid>/cmdline`. Prefer
+`--secret-file` (mode `0600`).
+
+MITM CA `not_after` is **now + 10 years** (`crates/bux-gvproxy/src/ca.rs`).
+Guest PID 1 writes PEMs, appends `ca-certificates.crt` when present, and sets
+`SSL_CERT_FILE=/etc/ssl/certs/bux-ca-bundle.pem` (`ca_trust.rs`).
+
+HTTP does not expose MITM secret values. Exec `env` is the injection path;
+values are visible in guest `/proc/<pid>/environ`.
+
+## Snapshots
+
+`Vm::create_snapshot` / `list_snapshots` / `delete_snapshot` copy the QCOW2
+overlay, optionally quiescing via `FIFREEZE`. Disk-only; no memory snapshot,
+no live migration.
+
+`Runtime::restore` flatten-like-clone. CLI `bux snapshot restore`. SQLite
+`snapshots.vm_id REFERENCES vms(id) ON DELETE CASCADE`. `bux rm` of the
+source VM deletes snapshot rows. Restore after delete is `NotFound`. Schema
+`user_version` is **5**.
+
+`Runtime::clone` flattens the overlay into a new base and boots detached.
+
+## Hosted worker
+
+A sandbox is a `Vm`. Tenancy is Bearer API keys. Key **id** is `tenant_id`
+(alphabet `[A-Za-z0-9._]`, 1..=32). Serve refuses to start with zero keys
+(including loopback and Unix). Compare the Bearer token to **every** secret
+with constant-time equality.
+
+Unauthenticated: **`GET /v1/health` only**. `/v1/config` and `/v1/metrics`
+require Bearer. `/v1/metrics` and `GET /v1/images` are worker-global (same
+JSON for every valid key).
+
+HTTP `{id}` is exact 12-char hex (`get_exact`). Unknown **or** other-tenant →
+**404** (same body). Never prefix lookup. Leftover `Error::Ambiguous` → 409
+`name_occupied`, never 404.
+
+API cannot disable jailer, Landlock, or set `allow_degraded`. API cannot
+pass bind mounts, host rootfs, MITM secrets, or port publish.
+
+`GET /v1/health` is the only public route. `--public` without a key is a
+hard error. `--public` applies to non-loopback **TCP** only.
+
+## Residual risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Phase A: exec pwns agent FS | High *inside* VM | One owner; hardware boundary vs host and vs other VMs |
+| libkrun/KVM 0-day | Critical | Pin 1.19.4; native rebuild workflow; jail+seccomp defense in depth |
+| Seatbelt/bwrap escape | High | VM is the real fence |
+| Unrestricted net if operator sets `--allow-unrestricted-net` | Medium | Flag off by default; inspect `egress` |
+| Shared ext4 base copy-on-write bug | High | QCOW2 overlay; FULL clone/restore tests |
+| Image supply chain | Medium | Digest store; `cargo deny`; pull from pinned refs in production |
+| Loopback serve accidentally `--public` | Medium | `--public` requires API key; default 127.0.0.1 |
+| Prefix IDOR via `Runtime::get` | High | HTTP uses exact id only; other-tenant 404 |
+| Tenant OOM via huge `ram_mib` / exec stdout | High | admission flags + exec output cap |
+| Hyphen in tenant/agent ids collapsing names | High | alphabet rejects `-`; `a-{t}-{a}` injective |
+
+No telemetry. Guest egress is the only network besides OCI pull. Overlay
+at-rest encryption is the operator’s (LUKS). Product does not add it.
+
+## Proof
+
+`scripts/e2e/smoke.sh` with `BUX_E2E_FULL=1` is a **manual** gate. Recorded
+HVF runs in [CONTRIBUTING.md](../CONTRIBUTING.md) are **pre-v10** and are
+not ship proof. Host CI forces `BUX_E2E_FULL=0`. There is **no** Linux KVM
+FULL record. Do not invent uname, git SHA, ELF sha256, or `SMOKE_EXIT=0`.

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -122,7 +122,7 @@ Auth: Bearer on every route except `GET /v1/health`. Compare the token to
 |------|---------|-------------------|
 | `--allow-unrestricted-net` | off | Required for request `"unrestricted": true` |
 | `--max-sandboxes` | 32 per tenant | 429 |
-| `--max-sandboxes-global` | same as `--max-sandboxes` | 429 |
+| `--max-sandboxes-global` | 32 | 429 |
 | `--max-ram-mib` | 2048 per sandbox | 400 |
 | `--max-vcpus` | 4 | 400 |
 | `--max-running-ram-mib` | 8192 (sum Running+Stopping + request) | 429 |
@@ -131,7 +131,6 @@ Auth: Bearer on every route except `GET /v1/health`. Compare the token to
 | `--max-exec-output-bytes` | 1048576 per stream | truncate + `truncated: true`; SIGKILL guest child |
 | `--default-ram-mib` | 512 | default if omitted |
 | `--default-vcpus` | 1 | default if omitted |
-| `--ready-timeout-secs` | 30 | create failure 503/504 with shim stderr tail |
 | `--pull-timeout-secs` | 300 | |
 
 `disk_bytes_used` on metrics is overlays+bases only and is **not** the
@@ -191,8 +190,7 @@ HTTP DELETE of a sandbox: stop, `Runtime::remove` (drops overlay), then
 ## `{id}.stderr`
 
 Shim and guest stderr land at `{data_dir}/socks/{id}.stderr`. CLI: `bux logs`.
-HTTP: `GET /v1/sandboxes/{id}/logs`. Create failure should return 503/504
-with a tail of this file, not hang past `--ready-timeout-secs`.
+HTTP: `GET /v1/sandboxes/{id}/logs`.
 
 ## Restart and rollback
 
@@ -247,7 +245,6 @@ POST   /v1/sandboxes                         # get-or-create by (tenant_id, agen
 GET    /v1/sandboxes                         # this tenant only
 GET    /v1/sandboxes/{id}                    # exact 12-char hex
 POST   /v1/sandboxes/{id}/start
-POST   /v1/sandboxes/{id}/stop
 DELETE /v1/sandboxes/{id}                    # stop+remove+volume rm; 204
 GET    /v1/sandboxes/{id}/logs
 
@@ -269,8 +266,8 @@ mounts, memory snapshot.
 1..=64 (`-` → 400). Same spec → same exact id. Spec mismatch → 409
 `sandbox_exists`. Name occupied by another tenant or a CLI VM → 409
 `name_occupied`. Network omit/`[]` → deny. `auto_stop_secs` default **1800**
-on API create. Sweep every 30 s. Idle clock resets on create, start, exec,
-file PUT/GET.
+on API create, clone, and restore. Sweep every 30 s. Idle clock resets on
+create, start, exec, file PUT/GET. HTTP has no stop route; idle sweep stops.
 
 Exec: collect-only. `timeout_ms` default 30000, min 1, max 300000, **never
 0**. Guest `ExecStart::timeout` kills the guest process. Do not rely on host

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -12,10 +12,12 @@ release bumps schema.
 
 ```bash
 tar xf bux-<ver>-x86_64-unknown-linux-gnu.tar.gz
-cd bux-<ver>-x86_64-unknown-linux-gnu
 ./bux system info --format json
 ./bux serve start --help
 ```
+
+Members are at archive root (`cd.yml` packs with `tar czf … -C "$staging" .`).
+Run `./bux` from the directory that received the extract.
 
 Targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
 `aarch64-apple-darwin`. Layout:
@@ -69,11 +71,10 @@ Zero API keys → process exits **2** before bind. No “warn and listen
 unauthenticated.” `--public` without a key is a hard error.
 
 ```bash
-./bux serve start \
-  --api-key-file /etc/bux/keys \
-  --listen 127.0.0.1:8080 \
-  --listen unix://${XDG_RUNTIME_DIR:-/tmp}/bux.sock
+./bux serve start --api-key-file /etc/bux/keys
 ```
+
+Omitted `--listen` binds both defaults (TCP loopback and Unix; see Listen).
 
 ```bash
 bux serve openapi   # JSON on stdout, exit 0

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -1,0 +1,287 @@
+# Serve
+
+Operator page for `bux serve`: one process, one `Runtime`, many per-agent
+VMs. Extract the GitHub tarball. Do not expect a fourth artifact.
+
+Workspace is **0.8.0**. Tag `v1.0.0` only when the hosted worker is in that
+tarball and FULL proof is recorded. Rollback target is **`v0.8.x`**. Schema
+`user_version` stays **5**; rollback does not wipe `BUX_HOME` unless a later
+release bumps schema.
+
+## Extract tarball
+
+```bash
+tar xf bux-<ver>-x86_64-unknown-linux-gnu.tar.gz
+cd bux-<ver>-x86_64-unknown-linux-gnu
+./bux system info --format json
+./bux serve start --help
+```
+
+Targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`,
+`aarch64-apple-darwin`. Layout:
+
+```text
+bux
+bux-shim
+bux-guest-<linux-musl-triple>
+libkrun* / libkrunfw*     # .so + soname aliases on Linux; .dylib on Darwin
+LICENSE-MIT
+LICENSE-APACHE
+```
+
+Keep `libkrun*` in the **same directory** as `./bux`. Linux `DT_NEEDED` is
+the soname (`libkrun.so.1`, `libkrunfw.so.5`). This repo stamps
+`-Wl,-rpath,$ORIGIN` (`.cargo/config.toml` and `bux-shim-bin` `build.rs`).
+Downstream Linux embedders must set:
+
+```toml
+# embedder .cargo/config.toml (Linux)
+[target.'cfg(target_os = "linux")']
+rustflags = ["-C", "link-arg=-Wl,-rpath,$ORIGIN"]
+```
+
+Darwin records `@loader_path/libkrun.dylib`. Embedders on Darwin do not need
+rpath rustflags. libkrun `dlopen`s `libkrunfw.5.dylib` / `libkrunfw.so.5`;
+versioned aliases are required.
+
+Capture env: `BUX_HOME`, `BUX_SHIM_PATH`, `BUX_GUEST_PATH`, `BUX_GUEST_DIR`
+(see root README). Guest resolution: `BUX_GUEST_PATH`, then a sibling of the
+running executable (`bux-guest-<triple>`, `bux-guest-linux`, `bux-guest`),
+then `$PATH`. There is no download protocol.
+
+## `/dev/kvm` and 412
+
+Linux production is a machine with a `/dev/kvm` character device (x86_64 or
+aarch64; nested virt not required on a KVM instance or bare metal).
+`create` / sandbox create calls `require_virtualization` before image
+resolve. Missing KVM or HVF is `Error::SecurityUnavailable` → HTTP **412**
+`security_unavailable`. That is fail-closed, not a warning.
+
+GitHub-hosted `e2e-host.yml` forces `BUX_E2E_FULL=0`. It is not Linux
+production proof.
+
+Darwin needs `kern.hv_support=1`. Codesign `bux-shim` with
+`crates/bux-shim/bux-shim.entitlements` when building from source.
+
+## Start
+
+Zero API keys → process exits **2** before bind. No “warn and listen
+unauthenticated.” `--public` without a key is a hard error.
+
+```bash
+./bux serve start \
+  --api-key-file /etc/bux/keys \
+  --listen 127.0.0.1:8080 \
+  --listen unix://${XDG_RUNTIME_DIR:-/tmp}/bux.sock
+```
+
+```bash
+bux serve openapi   # JSON on stdout, exit 0
+```
+
+### Keys
+
+| Flag / env | Form |
+|------------|------|
+| `--api-key-file PATH` / `BUX_API_KEY_FILE` | `id=secret` lines. Blank and `#` comments skipped. Mode `0600` preferred; warn if group/other readable, do not refuse. |
+| `--api-key ID:SECRET` (repeatable) / `BUX_API_KEYS` | `id:secret` pairs, comma-separated in env. |
+
+`--api-key SECRET` with no `:` is a startup error. Duplicate ids: startup
+error. `id` alphabet is `[A-Za-z0-9._]`, length 1..=32 (same as `tenant_id`).
+`id=foo-bar` is a startup error.
+
+Auth: Bearer on every route except `GET /v1/health`. Compare the token to
+**every** secret with constant-time equality; matching row’s `id` is
+`tenant_id`. Keys live in process memory, not SQLite. Restart to rotate.
+
+`--api-key id:secret` leaks via `/proc/pid/cmdline`. Prefer `--api-key-file`.
+
+### Listen
+
+`--listen` is repeatable. Each value is `HOST:PORT` or `unix://ABS_PATH`
+(a path starting with `/` is Unix). Default if omitted:
+
+```text
+--listen 127.0.0.1:8080
+--listen unix://$XDG_RUNTIME_DIR/bux.sock   # fallback /tmp/bux-$UID.sock
+```
+
+`BUX_LISTEN` is comma-separated, same grammar.
+
+- `--public` is required to bind a non-loopback **TCP** address.
+- Unix sockets are always local. `--public` does not apply to them and is a
+  startup error if the only listeners are Unix.
+- API keys are still required on Unix.
+- `--listen unix://...` alone (no TCP) is valid.
+- Unlink the socket file on shutdown.
+
+### Flags
+
+| Flag | Default | On exceed / notes |
+|------|---------|-------------------|
+| `--allow-unrestricted-net` | off | Required for request `"unrestricted": true` |
+| `--max-sandboxes` | 32 per tenant | 429 |
+| `--max-sandboxes-global` | same as `--max-sandboxes` | 429 |
+| `--max-ram-mib` | 2048 per sandbox | 400 |
+| `--max-vcpus` | 4 | 400 |
+| `--max-running-ram-mib` | 8192 (sum Running+Stopping + request) | 429 |
+| `--max-disk-bytes` | 32 GiB (`Runtime::data_dir_usage`, recursive) | 429 |
+| `--max-pull-bytes` | 4 GiB (manifest compressed bytes before blobs) | 413 |
+| `--max-exec-output-bytes` | 1048576 per stream | truncate + `truncated: true`; SIGKILL guest child |
+| `--default-ram-mib` | 512 | default if omitted |
+| `--default-vcpus` | 1 | default if omitted |
+| `--ready-timeout-secs` | 30 | create failure 503/504 with shim stderr tail |
+| `--pull-timeout-secs` | 300 | |
+
+`disk_bytes_used` on metrics is overlays+bases only and is **not** the
+admission cap. Alert on `data_dir_bytes` vs `--max-disk-bytes`.
+
+Logs: `RUST_LOG` / `--log-level`. No secret values in logs.
+
+## Busy flock
+
+`Runtime::open` takes an exclusive non-blocking flock on `{BUX_HOME}/bux.lock`.
+A second `bux serve start` on the same data dir exits `Busy`. Local CLI that
+opens a Runtime (`create`, `exec`, `ps`, …) cannot run **during** serve.
+`bux system info` is flock-free.
+
+One worker owns one data dir. That is the process model, not a bug.
+
+## Proxy
+
+The worker does not terminate TLS. Put it behind a reverse proxy if the org
+needs TLS or SSO. No JWT/OIDC in the worker. Copying Auth0 into this repo is
+a non-goal.
+
+Typical: proxy `127.0.0.1:8080` or the Unix socket. Forward
+`Authorization: Bearer`. Do not put the secret in query strings (they leak
+via access logs).
+
+## Data-dir layout
+
+Default dir: `$BUX_HOME`, else Linux `$XDG_DATA_HOME/bux` /
+`~/.local/share/bux`, macOS `~/Library/Application Support/bux`.
+
+```text
+{data_dir}/
+  bux.lock
+  bux.db                 # schema user_version 5
+  images.db              # OCI index; not merged with bux.db
+  layers/ configs/ rootfs/
+  disks/bases/{digest}.raw      # shared ext4 bases (size the disk for these)
+  disks/vms/{id}.qcow2          # per-VM overlay (~256 KiB empty)
+  volumes/ws-{tenant}-{agent}/  # HTTP workspace → guest /workspace
+  snapshots/{sid}.qcow2
+  socks/{id}
+  socks/{id}.stderr             # shim/guest stderr; GET /v1/sandboxes/{id}/logs
+  socks/{id}.exit
+```
+
+**Disk for shared bases:** each distinct image digest keeps a full ext4
+`.raw` under `disks/bases/`. Overlays are cheap; bases are not. `DELETE
+/v1/images?reference=` removes the OCI index entry and may drop unused
+layers. It does **not** delete `disks/bases/{digest}.raw`. Leftover bases
+after rmi are expected. Size `--max-disk-bytes` and the volume for layers +
+bases + overlays + workspace writes.
+
+HTTP DELETE of a sandbox: stop, `Runtime::remove` (drops overlay), then
+`VolumeManager::remove` of `ws-{tenant}-{agent}` (host directory gone).
+
+## `{id}.stderr`
+
+Shim and guest stderr land at `{data_dir}/socks/{id}.stderr`. CLI: `bux logs`.
+HTTP: `GET /v1/sandboxes/{id}/logs`. Create failure should return 503/504
+with a tail of this file, not hang past `--ready-timeout-secs`.
+
+## Restart and rollback
+
+Serve process restart: live **detached** VMs reattach; the worker must not
+SIGTERM them on Drop. `secrets_required` VMs are 409 on start/exec until
+secrets are re-supplied (CLI path). HTTP does not expose MITM secrets.
+
+Rollback: previous **`v0.8.x`** tarball. Schema v5 is unchanged; replacing
+the binary and restarting serve does not wipe. A later schema bump refuses
+`Runtime::open` until `bux system reset` (or deleting `BUX_HOME`).
+
+Native pins (`krun-v1.19.4` / `e2fs-v1.47.4` / `bwrap-v0.12.0`) are
+independent of product tags. Serve does not retag them.
+
+## HTTP (1.0)
+
+Error envelope:
+
+```json
+{ "error": { "code": "<snake>", "message": "...", "existing_id": "...", "field": "..." } }
+```
+
+`existing_id` / `field` only when applicable (`name_occupied`,
+`sandbox_exists`).
+
+| `bux::Error` / serve | HTTP |
+|----------------------|------|
+| `InvalidConfig` | 400 `invalid_config` |
+| `NotFound` / other-tenant / bad `{id}` | 404 `not_found` |
+| `Ambiguous` | 409 `name_occupied` |
+| `InvalidState` | 409 `invalid_state` |
+| `Busy` | 409 `busy` |
+| `GuestUnavailable` | 503 `guest_unavailable` |
+| `SecretsRequired` | 409 `secrets_required` |
+| `SecurityUnavailable` | **412** `security_unavailable` |
+| admission count/RAM/disk | 429 `resource_exhausted` |
+| body too large / pull over `--max-pull-bytes` | 413 `payload_too_large` |
+| missing/invalid Bearer | 401 `unauthorized` |
+
+```text
+GET    /v1/health                            # no auth
+GET    /v1/config                            # Bearer
+GET    /v1/me                                # { tenant_id, max_sandboxes }
+GET    /v1/metrics                           # Bearer; RuntimeMetrics + data_dir_bytes
+
+POST   /v1/images/pull                       # { "reference" }
+GET    /v1/images                            # worker-global
+DELETE /v1/images?reference=
+
+POST   /v1/sandboxes                         # get-or-create by (tenant_id, agent_id)
+GET    /v1/sandboxes                         # this tenant only
+GET    /v1/sandboxes/{id}                    # exact 12-char hex
+POST   /v1/sandboxes/{id}/start
+POST   /v1/sandboxes/{id}/stop
+DELETE /v1/sandboxes/{id}                    # stop+remove+volume rm; 204
+GET    /v1/sandboxes/{id}/logs
+
+POST   /v1/sandboxes/{id}/exec               # collect-only
+PUT    /v1/sandboxes/{id}/files?path=        # raw bytes, 32 MiB; mode decimal u32
+GET    /v1/sandboxes/{id}/files?path=
+
+POST   /v1/sandboxes/{id}/clone
+POST   /v1/sandboxes/{id}/snapshots
+GET    /v1/sandboxes/{id}/snapshots
+DELETE /v1/sandboxes/{id}/snapshots/{sid}
+POST   /v1/sandboxes/{id}/snapshots/{sid}/restore
+```
+
+Not in 1.0: exec_id routes, WebSocket attach, tar upload, port publish, bind
+mounts, memory snapshot.
+
+`POST /v1/sandboxes` get-or-create. `agent_id` alphabet `[A-Za-z0-9._]`,
+1..=64 (`-` → 400). Same spec → same exact id. Spec mismatch → 409
+`sandbox_exists`. Name occupied by another tenant or a CLI VM → 409
+`name_occupied`. Network omit/`[]` → deny. `auto_stop_secs` default **1800**
+on API create. Sweep every 30 s. Idle clock resets on create, start, exec,
+file PUT/GET.
+
+Exec: collect-only. `timeout_ms` default 30000, min 1, max 300000, **never
+0**. Guest `ExecStart::timeout` kills the guest process. Do not rely on host
+`tokio::time::timeout` alone (leaks the guest child).
+
+Files: `path` query required, absolute guest path, no `..`. PUT default mode
+`0o644`; query `mode` is decimal `u32` (`mode=420` for 0644). JSON body
+limit 1 MiB; files route 32 MiB.
+
+Registry auth is process-wide (`BUX_REGISTRY_USER` / `BUX_REGISTRY_PASSWORD`
+or anonymous), not per-tenant.
+
+## Isolation reminder
+
+Jailer on, Landlock fail-closed, no `allow_degraded` on the API. One VM per
+`(tenant_id, agent_id)`. Details: [security-model.md](security-model.md).

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -4,9 +4,9 @@ Operator page for `bux serve`: one process, one `Runtime`, many per-agent
 VMs. Extract the GitHub tarball. Do not expect a fourth artifact.
 
 Workspace is **0.8.0**. Tag `v1.0.0` only when the hosted worker is in that
-tarball and FULL proof is recorded. Rollback target is **`v0.8.x`**. Schema
-`user_version` stays **5**; rollback does not wipe `BUX_HOME` unless a later
-release bumps schema.
+tarball and FULL proof is recorded. Rollback is the **previous extract**.
+There is no `v0.8.0` GitHub Release. Schema `user_version` stays **5**;
+rollback does not wipe `BUX_HOME` unless a later release bumps schema.
 
 ## Extract tarball
 
@@ -200,8 +200,9 @@ Serve process restart: live **detached** VMs reattach; the worker must not
 SIGTERM them on Drop. `secrets_required` VMs are 409 on start/exec until
 secrets are re-supplied (CLI path). HTTP does not expose MITM secrets.
 
-Rollback: previous **`v0.8.x`** tarball. Schema v5 is unchanged; replacing
-the binary and restarting serve does not wipe. A later schema bump refuses
+Rollback: previous extract (previous `main` binary or previous tarball).
+There is no `v0.8.0` GitHub Release. Schema v5 is unchanged; replacing the
+binary and restarting serve does not wipe. A later schema bump refuses
 `Runtime::open` until `bux system reset` (or deleting `BUX_HOME`).
 
 Native pins (`krun-v1.19.4` / `e2fs-v1.47.4` / `bwrap-v0.12.0`) are

--- a/scripts/e2e/fetch-guest.sh
+++ b/scripts/e2e/fetch-guest.sh
@@ -60,16 +60,17 @@ if machine != expected:
 e_phoff = struct.unpack_from("<Q", data, 32)[0]
 e_phentsize = struct.unpack_from("<H", data, 54)[0]
 e_phnum = struct.unpack_from("<H", data, 56)[0]
-if e_phoff == 0 or e_phentsize == 0 or e_phnum == 0:
-    sys.exit(0)
-for i in range(e_phnum):
-    off = e_phoff + i * e_phentsize
-    end = off + 4
-    if end > len(data):
-        break
-    p_type = struct.unpack_from("<I", data, off)[0]
-    if p_type == 3:
-        sys.exit(1)
+if e_phoff != 0 and e_phentsize != 0 and e_phnum != 0:
+    for i in range(e_phnum):
+        off = e_phoff + i * e_phentsize
+        end = off + 4
+        if end > len(data):
+            break
+        p_type = struct.unpack_from("<I", data, off)[0]
+        if p_type == 3:
+            sys.exit(1)
+if b"bux-guest-protocol-v10" not in data:
+    sys.exit(1)
 sys.exit(0)
 PY
 }
@@ -77,7 +78,7 @@ PY
 install_from() {
   local src="$1"
   if ! validate_guest_elf "${src}"; then
-    echo "downloaded bux-guest-${TRIPLE} failed ELF checks (64-bit LE, host arch, no PT_INTERP)" >&2
+    echo "downloaded bux-guest-${TRIPLE} failed ELF checks (64-bit LE, host arch, no PT_INTERP, bux-guest-protocol-v10)" >&2
     exit 1
   fi
   mkdir -p "${ROOT}/target/debug"

--- a/scripts/e2e/full_common.sh
+++ b/scripts/e2e/full_common.sh
@@ -129,7 +129,58 @@ e2e_cleanup_bux_home() {
   fi
 }
 
-# Build cli+shim, Darwin codesign, pin guest, put target/debug on PATH.
+# Fail if any address's IPv4 form is in 198.18.0.0/15 (Clash/Surge fake-ip).
+# Live: getaddrinfo("example.com", 443, SOCK_STREAM). Args: injected hosts (tests).
+# IPv4 form: IPv4; else ipv4_mapped; else last 4 bytes of the 16-byte AAAA packed form.
+refuse_fake_ip_example_com() {
+  python3 - "$@" <<'PY'
+import ipaddress, socket, sys
+
+FAKE = ipaddress.ip_network("198.18.0.0/15")
+
+
+def ipv4_form(s):
+    ip = ipaddress.ip_address(s.split("%", 1)[0])
+    if isinstance(ip, ipaddress.IPv4Address):
+        return ip
+    if ip.ipv4_mapped is not None:
+        return ip.ipv4_mapped
+    return ipaddress.IPv4Address(ip.packed[-4:])
+
+
+if len(sys.argv) > 1:
+    hosts = sys.argv[1:]
+    for h in hosts:
+        print(f"example.com injected: {h}", file=sys.stderr)
+else:
+    try:
+        infos = socket.getaddrinfo("example.com", 443, type=socket.SOCK_STREAM)
+    except OSError as e:
+        print(f"FULL refuse: getaddrinfo(example.com, 443) failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    hosts = []
+    for rec in infos:
+        print(f"example.com getaddrinfo: {rec}", file=sys.stderr)
+        hosts.append(rec[4][0])
+
+hit = False
+for h in hosts:
+    v4 = ipv4_form(h)
+    print(f"example.com ipv4_form: {h} -> {v4}", file=sys.stderr)
+    if v4 in FAKE:
+        hit = True
+if hit:
+    print(
+        "FULL refuse: example.com IPv4 form in 198.18.0.0/15. "
+        "Disable fake-ip/MacPacket (hygiene, not a recorded 502). CONTRIBUTING.md",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+sys.exit(0)
+PY
+}
+
+# Build cli+shim, Darwin codesign, pin guest, fake-ip preflight, PATH.
 pin_full_binaries() {
   echo "building bux-cli and bux-shim-bin (FULL pin)..."
   cargo build -p bux-cli -p bux-shim-bin --manifest-path "${ROOT}/Cargo.toml"
@@ -141,4 +192,5 @@ pin_full_binaries() {
   export PATH="${ROOT}/target/debug:${PATH}"
   export BUX_SHIM_PATH="${ROOT}/target/debug/bux-shim"
   test -x "${BUX_SHIM_PATH}"
+  refuse_fake_ip_example_com
 }

--- a/scripts/e2e/full_common_test.sh
+++ b/scripts/e2e/full_common_test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Host-only tests for full_common.sh guest ELF stamp. No hypervisor.
+# Host-only tests for full_common.sh guest ELF stamp and fake-ip helper.
+# No hypervisor. Fake-ip cases use injected addresses (no live DNS).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -86,6 +87,22 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
     pin_full_guest
   ) && rc=0 || rc=$?
   [[ "${rc}" -ne 0 ]] || fail "Darwin leftover ELF must not pin without BUX_GUEST_PATH"
+fi
+
+if refuse_fake_ip_example_com "198.18.0.160"; then
+  fail "198.18.0.160 must fail refuse_fake_ip_example_com"
+fi
+if refuse_fake_ip_example_com "::ffff:198.18.0.160"; then
+  fail "::ffff:198.18.0.160 must fail refuse_fake_ip_example_com"
+fi
+if refuse_fake_ip_example_com "::ffff:0:c612:a0"; then
+  fail "::ffff:0:c612:a0 must fail refuse_fake_ip_example_com"
+fi
+if ! refuse_fake_ip_example_com "93.184.216.34"; then
+  fail "93.184.216.34 must pass refuse_fake_ip_example_com"
+fi
+if ! refuse_fake_ip_example_com "::ffff:93.184.216.34"; then
+  fail "::ffff:93.184.216.34 must pass refuse_fake_ip_example_com"
 fi
 
 echo OK

--- a/scripts/e2e/serve.sh
+++ b/scripts/e2e/serve.sh
@@ -1,0 +1,424 @@
+#!/usr/bin/env bash
+# Hosted `bux serve` e2e. GitHub-hosted CI keeps BUX_E2E_FULL=0 (help/openapi).
+# FULL=1 is a manual HVF/KVM gate (CONTRIBUTING.md). This script never enables FULL.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+E2E_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=full_common.sh
+source "${E2E_DIR}/full_common.sh"
+
+export BUX_HOME="${BUX_HOME:-$(mktemp -d /tmp/bux-e2e.XXXXXX)}"
+SERVE_PID=""
+RESP="${BUX_HOME}/http-body"
+SOCK=""
+PORT=""
+HTTP_CODE=""
+
+stop_serve() {
+  local pid="${SERVE_PID:-}"
+  SERVE_PID=""
+  if [[ -z "${pid}" ]]; then
+    return 0
+  fi
+  if kill -0 "${pid}" 2>/dev/null; then
+    # SIGTERM the worker only (not the process group). Detached shims must live (R3).
+    kill -TERM "${pid}" 2>/dev/null || true
+    local i
+    for i in $(seq 1 40); do
+      kill -0 "${pid}" 2>/dev/null || break
+      sleep 0.25
+    done
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill -KILL "${pid}" 2>/dev/null || true
+    fi
+  fi
+  wait "${pid}" 2>/dev/null || true
+}
+
+cleanup() {
+  stop_serve
+  e2e_cleanup_bux_home
+}
+trap cleanup EXIT
+
+echo "==> BUX_HOME=${BUX_HOME}"
+
+if [[ "${BUX_E2E_FULL:-}" == "1" ]]; then
+  pin_full_binaries
+elif ! command -v bux >/dev/null 2>&1; then
+  echo "building bux-cli..."
+  cargo build -q -p bux-cli --manifest-path "${ROOT}/Cargo.toml"
+  export PATH="${ROOT}/target/debug:${PATH}"
+fi
+
+echo "==> bux serve start --help"
+bux serve start --help | grep -q -- '--api-key'
+bux serve start --help | grep -q -- '--listen'
+
+echo "==> bux serve openapi"
+openapi="$(bux serve openapi)"
+printf '%s\n' "${openapi}" | grep -q '"openapi"'
+printf '%s\n' "${openapi}" | grep -q '/v1/health'
+printf '%s\n' "${openapi}" | grep -q '/v1/sandboxes'
+printf '%s\n' "${openapi}" | grep -q '/v1/sandboxes/{id}/exec'
+printf '%s\n' "${openapi}" | grep -q '/v1/sandboxes/{id}/snapshots'
+
+if [[ "${BUX_E2E_FULL:-}" != "1" ]]; then
+  echo "==> skip full serve e2e (set BUX_E2E_FULL=1 on a local HVF/KVM machine; see CONTRIBUTING.md)"
+  echo "OK (host-only serve smoke)"
+  exit 0
+fi
+
+info_json="$(bux system info --format json)"
+if ! printf '%s\n' "${info_json}" | grep -Eq '"virtualization":[[:space:]]*true'; then
+  echo "==> skip full serve e2e (host.virtualization is not true)"
+  echo "OK (skipped serve full)"
+  exit 0
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "FULL serve e2e requires curl" >&2
+  exit 1
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "FULL serve e2e requires python3" >&2
+  exit 1
+fi
+
+KEY1_ID="t1"
+KEY1_SEC="s1e2e"
+KEY2_ID="t2"
+KEY2_SEC="s2e2e"
+KEY1="${KEY1_ID}:${KEY1_SEC}"
+KEY2="${KEY2_ID}:${KEY2_SEC}"
+IMAGE="${BUX_E2E_IMAGE:-alpine:latest}"
+AGENT_LOOP="loop"
+AGENT_DENY="deny"
+AGENT_IDLE="idle"
+AGENT_REST="rest"
+AGENT_CLON="clon"
+VOL_LOOP="${BUX_HOME}/volumes/ws-${KEY1_ID}-${AGENT_LOOP}"
+
+json_get() {
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+path = sys.argv[2].split(".")
+with open(sys.argv[1], encoding="utf-8") as f:
+    v = json.load(f)
+for key in path:
+    if isinstance(v, list):
+        v = v[int(key)]
+    else:
+        v = v[key]
+if isinstance(v, (dict, list)):
+    json.dump(v, sys.stdout)
+    sys.stdout.write("\n")
+elif v is None:
+    pass
+else:
+    sys.stdout.write(str(v))
+PY
+}
+
+dump_fail() {
+  echo "body:" >&2
+  cat "${RESP}" >&2 2>/dev/null || true
+  echo "serve.log:" >&2
+  cat "${BUX_HOME}/serve.log" >&2 2>/dev/null || true
+  echo "shim stderr:" >&2
+  cat "${BUX_HOME}/socks/"*.stderr >&2 2>/dev/null || true
+}
+
+require_http() {
+  local want="$1"
+  local msg="$2"
+  if [[ "${HTTP_CODE}" != "${want}" ]]; then
+    echo "${msg}: HTTP ${HTTP_CODE} (want ${want})" >&2
+    dump_fail
+    return 1
+  fi
+}
+
+# Unix socket is the API transport (also proves --listen unix://). TCP is health + wait.
+# Bash 3.2 + set -u: do not expand an empty array.
+http() {
+  local method="$1" path="$2" token="$3"
+  local max="${HTTP_TIMEOUT:-120}"
+  shift 3
+  if [[ "${method}" == POST ]]; then
+    HTTP_CODE="$(
+      curl -sS -o "${RESP}" -w '%{http_code}' \
+        --unix-socket "${SOCK}" \
+        --max-time "${max}" \
+        -X POST \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: application/json" \
+        "$@" \
+        "http://localhost${path}"
+    )"
+  else
+    HTTP_CODE="$(
+      curl -sS -o "${RESP}" -w '%{http_code}' \
+        --unix-socket "${SOCK}" \
+        --max-time "${max}" \
+        -X "${method}" \
+        -H "Authorization: Bearer ${token}" \
+        "$@" \
+        "http://localhost${path}"
+    )"
+  fi
+}
+
+post_json() {
+  local path="$1" token="$2" body="$3"
+  http POST "${path}" "${token}" --data-binary "${body}"
+}
+
+sandbox_body() {
+  python3 - "$1" "$2" "$3" <<'PY'
+import json, sys
+image, agent, extra = sys.argv[1], sys.argv[2], sys.argv[3]
+body = {"agent_id": agent, "image": image}
+if extra == "deny":
+    body["allow_net"] = ["127.0.0.1"]
+elif extra == "idle":
+    body["auto_stop_secs"] = 1
+print(json.dumps(body))
+PY
+}
+
+exec_sh() {
+  local id="$1" token="$2" script="$3"
+  local payload
+  payload="$(python3 -c 'import json,sys; print(json.dumps({"cmd":"sh","args":["-c", sys.argv[1]]}))' "${script}")"
+  post_json "/v1/sandboxes/${id}/exec" "${token}" "${payload}"
+}
+
+wait_serve() {
+  local i
+  for i in $(seq 1 80); do
+    if curl -fsS --max-time 1 "http://127.0.0.1:${PORT}/v1/health" >/dev/null 2>&1 \
+      && curl -fsS --max-time 1 --unix-socket "${SOCK}" "http://localhost/v1/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    if [[ -n "${SERVE_PID}" ]] && ! kill -0 "${SERVE_PID}" 2>/dev/null; then
+      echo "serve exited before health" >&2
+      cat "${BUX_HOME}/serve.log" >&2 || true
+      return 1
+    fi
+    sleep 0.1
+  done
+  echo "serve health timeout" >&2
+  cat "${BUX_HOME}/serve.log" >&2 || true
+  return 1
+}
+
+start_serve() {
+  : >"${BUX_HOME}/serve.log"
+  bux serve start \
+    --listen "127.0.0.1:${PORT}" \
+    --listen "unix://${SOCK}" \
+    --api-key "${KEY1}" \
+    --api-key "${KEY2}" \
+    >>"${BUX_HOME}/serve.log" 2>&1 &
+  SERVE_PID=$!
+  wait_serve
+}
+
+wait_status() {
+  local id="$1" token="$2" want="$3" tries="${4:-60}"
+  local i got
+  for i in $(seq 1 "${tries}"); do
+    http GET "/v1/sandboxes/${id}" "${token}"
+    require_http 200 "GET ${id} while waiting for ${want}"
+    got="$(json_get "${RESP}" status)"
+    if [[ "${got}" == "${want}" ]]; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "sandbox ${id} status ${got:-empty} (want ${want})" >&2
+  dump_fail
+  return 1
+}
+
+guest_wget_probe() {
+  local id="$1" token="$2" timeout="${3:-10}"
+  exec_sh "${id}" "${token}" "
+    if command -v wget >/dev/null 2>&1; then
+      w() { wget -qO- -T ${timeout} http://example.com; }
+    elif command -v busybox >/dev/null 2>&1; then
+      w() { busybox wget -qO- -T ${timeout} http://example.com; }
+    else
+      echo WGET_MISSING
+      exit 0
+    fi
+    if w >/dev/null 2>&1; then
+      echo WGET_OK
+    else
+      echo WGET_FAIL
+    fi
+  "
+  require_http 200 "deny-net exec"
+  json_get "${RESP}" stdout
+}
+
+PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+SOCK="${BUX_HOME}/bux.sock"
+
+echo "==> serve start 127.0.0.1:${PORT} unix://${SOCK}"
+start_serve
+
+echo "==> curl --unix-socket /v1/health"
+curl -fsS --unix-socket "${SOCK}" "http://localhost/v1/health" >/dev/null
+http GET "/v1/me" "${KEY1_SEC}"
+require_http 200 "GET /v1/me"
+test "$(json_get "${RESP}" tenant_id)" = "${KEY1_ID}"
+
+echo "==> pull ${IMAGE}"
+HTTP_TIMEOUT=300 post_json "/v1/images/pull" "${KEY1_SEC}" "$(python3 -c 'import json,sys; print(json.dumps({"reference": sys.argv[1]}))' "${IMAGE}")"
+require_http 200 "POST /v1/images/pull"
+
+echo "==> POST sandboxes twice (same agent)"
+post_json "/v1/sandboxes" "${KEY1_SEC}" "$(sandbox_body "${IMAGE}" "${AGENT_LOOP}" "")"
+require_http 201 "POST create"
+LOOP_ID="$(json_get "${RESP}" id)"
+test "${#LOOP_ID}" -eq 12
+test -d "${VOL_LOOP}"
+post_json "/v1/sandboxes" "${KEY1_SEC}" "$(sandbox_body "${IMAGE}" "${AGENT_LOOP}" "")"
+require_http 200 "POST get-or-create"
+test "$(json_get "${RESP}" id)" = "${LOOP_ID}"
+
+echo "==> exec echo"
+exec_sh "${LOOP_ID}" "${KEY1_SEC}" "echo e2e-ok"
+require_http 200 "exec echo"
+test "$(json_get "${RESP}" code)" = "0"
+printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx e2e-ok
+
+echo "==> PUT/GET /workspace/x"
+printf 'persist-ok\n' >"${BUX_HOME}/workspace-x"
+http PUT "/v1/sandboxes/${LOOP_ID}/files?path=/workspace/x" "${KEY1_SEC}" \
+  --data-binary "@${BUX_HOME}/workspace-x"
+require_http 204 "PUT /workspace/x"
+http GET "/v1/sandboxes/${LOOP_ID}/files?path=/workspace/x" "${KEY1_SEC}"
+require_http 200 "GET /workspace/x"
+grep -qx persist-ok "${RESP}"
+
+echo "==> second tenant 404"
+http GET "/v1/sandboxes/${LOOP_ID}" "${KEY2_SEC}"
+require_http 404 "other tenant GET sandbox"
+test "$(json_get "${RESP}" error.code)" = "not_found"
+http GET "/v1/sandboxes/${LOOP_ID}/snapshots" "${KEY2_SEC}"
+require_http 404 "other tenant GET snapshots"
+test "$(json_get "${RESP}" error.code)" = "not_found"
+post_json "/v1/sandboxes/${LOOP_ID}/snapshots" "${KEY2_SEC}" "{}"
+require_http 404 "other tenant POST snapshot"
+
+echo "==> overlay marker + snapshot create"
+exec_sh "${LOOP_ID}" "${KEY1_SEC}" "printf '%s\n' serve-ok > /serve-marker && sync"
+require_http 200 "write /serve-marker"
+post_json "/v1/sandboxes/${LOOP_ID}/snapshots" "${KEY1_SEC}" '{"name":"e2e"}'
+require_http 201 "POST snapshot"
+SID="$(json_get "${RESP}" id)"
+test -n "${SID}"
+
+echo "==> restore {agent_id} + exec marker"
+post_json "/v1/sandboxes/${LOOP_ID}/snapshots/${SID}/restore" "${KEY1_SEC}" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"agent_id": sys.argv[1]}))' "${AGENT_REST}")"
+require_http 201 "POST restore"
+REST_ID="$(json_get "${RESP}" id)"
+test "${REST_ID}" != "${LOOP_ID}"
+exec_sh "${REST_ID}" "${KEY1_SEC}" "cat /serve-marker"
+require_http 200 "restore exec marker"
+printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx serve-ok
+
+echo "==> clone {agent_id} + exec marker"
+post_json "/v1/sandboxes/${LOOP_ID}/clone" "${KEY1_SEC}" \
+  "$(python3 -c 'import json,sys; print(json.dumps({"agent_id": sys.argv[1]}))' "${AGENT_CLON}")"
+require_http 201 "POST clone"
+CLON_ID="$(json_get "${RESP}" id)"
+test "${CLON_ID}" != "${LOOP_ID}"
+exec_sh "${CLON_ID}" "${KEY1_SEC}" "cat /serve-marker"
+require_http 200 "clone exec marker"
+printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx serve-ok
+
+http DELETE "/v1/sandboxes/${REST_ID}" "${KEY1_SEC}"
+require_http 204 "DELETE restore"
+http DELETE "/v1/sandboxes/${CLON_ID}" "${KEY1_SEC}"
+require_http 204 "DELETE clone"
+
+echo "==> allow_net deny wget"
+post_json "/v1/sandboxes" "${KEY1_SEC}" "$(sandbox_body "${IMAGE}" "${AGENT_DENY}" deny)"
+require_http 201 "POST deny sandbox"
+DENY_ID="$(json_get "${RESP}" id)"
+deny_status="$(guest_wget_probe "${DENY_ID}" "${KEY1_SEC}" 3)"
+case "${deny_status}" in
+  *WGET_FAIL*) ;;
+  *WGET_OK*)
+    echo "allow_net deny: wget succeeded" >&2
+    exit 1
+    ;;
+  *)
+    echo "allow_net deny: exec/wget missing (${deny_status:-empty})" >&2
+    dump_fail
+    exit 1
+    ;;
+esac
+http DELETE "/v1/sandboxes/${DENY_ID}" "${KEY1_SEC}"
+require_http 204 "DELETE deny"
+
+echo "==> idle sandbox (auto_stop_secs=1) + workspace file"
+post_json "/v1/sandboxes" "${KEY1_SEC}" "$(sandbox_body "${IMAGE}" "${AGENT_IDLE}" idle)"
+require_http 201 "POST idle"
+IDLE_ID="$(json_get "${RESP}" id)"
+printf 'idle-ok\n' >"${BUX_HOME}/idle-x"
+http PUT "/v1/sandboxes/${IDLE_ID}/files?path=/workspace/x" "${KEY1_SEC}" \
+  --data-binary "@${BUX_HOME}/idle-x"
+require_http 204 "PUT idle /workspace/x"
+# Sweep interval is 30s but the first tick is immediate on worker start.
+# Sleep past auto_stop_secs so SIGTERM+restart sweep stops this VM.
+sleep 2
+
+echo "==> SIGTERM serve, start again, exec still works (R3)"
+stop_serve
+start_serve
+exec_sh "${LOOP_ID}" "${KEY1_SEC}" "echo r3-ok"
+require_http 200 "R3 exec"
+test "$(json_get "${RESP}" code)" = "0"
+printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx r3-ok
+
+echo "==> stop/start file persists (auto-stop then POST /start)"
+wait_status "${IDLE_ID}" "${KEY1_SEC}" stopped 60
+http POST "/v1/sandboxes/${IDLE_ID}/start" "${KEY1_SEC}"
+require_http 200 "POST /start after auto-stop"
+test "$(json_get "${RESP}" status)" = "running"
+http GET "/v1/sandboxes/${IDLE_ID}/files?path=/workspace/x" "${KEY1_SEC}"
+require_http 200 "GET idle file after start"
+grep -qx idle-ok "${RESP}"
+
+echo "==> after auto-stop, POST resume must not immediately stop"
+wait_status "${IDLE_ID}" "${KEY1_SEC}" stopped 60
+post_json "/v1/sandboxes" "${KEY1_SEC}" "$(sandbox_body "${IMAGE}" "${AGENT_IDLE}" idle)"
+require_http 200 "POST resume after auto-stop"
+test "$(json_get "${RESP}" id)" = "${IDLE_ID}"
+test "$(json_get "${RESP}" status)" = "running"
+# start_with resets last_activity_at. Do not wait across a sweep tick:
+# auto_stop_secs=1 would then expire. Immediate GET is the "not immediately stop" check.
+http GET "/v1/sandboxes/${IDLE_ID}" "${KEY1_SEC}"
+require_http 200 "GET after resume"
+test "$(json_get "${RESP}" status)" = "running"
+
+echo "==> DELETE removes workspace volume"
+http DELETE "/v1/sandboxes/${IDLE_ID}" "${KEY1_SEC}"
+require_http 204 "DELETE idle"
+http DELETE "/v1/sandboxes/${LOOP_ID}" "${KEY1_SEC}"
+require_http 204 "DELETE loop"
+if [[ -e "${VOL_LOOP}" ]]; then
+  echo "DELETE left ${VOL_LOOP}" >&2
+  exit 1
+fi
+http GET "/v1/sandboxes/${LOOP_ID}" "${KEY1_SEC}"
+require_http 404 "GET after DELETE"
+
+echo "OK (full serve e2e)"

--- a/scripts/e2e/serve.sh
+++ b/scripts/e2e/serve.sh
@@ -58,11 +58,11 @@ bux serve start --help | grep -q -- '--listen'
 
 echo "==> bux serve openapi"
 openapi="$(bux serve openapi)"
-printf '%s\n' "${openapi}" | grep -q '"openapi"'
-printf '%s\n' "${openapi}" | grep -q '/v1/health'
-printf '%s\n' "${openapi}" | grep -q '/v1/sandboxes'
-printf '%s\n' "${openapi}" | grep -q '/v1/sandboxes/{id}/exec'
-printf '%s\n' "${openapi}" | grep -q '/v1/sandboxes/{id}/snapshots'
+grep -q -- '"openapi"' <<<"${openapi}"
+grep -q -- '/v1/health' <<<"${openapi}"
+grep -q -- '/v1/sandboxes' <<<"${openapi}"
+grep -q -- '/v1/sandboxes/{id}/exec' <<<"${openapi}"
+grep -q -- '/v1/sandboxes/{id}/snapshots' <<<"${openapi}"
 
 if [[ "${BUX_E2E_FULL:-}" != "1" ]]; then
   echo "==> skip full serve e2e (set BUX_E2E_FULL=1 on a local HVF/KVM machine; see CONTRIBUTING.md)"
@@ -71,7 +71,7 @@ if [[ "${BUX_E2E_FULL:-}" != "1" ]]; then
 fi
 
 info_json="$(bux system info --format json)"
-if ! printf '%s\n' "${info_json}" | grep -Eq '"virtualization":[[:space:]]*true'; then
+if ! grep -Eq -- '"virtualization":[[:space:]]*true' <<<"${info_json}"; then
   echo "==> skip full serve e2e (host.virtualization is not true)"
   echo "OK (skipped serve full)"
   exit 0
@@ -294,7 +294,7 @@ echo "==> exec echo"
 exec_sh "${LOOP_ID}" "${KEY1_SEC}" "echo e2e-ok"
 require_http 200 "exec echo"
 test "$(json_get "${RESP}" code)" = "0"
-printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx e2e-ok
+grep -qx -- e2e-ok <<<"$(json_get "${RESP}" stdout)"
 
 echo "==> PUT/GET /workspace/x"
 printf 'persist-ok\n' >"${BUX_HOME}/workspace-x"
@@ -331,7 +331,7 @@ REST_ID="$(json_get "${RESP}" id)"
 test "${REST_ID}" != "${LOOP_ID}"
 exec_sh "${REST_ID}" "${KEY1_SEC}" "cat /serve-marker"
 require_http 200 "restore exec marker"
-printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx serve-ok
+grep -qx -- serve-ok <<<"$(json_get "${RESP}" stdout)"
 
 echo "==> clone {agent_id} + exec marker"
 post_json "/v1/sandboxes/${LOOP_ID}/clone" "${KEY1_SEC}" \
@@ -341,7 +341,7 @@ CLON_ID="$(json_get "${RESP}" id)"
 test "${CLON_ID}" != "${LOOP_ID}"
 exec_sh "${CLON_ID}" "${KEY1_SEC}" "cat /serve-marker"
 require_http 200 "clone exec marker"
-printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx serve-ok
+grep -qx -- serve-ok <<<"$(json_get "${RESP}" stdout)"
 
 http DELETE "/v1/sandboxes/${REST_ID}" "${KEY1_SEC}"
 require_http 204 "DELETE restore"
@@ -386,7 +386,7 @@ start_serve
 exec_sh "${LOOP_ID}" "${KEY1_SEC}" "echo r3-ok"
 require_http 200 "R3 exec"
 test "$(json_get "${RESP}" code)" = "0"
-printf '%s\n' "$(json_get "${RESP}" stdout)" | grep -qx r3-ok
+grep -qx -- r3-ok <<<"$(json_get "${RESP}" stdout)"
 
 echo "==> stop/start file persists (auto-stop then POST /start)"
 wait_status "${IDLE_ID}" "${KEY1_SEC}" stopped 60


### PR DESCRIPTION
Hosted per-agent sandbox worker (`bux serve`) onto `main`.

Assembles the existing `b85a0e06` stack plus `gen_id` 12-hex mask, docs hygiene (`docs/native-deps.md` from `2a8c770`), fake-ip preflight + fetch-guest v10 stamp, CLI README clap honesty, and review fixes (OpenAPI snapshot/clone/restore, no HTTP `/stop`, `get_exact` on clone/restore, HTTP `auto_stop_secs=1800`).

**Merge method: merge commit, not squash.** Squash would destroy the 24-commit history and put `bux serve` on `main` without preserving the stacked review trail.

Does not tag `v1.0.0` / `v0.8.0` / `v0.9.0`. Workspace stays 0.8.0. Darwin HVF FULL is a follow-up after this merge (`guest-$M` of the merge commit).