### PR TITLE
fix(runtime): canonicalize current_exe for sidecar lookup; stamp-check guest ELF

### DIFF
--- a/crates/bux-bwrap/src/discover.rs
+++ b/crates/bux-bwrap/src/discover.rs
@@ -45,19 +45,30 @@ pub const fn path() -> Option<&'static Path> {
     None
 }
 
-/// Follows symlinks so a `~/.local/bin` install still finds `bwrap` next to the payload.
+/// Follows symlinks so `bwrap` is joined next to the real executable, not the invocation path.
+///
+/// `None` if `exe` is a symlink that cannot be resolved: do not join against the link.
 #[cfg(any(test, target_os = "linux"))]
 #[must_use]
-fn canonicalize_exe(exe: PathBuf) -> PathBuf {
-    exe.canonicalize().unwrap_or(exe)
+fn real_exe(exe: PathBuf) -> Option<PathBuf> {
+    exe.canonicalize().ok().or_else(|| {
+        let symlink = std::fs::symlink_metadata(&exe).is_ok_and(|m| m.file_type().is_symlink());
+        (!symlink).then_some(exe)
+    })
+}
+
+/// Sidecar next to [`real_exe`] when that path is a file.
+#[cfg(any(test, target_os = "linux"))]
+#[must_use]
+fn sibling_of(exe: PathBuf, name: &str) -> Option<PathBuf> {
+    let sibling = real_exe(exe)?.with_file_name(name);
+    sibling.is_file().then_some(sibling)
 }
 
 /// Check for a binary next to the current executable.
 #[cfg(target_os = "linux")]
 fn sibling_path(name: &str) -> Option<PathBuf> {
-    let exe = canonicalize_exe(std::env::current_exe().ok()?);
-    let sibling = exe.with_file_name(name);
-    sibling.is_file().then_some(sibling)
+    sibling_of(std::env::current_exe().ok()?, name)
 }
 
 /// Search `$PATH` for a binary.
@@ -80,46 +91,62 @@ mod tests {
     use std::fs;
 
     #[test]
-    fn canonicalize_exe_missing_path_stays_uncanonicalized() {
+    fn real_exe_missing_path_stays_uncanonicalized() {
         let missing = PathBuf::from("/definitely-not-a-bwrap-exe");
         assert_eq!(
-            canonicalize_exe(missing.clone()),
-            missing,
+            real_exe(missing.clone()).as_deref(),
+            Some(missing.as_path()),
             "missing path must stay uncanonicalized"
         );
     }
 
     #[cfg(unix)]
     #[test]
-    fn canonicalize_exe_sibling_is_in_real_dir() {
+    fn sibling_of_symlink_exe_uses_real_dir() {
         let dir = std::env::temp_dir().join(format!("bux-bwrap-canon-{}", std::process::id()));
         drop(fs::remove_dir_all(&dir));
-        fs::create_dir_all(dir.join("payload")).unwrap();
-        fs::create_dir_all(dir.join("bin")).unwrap();
+        fs::create_dir_all(dir.join("real")).unwrap();
+        fs::create_dir_all(dir.join("link")).unwrap();
         let _guard = DirGuard(dir.clone());
-        let real = dir.join("payload").join("bux");
+        let real = dir.join("real").join("bux");
         fs::write(&real, b"exe").unwrap();
-        let link = dir.join("bin").join("bux");
+        let link = dir.join("link").join("bux");
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        let canon = canonicalize_exe(link);
+        let planted = real.canonicalize().unwrap().with_file_name("bwrap");
+        fs::write(&planted, b"planted-bwrap").unwrap();
+        fs::write(dir.join("link").join("bwrap"), b"leftover-bwrap").unwrap();
+
         assert_eq!(
-            canon,
-            real.canonicalize().unwrap(),
-            "symlink current_exe must resolve to the payload file"
+            sibling_of(link, "bwrap").as_deref(),
+            Some(planted.as_path()),
+            "sibling bwrap must sit next to the real executable"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sibling_of_dangling_symlink_skips_leftover() {
+        let dir = std::env::temp_dir().join(format!("bux-bwrap-dangle-{}", std::process::id()));
+        drop(fs::remove_dir_all(&dir));
+        fs::create_dir_all(&dir).unwrap();
+        let _guard = DirGuard(dir.clone());
+        let link = dir.join("bux");
+        std::os::unix::fs::symlink(dir.join("missing"), &link).unwrap();
+        fs::write(dir.join("bwrap"), b"leftover-bwrap").unwrap();
+
         assert_eq!(
-            canon.with_file_name("bwrap"),
-            real.canonicalize().unwrap().with_file_name("bwrap"),
-            "sidecar join must land in the payload directory"
+            sibling_of(link, "bwrap"),
+            None,
+            "unresolved symlink exe must not pick leftover sibling"
         );
     }
 
     #[cfg(target_os = "linux")]
     #[test]
     fn sibling_path_finds_planted_bwrap() {
-        let exe = canonicalize_exe(std::env::current_exe().unwrap());
-        let path = exe.with_file_name("bwrap");
+        let exe = std::env::current_exe().unwrap();
+        let path = real_exe(exe.clone()).unwrap_or(exe).with_file_name("bwrap");
         let backup = fs::read(&path).ok();
         fs::write(&path, b"planted-bwrap").unwrap();
         let _restore = RestorePlanted {
@@ -130,7 +157,7 @@ mod tests {
         assert_eq!(
             found.as_deref(),
             Some(path.as_path()),
-            "sibling bwrap must sit next to the canonical executable"
+            "sibling bwrap must sit next to the running executable"
         );
     }
 

--- a/crates/bux-bwrap/src/discover.rs
+++ b/crates/bux-bwrap/src/discover.rs
@@ -8,7 +8,7 @@
 //!    `cargo run` during development.
 
 use std::path::Path;
-#[cfg(target_os = "linux")]
+#[cfg(any(test, target_os = "linux"))]
 use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use std::sync::OnceLock;
@@ -45,10 +45,17 @@ pub const fn path() -> Option<&'static Path> {
     None
 }
 
+/// Follows symlinks so a `~/.local/bin` install still finds `bwrap` next to the payload.
+#[cfg(any(test, target_os = "linux"))]
+#[must_use]
+fn canonicalize_exe(exe: PathBuf) -> PathBuf {
+    exe.canonicalize().unwrap_or(exe)
+}
+
 /// Check for a binary next to the current executable.
 #[cfg(target_os = "linux")]
 fn sibling_path(name: &str) -> Option<PathBuf> {
-    let exe = std::env::current_exe().ok()?;
+    let exe = canonicalize_exe(std::env::current_exe().ok()?);
     let sibling = exe.with_file_name(name);
     sibling.is_file().then_some(sibling)
 }
@@ -60,4 +67,96 @@ fn search_path(name: &str) -> Option<PathBuf> {
     std::env::split_paths(&path_var)
         .map(|dir| dir.join(name))
         .find(|p| p.is_file())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::missing_docs_in_private_items,
+    reason = "tests"
+)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn canonicalize_exe_missing_path_stays_uncanonicalized() {
+        let missing = PathBuf::from("/definitely-not-a-bwrap-exe");
+        assert_eq!(
+            canonicalize_exe(missing.clone()),
+            missing,
+            "missing path must stay uncanonicalized"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalize_exe_sibling_is_in_real_dir() {
+        let dir = std::env::temp_dir().join(format!("bux-bwrap-canon-{}", std::process::id()));
+        drop(fs::remove_dir_all(&dir));
+        fs::create_dir_all(dir.join("payload")).unwrap();
+        fs::create_dir_all(dir.join("bin")).unwrap();
+        let _guard = DirGuard(dir.clone());
+        let real = dir.join("payload").join("bux");
+        fs::write(&real, b"exe").unwrap();
+        let link = dir.join("bin").join("bux");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let canon = canonicalize_exe(link);
+        assert_eq!(
+            canon,
+            real.canonicalize().unwrap(),
+            "symlink current_exe must resolve to the payload file"
+        );
+        assert_eq!(
+            canon.with_file_name("bwrap"),
+            real.canonicalize().unwrap().with_file_name("bwrap"),
+            "sidecar join must land in the payload directory"
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn sibling_path_finds_planted_bwrap() {
+        let exe = canonicalize_exe(std::env::current_exe().unwrap());
+        let path = exe.with_file_name("bwrap");
+        let backup = fs::read(&path).ok();
+        fs::write(&path, b"planted-bwrap").unwrap();
+        let _restore = RestorePlanted {
+            path: path.clone(),
+            backup,
+        };
+        let found = sibling_path("bwrap");
+        assert_eq!(
+            found.as_deref(),
+            Some(path.as_path()),
+            "sibling bwrap must sit next to the canonical executable"
+        );
+    }
+
+    #[cfg(unix)]
+    struct DirGuard(PathBuf);
+
+    #[cfg(unix)]
+    impl Drop for DirGuard {
+        fn drop(&mut self) {
+            drop(fs::remove_dir_all(&self.0));
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    struct RestorePlanted {
+        path: PathBuf,
+        backup: Option<Vec<u8>>,
+    }
+
+    #[cfg(target_os = "linux")]
+    impl Drop for RestorePlanted {
+        fn drop(&mut self) {
+            match &self.backup {
+                Some(bytes) => drop(fs::write(&self.path, bytes)),
+                None => drop(fs::remove_file(&self.path)),
+            }
+        }
+    }
 }

--- a/crates/bux/src/guest.rs
+++ b/crates/bux/src/guest.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::util::push_unique_path;
+use crate::util::{current_exe_for_sidecars, push_unique_path};
 use crate::{Error, Result};
 
 const GUEST_EXEC_PATH: &str = "/bux/bin/bux-guest";
@@ -22,6 +22,7 @@ const EM_X86_64: u16 = 0x3E;
 const EM_AARCH64: u16 = 0xB7;
 const PT_INTERP: u32 = 3;
 const IMAGE_INJECTION_MARGIN_BYTES: u64 = 8 * 1024 * 1024;
+const ELF_PROTOCOL_STAMP: &[u8] = b"bux-guest-protocol-v10";
 
 #[derive(Debug, Clone)]
 pub(crate) struct ManagedGuestBinary {
@@ -162,33 +163,25 @@ fn candidate_paths() -> Vec<PathBuf> {
         push_unique_path(&mut paths, PathBuf::from(explicit));
     }
 
-    let names = guest_binary_names();
+    let name = guest_binary_name();
 
-    if let Ok(current_exe) = std::env::current_exe()
-        && let Some(dir) = current_exe.parent()
+    if let Ok(exe) = current_exe_for_sidecars()
+        && let Some(dir) = exe.parent()
     {
-        for name in &names {
-            push_unique_path(&mut paths, dir.join(name));
-        }
+        push_unique_path(&mut paths, dir.join(&name));
     }
 
     if let Some(path_var) = std::env::var_os("PATH") {
         for dir in std::env::split_paths(&path_var) {
-            for name in &names {
-                push_unique_path(&mut paths, dir.join(name));
-            }
+            push_unique_path(&mut paths, dir.join(&name));
         }
     }
 
     paths
 }
 
-fn guest_binary_names() -> [String; 3] {
-    [
-        format!("bux-guest-{}", linux_guest_target()),
-        "bux-guest-linux".to_owned(),
-        "bux-guest".to_owned(),
-    ]
+fn guest_binary_name() -> String {
+    format!("bux-guest-{}", linux_guest_target())
 }
 
 fn linux_guest_target() -> &'static str {
@@ -249,6 +242,16 @@ fn validate_guest_binary(path: &Path, data: &[u8]) -> Result<()> {
             "guest binary {} is dynamically linked; rebuild bux-guest as a static {} binary",
             path.display(),
             linux_guest_target()
+        )));
+    }
+
+    if !data
+        .windows(ELF_PROTOCOL_STAMP.len())
+        .any(|w| w == ELF_PROTOCOL_STAMP)
+    {
+        return Err(Error::InvalidConfig(format!(
+            "guest binary {} is missing bux-guest-protocol-v10",
+            path.display()
         )));
     }
 
@@ -351,6 +354,7 @@ pub(crate) fn test_static_guest_elf(tag: &[u8; 16]) -> Vec<u8> {
     data[6] = 1;
     data[18..20].copy_from_slice(&machine.to_le_bytes());
     data[64..80].copy_from_slice(tag);
+    data.extend_from_slice(ELF_PROTOCOL_STAMP);
     data
 }
 
@@ -436,7 +440,9 @@ pub(crate) mod sidecar_env {
 
     impl Planted {
         pub(crate) fn sibling(name: &str, data: &[u8]) -> Self {
-            let path = std::env::current_exe().unwrap().with_file_name(name);
+            let path = crate::util::current_exe_for_sidecars()
+                .unwrap()
+                .with_file_name(name);
             let backup = fs::read(&path).ok();
             fs::write(&path, data).unwrap();
             Self { path, backup }
@@ -481,6 +487,7 @@ mod tests {
             data[56..58].copy_from_slice(&1_u16.to_le_bytes());
             data[64..68].copy_from_slice(&PT_INTERP.to_le_bytes());
         }
+        data.extend_from_slice(ELF_PROTOCOL_STAMP);
         data
     }
 
@@ -529,6 +536,25 @@ mod tests {
             .unwrap_err()
             .to_string();
         assert!(err.contains("dynamically linked"));
+    }
+
+    #[test]
+    fn rejects_static_elf_missing_protocol_stamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bux-guest");
+        let mut data = make_elf(expected_machine().unwrap(), false);
+        data.truncate(data.len() - ELF_PROTOCOL_STAMP.len());
+        assert!(
+            !data
+                .windows(ELF_PROTOCOL_STAMP.len())
+                .any(|w| w == ELF_PROTOCOL_STAMP),
+            "precondition: fixture has no protocol stamp"
+        );
+        fs::write(&path, data).unwrap();
+        let err = ManagedGuestBinary::from_path(&path)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("bux-guest-protocol-v10"), "{err}");
     }
 
     #[test]
@@ -674,8 +700,81 @@ mod tests {
         let mut env = sidecar_env::lock();
         env.unset("BUX_GUEST_PATH");
         let planted_bytes = test_static_guest_elf(b"SIBLING-GUEST-OK");
-        let planted = sidecar_env::Planted::sibling("bux-guest", &planted_bytes);
+        let planted = sidecar_env::Planted::sibling(&guest_binary_name(), &planted_bytes);
         let guest = ManagedGuestBinary::resolve(None).unwrap();
         assert_eq!(guest.host_path, planted.path());
+        assert_eq!(
+            planted.path(),
+            current_exe_for_sidecars()
+                .unwrap()
+                .with_file_name(guest_binary_name()),
+            "planted sibling must sit next to the canonical executable"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive resolve"
+    )]
+    fn resolve_none_ignores_bux_guest_and_bux_guest_linux_aliases() {
+        let mut env = sidecar_env::lock();
+        env.unset("BUX_GUEST_PATH");
+        let empty = tempfile::tempdir().unwrap();
+        env.set("PATH", empty.path());
+        let bytes = test_static_guest_elf(b"ALIAS-GUEST-ELF!");
+        let alias = sidecar_env::Planted::sibling("bux-guest", &bytes);
+        let alias_linux = sidecar_env::Planted::sibling("bux-guest-linux", &bytes);
+        match ManagedGuestBinary::resolve(None) {
+            Ok(guest) => {
+                assert_ne!(
+                    guest.host_path,
+                    alias.path(),
+                    "must not resolve bux-guest alias"
+                );
+                assert_ne!(
+                    guest.host_path,
+                    alias_linux.path(),
+                    "must not resolve bux-guest-linux alias"
+                );
+                assert_eq!(
+                    guest.host_path.file_name().map(std::ffi::OsStr::to_owned),
+                    Some(std::ffi::OsString::from(guest_binary_name())),
+                    "production guest name is bux-guest-<musl-triple>"
+                );
+            }
+            Err(err) => {
+                assert!(
+                    matches!(err, Error::NotFound(_) | Error::InvalidConfig(_)),
+                    "{err}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive candidate_paths"
+    )]
+    fn candidate_paths_only_musl_triple_name() {
+        let mut env = sidecar_env::lock();
+        env.unset("BUX_GUEST_PATH");
+        let empty = tempfile::tempdir().unwrap();
+        env.set("PATH", empty.path());
+        let expected = current_exe_for_sidecars()
+            .unwrap()
+            .with_file_name(guest_binary_name());
+        let paths = candidate_paths();
+        assert!(
+            paths.contains(&expected),
+            "expected canonical sibling {expected:?} in {paths:?}"
+        );
+        for path in &paths {
+            let name = path.file_name().unwrap().to_string_lossy();
+            assert_ne!(&*name, "bux-guest", "{path:?}");
+            assert_ne!(&*name, "bux-guest-linux", "{path:?}");
+            assert_eq!(&*name, guest_binary_name(), "{path:?}");
+        }
     }
 }

--- a/crates/bux/src/guest.rs
+++ b/crates/bux/src/guest.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 
 use sha2::{Digest, Sha256};
 
-use crate::util::{current_exe_for_sidecars, push_unique_path};
+use crate::util::{push_unique_path, sidecar_path};
 use crate::{Error, Result};
 
 const GUEST_EXEC_PATH: &str = "/bux/bin/bux-guest";
@@ -54,15 +54,15 @@ impl ManagedGuestBinary {
             }
         }
 
-        let target = linux_guest_target();
+        let name = guest_binary_name();
         if invalid.is_empty() {
             return Err(Error::NotFound(format!(
-                "bux-guest not found (set RuntimeOptions.guest_path, BUX_GUEST_PATH, place a static {target} bux-guest next to the running executable, or on PATH)"
+                "bux-guest not found (set RuntimeOptions.guest_path, BUX_GUEST_PATH, place {name} next to the running executable, or on PATH)"
             )));
         }
 
         Err(Error::InvalidConfig(format!(
-            "failed to find a usable Linux bux-guest binary; set RuntimeOptions.guest_path or BUX_GUEST_PATH to a static {target} build. Candidates: {}",
+            "failed to find a usable Linux bux-guest binary; set RuntimeOptions.guest_path or BUX_GUEST_PATH to a static {name}. Candidates: {}",
             invalid.join("; ")
         )))
     }
@@ -157,6 +157,10 @@ fn stage_executable_copy(src: &Path, beside: &Path) -> Result<PathBuf> {
 }
 
 fn candidate_paths() -> Vec<PathBuf> {
+    candidate_paths_from(std::env::current_exe().ok().as_deref())
+}
+
+fn candidate_paths_from(exe: Option<&Path>) -> Vec<PathBuf> {
     let mut paths = Vec::new();
 
     if let Some(explicit) = std::env::var_os("BUX_GUEST_PATH") {
@@ -165,10 +169,10 @@ fn candidate_paths() -> Vec<PathBuf> {
 
     let name = guest_binary_name();
 
-    if let Ok(exe) = current_exe_for_sidecars()
-        && let Some(dir) = exe.parent()
+    if let Some(exe) = exe
+        && let Some(sibling) = sidecar_path(exe, &name)
     {
-        push_unique_path(&mut paths, dir.join(&name));
+        push_unique_path(&mut paths, sibling);
     }
 
     if let Some(path_var) = std::env::var_os("PATH") {
@@ -440,9 +444,9 @@ pub(crate) mod sidecar_env {
 
     impl Planted {
         pub(crate) fn sibling(name: &str, data: &[u8]) -> Self {
-            let path = crate::util::current_exe_for_sidecars()
-                .unwrap()
-                .with_file_name(name);
+            let exe = std::env::current_exe().unwrap();
+            let path =
+                crate::util::sidecar_path(&exe, name).unwrap_or_else(|| exe.with_file_name(name));
             let backup = fs::read(&path).ok();
             fs::write(&path, data).unwrap();
             Self { path, backup }
@@ -703,13 +707,6 @@ mod tests {
         let planted = sidecar_env::Planted::sibling(&guest_binary_name(), &planted_bytes);
         let guest = ManagedGuestBinary::resolve(None).unwrap();
         assert_eq!(guest.host_path, planted.path());
-        assert_eq!(
-            planted.path(),
-            current_exe_for_sidecars()
-                .unwrap()
-                .with_file_name(guest_binary_name()),
-            "planted sibling must sit next to the canonical executable"
-        );
     }
 
     #[test]
@@ -744,9 +741,15 @@ mod tests {
                 );
             }
             Err(err) => {
+                let msg = err.to_string();
                 assert!(
                     matches!(err, Error::NotFound(_) | Error::InvalidConfig(_)),
-                    "{err}"
+                    "{msg}"
+                );
+                assert!(
+                    msg.contains(&guest_binary_name()),
+                    "not-found must name {name}: {msg}",
+                    name = guest_binary_name()
                 );
             }
         }
@@ -762,9 +765,8 @@ mod tests {
         env.unset("BUX_GUEST_PATH");
         let empty = tempfile::tempdir().unwrap();
         env.set("PATH", empty.path());
-        let expected = current_exe_for_sidecars()
-            .unwrap()
-            .with_file_name(guest_binary_name());
+        let exe = std::env::current_exe().unwrap();
+        let expected = sidecar_path(&exe, &guest_binary_name()).unwrap();
         let paths = candidate_paths();
         assert!(
             paths.contains(&expected),
@@ -776,5 +778,69 @@ mod tests {
             assert_ne!(&*name, "bux-guest-linux", "{path:?}");
             assert_eq!(&*name, guest_binary_name(), "{path:?}");
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive candidate_paths_from"
+    )]
+    fn candidate_paths_from_symlink_exe_uses_real_dir() {
+        let mut env = sidecar_env::lock();
+        env.unset("BUX_GUEST_PATH");
+        let empty = tempfile::tempdir().unwrap();
+        env.set("PATH", empty.path());
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        fs::create_dir(&real_dir).unwrap();
+        fs::create_dir(&link_dir).unwrap();
+        let real = real_dir.join("bux");
+        fs::write(&real, b"exe").unwrap();
+        let link = link_dir.join("bux");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let name = guest_binary_name();
+        let planted = real.canonicalize().unwrap().with_file_name(&name);
+        fs::write(&planted, b"guest").unwrap();
+        let leftover = link_dir.join(&name);
+        fs::write(&leftover, b"leftover").unwrap();
+
+        let paths = candidate_paths_from(Some(&link));
+        assert!(
+            paths.contains(&planted),
+            "expected sibling next to the real executable in {paths:?}"
+        );
+        assert!(
+            !paths.contains(&leftover),
+            "must not join against the invocation path: {paths:?}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive candidate_paths_from"
+    )]
+    fn candidate_paths_from_dangling_symlink_skips_sibling() {
+        let mut env = sidecar_env::lock();
+        env.unset("BUX_GUEST_PATH");
+        let empty = tempfile::tempdir().unwrap();
+        env.set("PATH", empty.path());
+
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("bux");
+        std::os::unix::fs::symlink(dir.path().join("missing"), &link).unwrap();
+        let leftover = dir.path().join(guest_binary_name());
+        fs::write(&leftover, b"leftover").unwrap();
+
+        let paths = candidate_paths_from(Some(&link));
+        assert!(
+            !paths.contains(&leftover),
+            "unresolved symlink exe must skip sibling lookup: {paths:?}"
+        );
     }
 }

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -449,7 +449,7 @@ pub(crate) fn find_shim(explicit: Option<&Path>) -> Result<PathBuf> {
         }
     }
 
-    if let Ok(exe) = std::env::current_exe() {
+    if let Ok(exe) = crate::util::current_exe_for_sidecars() {
         let sibling = exe.with_file_name(NAME);
         if sibling.is_file() {
             return Ok(sibling);
@@ -575,6 +575,13 @@ mod tests {
         let planted = crate::guest::sidecar_env::Planted::sibling("bux-shim", b"planted-shim");
         let found = find_shim(None).unwrap();
         assert_eq!(found, planted.path());
+        assert_eq!(
+            found,
+            crate::util::current_exe_for_sidecars()
+                .unwrap()
+                .with_file_name("bux-shim"),
+            "sibling shim must sit next to the canonical executable"
+        );
     }
 
     #[test]

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -430,6 +430,15 @@ fn map_jail_error(e: bux_jail::Error, shim: &Path) -> crate::Error {
 ///
 /// Returns [`crate::Error::NotFound`] if the shim cannot be located.
 pub(crate) fn find_shim(explicit: Option<&Path>) -> Result<PathBuf> {
+    find_shim_from(explicit, std::env::current_exe().ok().as_deref())
+}
+
+/// Same search as [`find_shim`], with `current_exe` supplied for sibling joins.
+///
+/// # Errors
+///
+/// Returns [`crate::Error::NotFound`] if the shim cannot be located.
+fn find_shim_from(explicit: Option<&Path>, current_exe: Option<&Path>) -> Result<PathBuf> {
     const NAME: &str = "bux-shim";
 
     if let Some(path) = explicit {
@@ -449,11 +458,11 @@ pub(crate) fn find_shim(explicit: Option<&Path>) -> Result<PathBuf> {
         }
     }
 
-    if let Ok(exe) = crate::util::current_exe_for_sidecars() {
-        let sibling = exe.with_file_name(NAME);
-        if sibling.is_file() {
-            return Ok(sibling);
-        }
+    if let Some(exe) = current_exe
+        && let Some(sibling) = crate::util::sidecar_path(exe, NAME)
+        && sibling.is_file()
+    {
+        return Ok(sibling);
     }
 
     if let Ok(path_var) = std::env::var("PATH") {
@@ -575,12 +584,62 @@ mod tests {
         let planted = crate::guest::sidecar_env::Planted::sibling("bux-shim", b"planted-shim");
         let found = find_shim(None).unwrap();
         assert_eq!(found, planted.path());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive find_shim_from"
+    )]
+    fn find_shim_from_symlink_exe_uses_real_dir() {
+        let mut env = crate::guest::sidecar_env::lock();
+        env.unset("BUX_SHIM_PATH");
+        let empty = tempfile::tempdir().unwrap();
+        env.set("PATH", empty.path());
+
+        let dir = tempfile::tempdir().unwrap();
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        fs::create_dir(&real_dir).unwrap();
+        fs::create_dir(&link_dir).unwrap();
+        let real = real_dir.join("bux");
+        fs::write(&real, b"exe").unwrap();
+        let link = link_dir.join("bux");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let planted = real.canonicalize().unwrap().with_file_name("bux-shim");
+        fs::write(&planted, b"planted-shim").unwrap();
+        fs::write(link_dir.join("bux-shim"), b"leftover-shim").unwrap();
+
+        let found = find_shim_from(None, Some(&link)).unwrap();
         assert_eq!(
-            found,
-            crate::util::current_exe_for_sidecars()
-                .unwrap()
-                .with_file_name("bux-shim"),
-            "sibling shim must sit next to the canonical executable"
+            found, planted,
+            "sibling shim must sit next to the real executable"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[allow(
+        clippy::significant_drop_tightening,
+        reason = "env lock must outlive find_shim_from"
+    )]
+    fn find_shim_from_dangling_symlink_skips_sibling() {
+        let mut env = crate::guest::sidecar_env::lock();
+        env.unset("BUX_SHIM_PATH");
+        let empty = tempfile::tempdir().unwrap();
+        env.set("PATH", empty.path());
+
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("bux");
+        std::os::unix::fs::symlink(dir.path().join("missing"), &link).unwrap();
+        fs::write(dir.path().join("bux-shim"), b"leftover-shim").unwrap();
+
+        let err = find_shim_from(None, Some(&link)).unwrap_err();
+        assert!(
+            matches!(err, crate::Error::NotFound(_)),
+            "unresolved symlink exe must not pick leftover sibling: {err}"
         );
     }
 

--- a/crates/bux/src/util.rs
+++ b/crates/bux/src/util.rs
@@ -1,10 +1,78 @@
 //! Shared internal helpers.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Appends `path` to `paths` only if it is not already present.
 pub(crate) fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
     if !paths.iter().any(|p| p == &path) {
         paths.push(path);
+    }
+}
+
+/// Follows symlinks so sidecar lookup uses the payload directory, not `~/.local/bin`.
+#[must_use]
+pub(crate) fn canonicalize_exe(exe: &Path) -> PathBuf {
+    match exe.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                path = %exe.display(),
+                "canonicalize failed, using uncanonicalized current_exe"
+            );
+            exe.to_path_buf()
+        }
+    }
+}
+
+/// Executable path used to join sibling sidecar names.
+///
+/// # Errors
+///
+/// Returns the error from [`std::env::current_exe`].
+pub(crate) fn current_exe_for_sidecars() -> std::io::Result<PathBuf> {
+    std::env::current_exe().map(|exe| canonicalize_exe(&exe))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn canonicalize_exe_missing_path_stays_uncanonicalized() {
+        let missing = PathBuf::from("/definitely-not-a-bux-exe");
+        assert_eq!(
+            canonicalize_exe(&missing),
+            missing,
+            "missing path must stay uncanonicalized"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonicalize_exe_sibling_is_in_real_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let payload = dir.path().join("payload");
+        let bin = dir.path().join("bin");
+        fs::create_dir(&payload).unwrap();
+        fs::create_dir(&bin).unwrap();
+        let real = payload.join("bux");
+        fs::write(&real, b"exe").unwrap();
+        let link = bin.join("bux");
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+
+        let canon = canonicalize_exe(&link);
+        assert_eq!(
+            canon,
+            real.canonicalize().unwrap(),
+            "symlink current_exe must resolve to the payload file"
+        );
+        assert_eq!(
+            canon.with_file_name("bux-shim"),
+            real.canonicalize().unwrap().with_file_name("bux-shim"),
+            "sidecar join must land in the payload directory"
+        );
     }
 }

--- a/crates/bux/src/util.rs
+++ b/crates/bux/src/util.rs
@@ -1,5 +1,6 @@
 //! Shared internal helpers.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
 /// Appends `path` to `paths` only if it is not already present.
@@ -9,70 +10,96 @@ pub(crate) fn push_unique_path(paths: &mut Vec<PathBuf>, path: PathBuf) {
     }
 }
 
-/// Follows symlinks so sidecar lookup uses the payload directory, not `~/.local/bin`.
+/// Follows symlinks so sidecars are joined next to the real executable, not the invocation path.
+///
+/// `None` if `exe` is a symlink that cannot be resolved: joining against the link's
+/// directory would pick a leftover next to the invocation path.
 #[must_use]
-pub(crate) fn canonicalize_exe(exe: &Path) -> PathBuf {
+pub(crate) fn real_exe(exe: &Path) -> Option<PathBuf> {
     match exe.canonicalize() {
-        Ok(path) => path,
+        Ok(path) => Some(path),
         Err(error) => {
-            tracing::warn!(
-                error = %error,
-                path = %exe.display(),
-                "canonicalize failed, using uncanonicalized current_exe"
-            );
-            exe.to_path_buf()
+            if is_symlink(exe) {
+                tracing::warn!(
+                    error = %error,
+                    path = %exe.display(),
+                    "canonicalize failed for symlink current_exe, skipping sibling lookup"
+                );
+                None
+            } else {
+                tracing::warn!(
+                    error = %error,
+                    path = %exe.display(),
+                    "canonicalize failed, using uncanonicalized current_exe"
+                );
+                Some(exe.to_path_buf())
+            }
         }
     }
 }
 
-/// Executable path used to join sibling sidecar names.
-///
-/// # Errors
-///
-/// Returns the error from [`std::env::current_exe`].
-pub(crate) fn current_exe_for_sidecars() -> std::io::Result<PathBuf> {
-    std::env::current_exe().map(|exe| canonicalize_exe(&exe))
+/// Sidecar path next to [`real_exe`]. `None` when sibling lookup should be skipped.
+#[must_use]
+pub(crate) fn sidecar_path(exe: &Path, name: &str) -> Option<PathBuf> {
+    real_exe(exe).map(|exe| exe.with_file_name(name))
+}
+
+/// True when `path` itself is a symlink.
+fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, reason = "tests")]
 mod tests {
     use super::*;
-    use std::fs;
 
     #[test]
-    fn canonicalize_exe_missing_path_stays_uncanonicalized() {
+    fn real_exe_missing_path_stays_uncanonicalized() {
         let missing = PathBuf::from("/definitely-not-a-bux-exe");
         assert_eq!(
-            canonicalize_exe(&missing),
-            missing,
+            real_exe(&missing).as_deref(),
+            Some(missing.as_path()),
             "missing path must stay uncanonicalized"
         );
     }
 
     #[cfg(unix)]
     #[test]
-    fn canonicalize_exe_sibling_is_in_real_dir() {
+    fn sidecar_path_from_symlink_exe_uses_real_dir() {
         let dir = tempfile::tempdir().unwrap();
-        let payload = dir.path().join("payload");
-        let bin = dir.path().join("bin");
-        fs::create_dir(&payload).unwrap();
-        fs::create_dir(&bin).unwrap();
-        let real = payload.join("bux");
+        let real_dir = dir.path().join("real");
+        let link_dir = dir.path().join("link");
+        fs::create_dir(&real_dir).unwrap();
+        fs::create_dir(&link_dir).unwrap();
+        let real = real_dir.join("bux");
         fs::write(&real, b"exe").unwrap();
-        let link = bin.join("bux");
+        let link = link_dir.join("bux");
         std::os::unix::fs::symlink(&real, &link).unwrap();
 
-        let canon = canonicalize_exe(&link);
+        let expected = real.canonicalize().unwrap().with_file_name("bux-shim");
         assert_eq!(
-            canon,
-            real.canonicalize().unwrap(),
-            "symlink current_exe must resolve to the payload file"
+            sidecar_path(&link, "bux-shim").as_deref(),
+            Some(expected.as_path()),
+            "sidecar join must land next to the real executable"
         );
+        assert_ne!(
+            sidecar_path(&link, "bux-shim").unwrap().parent(),
+            Some(link_dir.as_path()),
+            "must not join against the invocation path"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sidecar_path_dangling_symlink_skips_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("bux");
+        std::os::unix::fs::symlink(dir.path().join("missing"), &link).unwrap();
         assert_eq!(
-            canon.with_file_name("bux-shim"),
-            real.canonicalize().unwrap().with_file_name("bux-shim"),
-            "sidecar join must land in the payload directory"
+            sidecar_path(&link, "bux-shim"),
+            None,
+            "unresolved symlink exe must skip sibling lookup"
         );
     }
 }


### PR DESCRIPTION
Sibling sidecar lookup follows `current_exe` symlinks so `~/.local/bin/bux` → `bux-pkg/.../bux` finds `bux-shim` / guest / `bwrap` next to the real binary. Production guest name is `bux-guest-<musl-triple>` only. `validate_guest_binary` requires `bux-guest-protocol-v10`.

Stack: execute-plan/6f7864c8 PR 1/8.