### PR TITLE
ci: package bwrap on Linux; checksum guest-v; prerelease non-product tags

### DIFF
--- a/.github/workflows/bwrap-build.yml
+++ b/.github/workflows/bwrap-build.yml
@@ -85,5 +85,6 @@ jobs:
           merge-multiple: true
       - uses: softprops/action-gh-release@v2
         with:
+          prerelease: true
           files: bux-bwrap-*.tar.gz
           generate_release_notes: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   push:
-    tags: ["v*.*.*", "guest-*"]
+    tags: ["v*.*.*", "guest-v*.*.*"]
   workflow_dispatch:
 
 permissions:
@@ -10,6 +10,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Keep in sync with crates/bux-bwrap/build.rs BUBBLEWRAP_VERSION.
+  BWRAP_VERSION: "0.12.0"
 
 jobs:
   guest:
@@ -83,7 +85,7 @@ jobs:
 
   build:
     needs: guest
-    if: ${{ !startsWith(github.ref, 'refs/tags/guest-') }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/guest-v') }}
     strategy:
       fail-fast: false
       matrix:
@@ -193,6 +195,23 @@ jobs:
             exit 1
           fi
 
+          # Matrix target, not runner arch: the aarch64 Linux job is cross on x86_64.
+          if [[ "$target" != *apple-darwin* ]]; then
+            bwrap_url="https://github.com/qntx/bux/releases/download/bwrap-v${BWRAP_VERSION}/bux-bwrap-${target}.tar.gz"
+            mkdir -p .bwrap
+            curl -fsSL "$bwrap_url" | tar xz -C .bwrap
+            if [ ! -f .bwrap/bwrap ]; then
+              echo "missing bwrap in $bwrap_url"
+              exit 1
+            fi
+            cp -a .bwrap/bwrap "$staging/"
+            chmod 0755 "$staging/bwrap"
+            if [ ! -f "$staging/bwrap" ]; then
+              echo "missing bwrap"
+              exit 1
+            fi
+          fi
+
           if [ "${{ matrix.cross }}" != "true" ]; then
             ( cd "$staging" && ./bux serve start --help | grep -q -- '--api-key' )
           fi
@@ -237,13 +256,27 @@ jobs:
   guest-release:
     needs: guest
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/guest-')
+    if: startsWith(github.ref, 'refs/tags/guest-v')
     steps:
-      - name: Assert tag is guest-<this-commit-sha>
-        if: github.ref_name != format('guest-{0}', github.sha)
+      - uses: actions/checkout@v7
+
+      - name: Assert tag is guest-v{bux-guest version}
         run: |
-          echo "tag ${{ github.ref_name }} is not guest-${{ github.sha }}" >&2
-          exit 1
+          ver="$(python3 - <<'PY'
+          from pathlib import Path
+          for line in Path("crates/bux-guest/Cargo.toml").read_text().splitlines():
+              s = line.strip()
+              if s.startswith("version") and "=" in s:
+                  print(s.split("=", 1)[1].strip().strip('"'))
+                  raise SystemExit(0)
+          raise SystemExit("no version in crates/bux-guest/Cargo.toml")
+          PY
+          )"
+          expected="guest-v${ver}"
+          if [[ "${GITHUB_REF_NAME}" != "${expected}" ]]; then
+            echo "tag ${GITHUB_REF_NAME} is not ${expected}" >&2
+            exit 1
+          fi
 
       - uses: actions/download-artifact@v8
         with:
@@ -314,11 +347,33 @@ jobs:
           PY
           chmod 0755 bux-guest-x86_64-unknown-linux-musl bux-guest-aarch64-unknown-linux-musl
 
+      - name: Checksum guest ELFs
+        run: |
+          for triple in x86_64-unknown-linux-musl aarch64-unknown-linux-musl; do
+            elf="bux-guest-${triple}"
+            if [ ! -f "$elf" ]; then
+              echo "missing $elf"
+              exit 1
+            fi
+            if command -v sha256sum &>/dev/null; then
+              sha256sum "$elf" > "${elf}.sha256"
+            else
+              shasum -a 256 "$elf" > "${elf}.sha256"
+            fi
+            if [ ! -s "${elf}.sha256" ]; then
+              echo "missing ${elf}.sha256"
+              exit 1
+            fi
+          done
+
       - uses: softprops/action-gh-release@v2
         with:
+          prerelease: true
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
-          body: Static musl guest at ${{ github.sha }}. Not a product release. Not FULL proof.
+          body: Static musl guest ${{ github.ref_name }} built at ${{ github.sha }}. Not a product `v*` release. Not FULL proof.
           files: |
             bux-guest-x86_64-unknown-linux-musl
+            bux-guest-x86_64-unknown-linux-musl.sha256
             bux-guest-aarch64-unknown-linux-musl
+            bux-guest-aarch64-unknown-linux-musl.sha256

--- a/.github/workflows/e2fs-build.yml
+++ b/.github/workflows/e2fs-build.yml
@@ -159,5 +159,6 @@ jobs:
           merge-multiple: true
       - uses: softprops/action-gh-release@v2
         with:
+          prerelease: true
           files: bux-e2fs-*.tar.gz
           generate_release_notes: true

--- a/.github/workflows/krun-build.yml
+++ b/.github/workflows/krun-build.yml
@@ -137,5 +137,6 @@ jobs:
           merge-multiple: true
       - uses: softprops/action-gh-release@v2
         with:
+          prerelease: true
           files: bux-deps-*.tar.gz
           generate_release_notes: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,8 +34,9 @@ Releases tagged `krun-v{LIBKRUN_VERSION}` (not crate versions).
 | `BUX_GUEST_DIR` | Build-time directory of a prebuilt Linux guest ELF (`bux-cli` stages a sibling copy) |
 | `PATH` | Locates `bux-shim`, `bwrap` (Linux), `sandbox-exec` (macOS), `go` |
 
