### PR TITLE
ci(cd): native tarball runs bux serve start --help

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -193,6 +193,10 @@ jobs:
             exit 1
           fi
 
+          if [ "${{ matrix.cross }}" != "true" ]; then
+            ( cd "$staging" && ./bux serve start --help | grep -q -- '--api-key' )
+          fi
+
           tar czf "$staging.tar.gz" -C "$staging" .
 
           # SHA-256 checksum


### PR DESCRIPTION
After libkrun* copy in `cd.yml` Package, run `./bux serve start --help | grep --api-key` only when `matrix.cross != true`.

Native rows (`x86_64-linux-gnu`, `aarch64-apple-darwin`) execute the staged binary. Cross aarch64-linux does not. No qemu-user. No krun retag. No `v*` tag.

Unordered vs Darwin HVF FULL. Required before any product `v*` tag.