### PR TITLE
refactor: bux-shim krun feature; engine does not DT_NEEDED libkrun

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -136,9 +136,34 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu libcap-ng-dev:arm64
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
-      - run: cargo build --release --target ${{ matrix.target }} -p bux-cli -p bux-shim-bin
+      # Separate -p so feature unification does not DT_NEEDED libkrun on bux.
+      - name: Build bux-cli
+        run: cargo build --release --target ${{ matrix.target }} -p bux-cli
         env:
           BUX_GUEST_DIR: ${{ github.workspace }}/.guest
+
+      - name: Build bux-shim
+        run: cargo build --release --target ${{ matrix.target }} -p bux-shim-bin
+
+      - name: bux does not DT_NEEDED libkrun
+        run: |
+          set -euo pipefail
+          bin="target/${{ matrix.target }}/release/bux"
+          if [[ "${{ runner.os }}" == "macOS" ]]; then
+            libs=$(otool -L "$bin")
+            printf '%s\n' "$libs"
+            if printf '%s\n' "$libs" | grep -qi krun; then
+              echo "bux DT_NEEDED libkrun" >&2
+              exit 1
+            fi
+          else
+            needed=$(readelf -d "$bin")
+            printf '%s\n' "$needed"
+            if printf '%s\n' "$needed" | grep NEEDED | grep -qi krun; then
+              echo "bux DT_NEEDED libkrun" >&2
+              exit 1
+            fi
+          fi
 
       - name: Sign bux-shim (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.1
+      - uses: Swatinem/rust-cache@v2
       - name: crates/bux does not depend on bux-krun
         run: |
           set -euo pipefail
-          cargo tree -p bux --prefix none -f '{p}' | tee /tmp/bux-tree.txt
-          if grep -E '^bux-krun ' /tmp/bux-tree.txt; then
+          if cargo tree -p bux -i bux-krun --locked; then
             echo "crates/bux must not depend on bux-krun" >&2
-            cargo tree -p bux -i bux-krun
             exit 1
           fi
+          cargo check -p bux --all-targets --locked
+          cargo check -p bux-shim --no-default-features --all-targets --locked
 
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,23 @@ jobs:
         with:
           command: check
 
+  engine-no-krun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.97.1
+      - name: crates/bux does not depend on bux-krun
+        run: |
+          set -euo pipefail
+          cargo tree -p bux --prefix none -f '{p}' | tee /tmp/bux-tree.txt
+          if grep -E '^bux-krun ' /tmp/bux-tree.txt; then
+            echo "crates/bux must not depend on bux-krun" >&2
+            cargo tree -p bux -i bux-krun
+            exit 1
+          fi
+
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e-host.yml
+++ b/.github/workflows/e2e-host.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           toolchain: 1.97.1
           components: rustfmt, clippy
-      # Host-only smoke builds bux-cli (links libkrun). Do not install Go here:
+      # Host-only smoke builds bux-cli (does not link libkrun). Do not install Go here:
       # FULL=0 does not build bux-shim-bin / libgvproxy.
       # Manual HVF/KVM gate only (CONTRIBUTING.md). Never FULL=1 on GitHub-hosted runners.
       # Seatbelt profile-string tests are Darwin-only and never run on ubuntu CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,9 @@ Operator docs: root `README.md`, `docs/architecture.md`,
 ## Build
 
 ```bash
-cargo build -p bux-cli -p bux-shim-bin
+# Separate invocations: one `-p` pair unifies `krun` onto `bux`.
+cargo build -p bux-cli
+cargo build -p bux-shim-bin
 # Linux guest agent (static musl recommended for rootfs injection):
 cargo build -p bux-guest --target aarch64-unknown-linux-musl   # or x86_64-...
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,17 +48,11 @@ Darwin: `bux-krun` copies `libkrun.dylib` and `libkrunfw.dylib` into
 `@loader_path/libkrunfw.dylib`, adds `LC_RPATH @loader_path` on
 `libkrun.dylib` so `dlopen("libkrunfw.5.dylib")` searches the dylib's
 directory, ad-hoc codesigns those copies, and link-searches only `link-lib`.
-Linked binaries record `@loader_path/libkrun.dylib`. Downstream Darwin
-embedders do not need rpath rustflags.
+The `bux-shim` binary records `@loader_path/libkrun.dylib`. `crates/bux`
+does not link libkrun.
 
-Linux: `DT_NEEDED` stays the soname. This workspace stamps
-`-Wl,-rpath,$ORIGIN` via `.cargo/config.toml`. Downstream embedders must set:
-
-```toml
-# embedder .cargo/config.toml (Linux)
-[target.'cfg(target_os = "linux")']
-rustflags = ["-C", "link-arg=-Wl,-rpath,$ORIGIN"]
-```
+Linux: `DT_NEEDED` on `bux-shim` stays the soname. This workspace stamps
+`-Wl,-rpath,$ORIGIN` via `.cargo/config.toml` for in-tree bins.
 
 `crates/bux-shim-bin/build.rs` emits `-Wl,-rpath,@executable_path` (Darwin)
 or `-Wl,-rpath,$ORIGIN` (Linux) so this repo's shim does not depend solely

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bux-serve = { version = "0.8", path = "crates/bux-serve" }
 bux-bwrap = { version = "0.2", path = "crates/bux-bwrap" }
 bux-jail = { version = "0.1", path = "crates/bux-jail" }
 bux-krun = { version = "0.2", path = "crates/bux-krun" }
-bux-shim = { version = "0.1", path = "crates/bux-shim" }
+bux-shim = { version = "0.1", path = "crates/bux-shim", default-features = false }
 bux-e2fs = { version = "0.2", path = "crates/bux-e2fs" }
 bux-gvproxy = { version = "0.1", path = "crates/bux-gvproxy" }
 bux-landlock = { version = "0.1", path = "crates/bux-landlock" }

--- a/README.md
+++ b/README.md
@@ -75,9 +75,8 @@ LICENSE-MIT
 LICENSE-APACHE
 ```
 
-Linux binaries stamp `DT_RPATH` `$ORIGIN` (this repo’s `.cargo/config.toml`).
-Downstream Linux embedders must set the same rustflag. Darwin uses
-`@loader_path`; embedders do not need rpath rustflags.
+Linux `bux-shim` stamps `DT_RPATH` `$ORIGIN` (this repo’s `.cargo/config.toml`).
+Darwin uses `@loader_path`. The engine (`crates/bux`) does not link libkrun.
 
 Operator path, 412, Busy flock, data-dir sizing, rollback:
 [docs/serve.md](docs/serve.md).

--- a/crates/bux-cli/README.md
+++ b/crates/bux-cli/README.md
@@ -7,7 +7,7 @@ VMs). Serve is in this 0.8.0 workspace clap; the product tag is not 1.0.
 1.0 is **hosted + FULL proof**, not library-only. See
 [`docs/serve.md`](../../docs/serve.md) and the root [`README.md`](../../README.md).
 