-Release packaging ships `bux`, `bux-shim`, `bux-guest-*`, and
-`libkrun*`/`libkrunfw*` (including soname aliases) in the same directory.
+Release packaging ships `bux`, `bux-shim`, `bux-guest-*`,
+`libkrun*`/`libkrunfw*` (including soname aliases), and Linux `bwrap` in the
+same directory.
 `cargo build` stages those dylibs into the cargo profile directory next to
 `bux` / `bux-shim`. Versioned aliases (`libkrun.1.dylib` /
 `libkrunfw.5.dylib`, Linux `libkrun.so.1` / `libkrunfw.so.5`) are required:
@@ -227,27 +228,27 @@ no `PT_INTERP`, plus that stamp.
 
 FULL needs python3 for the guest ELF validator and Go for `bux-shim-bin`;
 Darwin FULL still needs `BUX_GUEST_PATH` and `gh` authenticated to `qntx/bux`
-with `workflow` if they must dispatch; `gh release download guest-<sha>` is
+with `workflow` if they must dispatch; `gh release download guest-v0.1.0` is
 enough when that Release exists; `gh run download` is enough when a matching
 run already exists.
 
 CD `cd.yml` musl guest:
 
-- Release tag: `guest-<40-char-sha>` of that commit (never `v0.4.1`)
-- Release asset **file**: `bux-guest-<triple>`
+- Release tag: `guest-v{crates/bux-guest version}` (never `v0.8.0`, never `guest-<sha>`)
+- Release asset **file**: `bux-guest-<triple>` and `bux-guest-<triple>.sha256`
 - GHA artifact **name**: `guest-<triple>` (never `bux-guest-*`)
 - **file** inside the artifact: `bux-guest-<triple>`
 - sibling after fetch: `target/debug/bux-guest-<triple>`
 
-After this merge is on `main`, tag the guest of that commit:
+After this merge is on `main`, tag the guest of that commit (`guest-v` plus
+`crates/bux-guest/Cargo.toml` `version`; `0.1.0` today):
 
 ```bash
 git fetch origin
 git checkout main
 git pull --ff-only origin main
-SHA="$(git rev-parse HEAD)"
-git tag "guest-${SHA}" "${SHA}"
-git push origin "guest-${SHA}"
+git tag guest-v0.1.0
+git push origin guest-v0.1.0
 ```
 
 Do not vendor the ELF in git. Do not fill the FULL record above from a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "bux-guest"
-version = "0.8.0"
+version = "0.1.0"
 dependencies = [
  "bux-proto",
  "futures",

--- a/crates/bux-bwrap/build.rs
+++ b/crates/bux-bwrap/build.rs
@@ -53,6 +53,7 @@ fn main() {
 
     let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
     let bwrap_path = obtain_binary(&target, &out_dir);
+    stage_bwrap_beside_binaries(&bwrap_path, &out_dir);
 
     // Expose the bwrap path to dependent crates' build scripts
     // (available as DEP_BUBBLEWRAP_BWRAP_PATH) and to lib.rs at compile time.
@@ -60,6 +61,59 @@ fn main() {
     println!(
         "cargo:rustc-env=BUX_BWRAP_BUILD_PATH={}",
         bwrap_path.display()
+    );
+}
+
+/// `OUT_DIR` ancestor named `$PROFILE` is the cargo bin dir (native or `--target`).
+fn profile_bin_dir(out_dir: &Path, profile: &str) -> PathBuf {
+    out_dir
+        .ancestors()
+        .find(|path| path.file_name().is_some_and(|name| name == profile))
+        .map_or_else(
+            || {
+                panic!(
+                    "bux-bwrap: cannot resolve profile bin dir from OUT_DIR={} PROFILE={profile}",
+                    out_dir.display()
+                )
+            },
+            Path::to_path_buf,
+        )
+}
+
+/// Copy `bwrap` into the cargo profile dir so sibling lookup finds it for `cargo run`.
+fn stage_bwrap_beside_binaries(bwrap: &Path, out_dir: &Path) {
+    let profile = env::var("PROFILE").expect("PROFILE not set");
+    let dest_dir = profile_bin_dir(out_dir, &profile);
+    fs::create_dir_all(&dest_dir).unwrap_or_else(|e| {
+        panic!(
+            "bux-bwrap: failed to create profile dir {}: {e}",
+            dest_dir.display()
+        )
+    });
+    let dest = dest_dir.join("bwrap");
+    if dest.symlink_metadata().is_ok() {
+        fs::remove_file(&dest).unwrap_or_else(|e| {
+            panic!("bux-bwrap: failed to replace {}: {e}", dest.display());
+        });
+    }
+    fs::copy(bwrap, &dest).unwrap_or_else(|e| {
+        panic!(
+            "bux-bwrap: failed to copy {} -> {}: {e}",
+            bwrap.display(),
+            dest.display()
+        );
+    });
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&dest, fs::Permissions::from_mode(0o755)).unwrap_or_else(|e| {
+            panic!("bux-bwrap: failed to chmod 0755 {}: {e}", dest.display());
+        });
+    }
+    assert!(
+        dest.is_file(),
+        "bux-bwrap: bwrap missing next to binaries at {}",
+        dest.display()
     );
 }
 

--- a/crates/bux-guest/Cargo.toml
+++ b/crates/bux-guest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bux-guest"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Linux product tarball includes matrix-target `bwrap`. `guest-release` writes `.sha256` and tags `guest-v*.*.*`. Native/guest GitHub Releases are `prerelease: true` so they cannot win product-tag selection.

Stack: execute-plan/6f7864c8 PR 2/8. Base is PR 1.