-Build: `cargo build -p bux-cli -p bux-shim-bin`. Capture env, tarball layout,
+Build: `cargo build -p bux-cli` then `cargo build -p bux-shim-bin`. Capture env, tarball layout,
 and FULL procedure: [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## Commands

--- a/crates/bux-shim-bin/Cargo.toml
+++ b/crates/bux-shim-bin/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 bux-gvproxy = { workspace = true }
-bux-shim = { workspace = true }
+bux-shim = { workspace = true, features = ["krun"] }
 
 [lints]
 workspace = true

--- a/crates/bux-shim/Cargo.toml
+++ b/crates/bux-shim/Cargo.toml
@@ -9,8 +9,12 @@ keywords = ["vm", "libkrun", "sandbox", "shim"]
 categories = ["virtualization", "os"]
 readme = "README.md"
 
+[features]
+default = ["krun"]
+krun = ["dep:bux-krun", "dep:bux-seccomp"]
+
 [dependencies]
-bux-krun = { workspace = true }
+bux-krun = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -20,7 +24,7 @@ libc = { workspace = true }
 nix = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-bux-seccomp = { workspace = true }
+bux-seccomp = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/crates/bux-shim/src/config.rs
+++ b/crates/bux-shim/src/config.rs
@@ -75,7 +75,8 @@ pub enum ShimNetConn {
     UnixDgram,
 }
 
-/// Data for the `bux-shim` binary to start gvproxy. Ignored by [`crate::prepare`].
+/// Data for the `bux-shim` binary (`bux-shim-bin`) to start gvproxy.
+/// Ignored by libkrun apply.
 ///
 /// Types live here so the `bux-shim` library does not depend on `bux-gvproxy`.
 #[derive(Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/bux-shim/src/error.rs
+++ b/crates/bux-shim/src/error.rs
@@ -16,6 +16,7 @@ pub enum Error {
     InvalidConfig(String),
 
     /// libkrun FFI failure.
+    #[cfg(feature = "krun")]
     #[error(transparent)]
     Krun(#[from] bux_krun::Error),
 

--- a/crates/bux-shim/src/host.rs
+++ b/crates/bux-shim/src/host.rs
@@ -1,5 +1,4 @@
-//! Host probes that wrap libkrun. The shim crate is the only product
-//! crate that links libkrun; embedders query through this module.
+//! Host probes that wrap libkrun.
 
 #[cfg(unix)]
 pub use bux_krun::{Feature, KernelFormat, LogStyle, SyncMode};

--- a/crates/bux-shim/src/lib.rs
+++ b/crates/bux-shim/src/lib.rs
@@ -1,17 +1,20 @@
-//! bux micro-VM engine crate: [`ShimConfig`] → libkrun.
+//! bux micro-VM engine crate: [`ShimConfig`] for the `bux-shim` process.
 //!
 //! The host `bux` Runtime serialises a [`ShimConfig`] and spawns the
-//! `bux-shim` binary (`bux-shim-bin`). Product path is [`prepare`] /
-//! [`install_seccomp`] / [`start`]. This library does not start gvproxy.
+//! `bux-shim` binary (`bux-shim-bin`). Feature `krun` (default) applies
+//! that config to libkrun. This library does not start gvproxy.
 
+#[cfg(feature = "krun")]
 mod apply;
 mod config;
 mod crash;
 mod error;
 mod exit_info;
+#[cfg(feature = "krun")]
 pub mod host;
 mod watchdog;
 
+#[cfg(feature = "krun")]
 pub use apply::{PreparedVm, install_seccomp, prepare, start};
 pub use config::{
     ShimConfig, ShimDiskFormat, ShimGvproxy, ShimNetConn, ShimNetwork, ShimSecret, ShimVirtioFs,

--- a/crates/bux/Cargo.toml
+++ b/crates/bux/Cargo.toml
@@ -24,7 +24,7 @@ bux-oci.workspace = true
 rcgen = { version = "0.14", default-features = false, features = ["ring", "pem"] }
 time = "0.3"
 bux-qcow2.workspace = true
-bux-shim.workspace = true
+bux-shim = { workspace = true, default-features = false }
 dirs.workspace = true
 nix.workspace = true
 rusqlite.workspace = true

--- a/crates/bux/src/security.rs
+++ b/crates/bux/src/security.rs
@@ -108,7 +108,7 @@ const fn map_layer(s: bux_jail::LayerStatus) -> LayerStatus {
     }
 }
 
-/// Host isolation and libkrun capabilities for `Runtime::host_info`.
+/// Host isolation for `Runtime::host_info`. libkrun fields are unused (engine does not load libkrun).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 #[allow(
@@ -204,7 +204,7 @@ mod tests {
     }
 
     #[test]
-    fn probe_does_not_load_libkrun() {
+    fn probe_krun_fields_are_empty() {
         let h = HostInfo::probe();
         assert!(
             h.krun_features.is_empty(),

--- a/crates/bux/src/security.rs
+++ b/crates/bux/src/security.rs
@@ -128,11 +128,11 @@ pub struct HostInfo {
     pub cgroups: bool,
     /// Landlock LSM (Linux 5.13+).
     pub landlock: bool,
-    /// Hypervisor max vCPUs (`None` if libkrun cannot be probed).
+    /// Hypervisor max vCPUs. Always `None`: the engine does not load libkrun.
     pub max_vcpus: Option<u32>,
-    /// Nested virtualization (`None` if the probe fails).
+    /// Nested virtualization. Always `None`: the engine does not load libkrun.
     pub nested_virt: Option<bool>,
-    /// libkrun build features that are present (e.g. `net`, `blk`, `gpu`).
+    /// libkrun build features. Always empty: the engine does not load libkrun.
     pub krun_features: Vec<String>,
     /// Isolation gaps from the jailer host audit.
     pub isolation_warnings: Vec<String>,
@@ -140,12 +140,15 @@ pub struct HostInfo {
 
 impl HostInfo {
     /// Probe the current host.
+    ///
+    /// `max_vcpus`, `nested_virt`, and `krun_features` are empty: the engine
+    /// does not load libkrun. `virtualization` still comes from the jailer
+    /// host audit (KVM / HVF).
     #[must_use]
     pub fn probe() -> Self {
         #[cfg(unix)]
         {
             let caps = bux_jail::checks::check_host();
-            let (max_vcpus, nested_virt, krun_features) = probe_krun();
             Self {
                 virtualization: caps.virtualization,
                 namespaces: caps.namespaces,
@@ -153,9 +156,9 @@ impl HostInfo {
                 mandatory_access_control: caps.mandatory_access_control,
                 cgroups: caps.cgroups,
                 landlock: caps.landlock,
-                max_vcpus,
-                nested_virt,
-                krun_features,
+                max_vcpus: None,
+                nested_virt: None,
+                krun_features: Vec::new(),
                 isolation_warnings: bux_jail::checks::audit_isolation(&caps),
             }
         }
@@ -175,34 +178,6 @@ impl HostInfo {
             }
         }
     }
-}
-
-/// libkrun probes (shim is the only crate that links libkrun).
-#[cfg(unix)]
-fn probe_krun() -> (Option<u32>, Option<bool>, Vec<String>) {
-    use bux_shim::host::{self, Feature};
-
-    let max_vcpus = host::max_vcpus().ok();
-    let nested_virt = host::check_nested_virt().ok();
-    let mut krun_features = Vec::new();
-    for (feature, name) in [
-        (Feature::Net, "net"),
-        (Feature::Blk, "blk"),
-        (Feature::Gpu, "gpu"),
-        (Feature::Snd, "snd"),
-        (Feature::Input, "input"),
-        (Feature::Efi, "efi"),
-        (Feature::Tee, "tee"),
-        (Feature::AmdSev, "amd-sev"),
-        (Feature::IntelTdx, "intel-tdx"),
-        (Feature::AwsNitro, "aws-nitro"),
-        (Feature::VirglResourceMap2, "virgl-resource-map2"),
-    ] {
-        if host::has_feature(feature).unwrap_or(false) {
-            krun_features.push(name.to_owned());
-        }
-    }
-    (max_vcpus, nested_virt, krun_features)
 }
 
 #[cfg(test)]
@@ -226,5 +201,19 @@ mod tests {
         assert!(!s.landlock);
         assert!(s.allow_degraded);
         assert!(!s.jailer);
+    }
+
+    #[test]
+    fn probe_does_not_load_libkrun() {
+        let h = HostInfo::probe();
+        assert!(
+            h.krun_features.is_empty(),
+            "engine must not probe libkrun features"
+        );
+        assert_eq!(h.max_vcpus, None, "engine must not probe libkrun max_vcpus");
+        assert_eq!(
+            h.nested_virt, None,
+            "engine must not probe libkrun nested_virt"
+        );
     }
 }

--- a/docs/native-deps.md
+++ b/docs/native-deps.md
@@ -41,8 +41,6 @@ tags attach assets only. Do not re-add `cargo publish` to these workflows.
   `disable-library-validation` so the shim can load ad-hoc libkrun.
 - Linux `patchelf` only in GHA (`krun-build.yml`), not on the operator laptop.
 
-Linux embedder `$ORIGIN` rustflags: [`CONTRIBUTING.md`](../CONTRIBUTING.md).
-
 ## URL scheme
 
 One scheme. No crate-version URL. No dual GET.
@@ -77,8 +75,9 @@ These are local paths, not a second URL. Air-gapped / iterating on a local
 ## Compile from cold
 
 Unset `BUX_DEPS_DIR` / `BUX_E2FS_DIR` / `BUX_BWRAP_DIR`. First
-`cargo build -p bux-cli -p bux-shim-bin` downloads `krun-v1.19.4` and
-`e2fs-v1.47.4` and compiles gvproxy from Go.
+`cargo build -p bux-cli` downloads `e2fs-v1.47.4`. Then
+`cargo build -p bux-shim-bin` downloads `krun-v1.19.4` and compiles gvproxy
+from Go. Separate `-p` so `bux` does not DT_NEEDED libkrun.
 
 Measured on this machine, 2026-08-26, Darwin arm64, after `krun-v1.19.4` /
 `e2fs-v1.47.4` assets existed:
@@ -96,7 +95,7 @@ otool -L target/debug/libkrun.dylib
 [bux-e2fs 0.2.0] bux-e2fs: downloading https://github.com/qntx/bux/releases/download/e2fs-v1.47.4/bux-e2fs-aarch64-apple-darwin.tar.gz
 ```
 
-`cargo build -p bux-cli -p bux-shim-bin` Finished after the krun 1.19 fetch.
+`cargo build -p bux-shim-bin` Finished after the krun 1.19 fetch.
 Cargo warned that no Linux `bux-guest` binary was found
 (`aarch64-unknown-linux-musl`). No musl guest ELF on this host. Darwin does
 not compile the guest. That is not a `BUX_E2E_FULL` record.
@@ -249,7 +248,8 @@ cargo build -p bux-krun -vv
 # must log:
 # bux-krun: downloading https://github.com/qntx/bux/releases/download/krun-v1.19.4/bux-deps-{target}.tar.gz
 # Darwin: otool -L target/debug/libkrun.dylib  → current version 1.19.x, not 1.17
-cargo build -p bux-cli -p bux-shim-bin
+cargo build -p bux-cli
+cargo build -p bux-shim-bin
 ```
 
 Same for e2fs (`e2fs-v1.47.4`). bwrap verify is Linux-only.

--- a/docs/serve.md
+++ b/docs/serve.md
@@ -31,20 +31,12 @@ LICENSE-MIT
 LICENSE-APACHE
 ```
 
-Keep `libkrun*` in the **same directory** as `./bux`. Linux `DT_NEEDED` is
-the soname (`libkrun.so.1`, `libkrunfw.so.5`). This repo stamps
+Keep `libkrun*` in the **same directory** as `bux-shim`. Linux `DT_NEEDED` on
+`bux-shim` is the soname (`libkrun.so.1`, `libkrunfw.so.5`). This repo stamps
 `-Wl,-rpath,$ORIGIN` (`.cargo/config.toml` and `bux-shim-bin` `build.rs`).
-Downstream Linux embedders must set:
-
-```toml
-# embedder .cargo/config.toml (Linux)
-[target.'cfg(target_os = "linux")']
-rustflags = ["-C", "link-arg=-Wl,-rpath,$ORIGIN"]
-```
-
-Darwin records `@loader_path/libkrun.dylib`. Embedders on Darwin do not need
-rpath rustflags. libkrun `dlopen`s `libkrunfw.5.dylib` / `libkrunfw.so.5`;
-versioned aliases are required.
+Darwin `bux-shim` records `@loader_path/libkrun.dylib`. The engine
+(`crates/bux`) does not link libkrun. libkrun `dlopen`s `libkrunfw.5.dylib` /
+`libkrunfw.so.5`; versioned aliases are required.
 
 Capture env: `BUX_HOME`, `BUX_SHIM_PATH`, `BUX_GUEST_PATH`, `BUX_GUEST_DIR`
 (see root README). Guest resolution: `BUX_GUEST_PATH`, then a sibling of the

--- a/scripts/e2e/full_common.sh
+++ b/scripts/e2e/full_common.sh
@@ -183,7 +183,8 @@ PY
 # Build cli+shim, Darwin codesign, pin guest, fake-ip preflight, PATH.
 pin_full_binaries() {
   echo "building bux-cli and bux-shim-bin (FULL pin)..."
-  cargo build -p bux-cli -p bux-shim-bin --manifest-path "${ROOT}/Cargo.toml"
+  cargo build -p bux-cli --manifest-path "${ROOT}/Cargo.toml"
+  cargo build -p bux-shim-bin --manifest-path "${ROOT}/Cargo.toml"
   if [[ "$(uname -s)" == "Darwin" ]]; then
     codesign --entitlements "${ROOT}/crates/bux-shim/bux-shim.entitlements" \
       -s - --force "${ROOT}/target/debug/bux-shim"


### PR DESCRIPTION
`crates/bux` depends on `bux-shim` with `default-features = false`. Only `bux-shim-bin` links libkrun. CI `engine-no-krun` fails closed if the engine graph contains `bux-krun`. CD/FULL build `bux-cli` and `bux-shim-bin` in separate cargo invocations.

Stack: execute-plan/6f7864c8 PR 4/8. Base is PR 2.