### PR TITLE
feat: sh.qntx.org/bux installer (payload dir + symlink)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -241,7 +241,13 @@ jobs:
             ( cd "$staging" && ./bux serve start --help | grep -q -- '--api-key' )
           fi
 
-          tar czf "$staging.tar.gz" -C "$staging" .
+          # Darwin tar injects AppleDouble ._* members unless COPYFILE_DISABLE=1.
+          # install.sh inspect_archive rejects those names.
+          COPYFILE_DISABLE=1 tar czf "$staging.tar.gz" -C "$staging" .
+          if tar tzf "$staging.tar.gz" | grep -E '(^|/)\._'; then
+            echo "AppleDouble ._* members in tarball"
+            exit 1
+          fi
 
           # SHA-256 checksum
           if command -v sha256sum &>/dev/null; then sha256sum "$staging.tar.gz" > "$staging.tar.gz.sha256"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
+      - name: Installer tests
+        run: /bin/sh scripts/install_test.sh
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.97.1

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,5 @@
+# bux has no Windows product. This file must exist so
+# irm https://sh.qntx.org/bux/ps | iex does not fall through to the
+# default one-binary template.
+Write-Error 'bux does not support Windows'
+exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,627 @@
+#!/bin/sh
+# Installer for bux. Served verbatim at https://sh.qntx.org/bux.
+#
+# Usage:
+#   curl -fsSL https://sh.qntx.org/bux | sh
+#   curl -fsSL https://sh.qntx.org/bux | sh -s -- --uninstall
+#   curl -fsSL https://sh.qntx.org/bux | sh -s -- --dry-run
+#   curl -fsSL https://sh.qntx.org/bux | sh -s -- --help
+#
+# Environment:
+#   BUX_VERSION      Pin a version (default: newest GitHub product tag ^v[0-9])
+#   BUX_INSTALL_DIR  Symlink directory (default: $HOME/.local/bin; absolute, path_safe)
+#   UNINSTALL=1      Same as --uninstall
+#   DRY_RUN=1        Same as --dry-run
+#   HELP=1           Same as --help
+#   NO_COLOR         Disable color output
+#   GITHUB_PATH      If set (GitHub Actions), append install dir and skip shell rc PATH
+#
+# python3 is required (product-tag parser and archive allowlist).
+# Never uses /releases/latest: that tag is a guest-* / native build, not the product.
+#
+# POSIX sh has no `local`. Every function MUST use unique prefixed names for
+# temporaries so helpers never clobber callers.
+
+set -eu
+
+REPO="qntx/bux"
+BIN="bux"
+UP="BUX"
+
+if [ -z "${HOME:-}" ]; then
+    printf '%s\n' "error: HOME is unset" >&2
+    exit 1
+fi
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+    B=$(printf '\033[1m')
+    R=$(printf '\033[31m')
+    N=$(printf '\033[0m')
+else
+    B=''
+    R=''
+    N=''
+fi
+
+say()  { printf '%s%s%s\n' "$B" "$*" "$N"; }
+err()  { printf '%serror%s: %s\n' "$R" "$N" "$*" >&2; exit 1; }
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# True if $1 looks like a safe release version (no path / shell metacharacters).
+# Accepts: 1, 1.2.3, 1.2.3-beta.1 (caller strips leading v).
+version_ok() {
+    # shellcheck disable=SC2254
+    case "$1" in
+        '' | *[' /\\'!@#$%^\&*\(\)+=\[\]\{\}\;\:\'\"\\\|\,\?\*]* | *..* ) return 1 ;;
+        [0-9] | [0-9][0-9A-Za-z._-]* ) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+absolute_path() {
+    case "$1" in
+        /*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# True if $1 is safe to embed in shell rc / fish conf (reject injection vectors).
+# Absolute, no "..", no "//", only [A-Za-z0-9/._+-].
+# Applied only to BUX_INSTALL_DIR — Darwin payload contains a space.
+path_safe() {
+    case "$1" in
+        /*) ;;
+        *) return 1 ;;
+    esac
+    case "$1" in
+        *//* | *..* ) return 1 ;;
+    esac
+    # shellcheck disable=SC2254
+    case "$1" in
+        *[!A-Za-z0-9/._+-]* ) return 1 ;;
+    esac
+    return 0
+}
+
+# HTTP GET with 3 attempts and exponential backoff.
+# $1=url, $2=outfile (empty for stdout).
+http() {
+    _http_url=$1
+    _http_out=${2:-}
+    _http_i=1
+    _http_delay=1
+    while :; do
+        if have curl; then
+            if [ -n "$_http_out" ]; then
+                curl -fsSL -A "$BIN-installer" -o "$_http_out" "$_http_url" && return 0
+            else
+                curl -fsSL -A "$BIN-installer" "$_http_url" && return 0
+            fi
+        elif have wget; then
+            if [ -n "$_http_out" ]; then
+                wget -q --user-agent="$BIN-installer" -O "$_http_out" "$_http_url" && return 0
+            else
+                wget -q --user-agent="$BIN-installer" -O- "$_http_url" && return 0
+            fi
+        else
+            err "curl or wget is required"
+        fi
+        [ "$_http_i" -ge 3 ] && return 1
+        sleep "$_http_delay"
+        _http_i=$((_http_i + 1))
+        _http_delay=$((_http_delay * 2))
+    done
+}
+
+# Closed CD-matrix map. Musl host and Intel Mac are errors, not a 404 tarball.
+host_target() {
+    _ht_os=$(uname -s)
+    _ht_arch=$(uname -m)
+    case "$_ht_os" in
+        Linux)
+            for _ht_p in /lib /lib64 /usr/lib; do
+                # shellcheck disable=SC2086
+                ls "$_ht_p"/ld-musl-* >/dev/null 2>&1 && {
+                    err "unsupported host: musl libc (bux ships *-unknown-linux-gnu only)"
+                }
+            done
+            case "$_ht_arch" in
+                x86_64 | amd64) printf '%s\n' "x86_64-unknown-linux-gnu" ;;
+                aarch64 | arm64) printf '%s\n' "aarch64-unknown-linux-gnu" ;;
+                *) err "unsupported architecture: $_ht_arch" ;;
+            esac
+            ;;
+        Darwin)
+            if [ "$_ht_arch" = x86_64 ] \
+                && sysctl -n hw.optional.arm64 2>/dev/null | grep -q 1; then
+                _ht_arch=aarch64
+            fi
+            case "$_ht_arch" in
+                aarch64 | arm64) printf '%s\n' "aarch64-apple-darwin" ;;
+                x86_64 | amd64)
+                    err "unsupported host: Intel Mac (x86_64-apple-darwin is not shipped)"
+                    ;;
+                *) err "unsupported architecture: $_ht_arch" ;;
+            esac
+            ;;
+        *) err "unsupported OS: $_ht_os" ;;
+    esac
+}
+
+# dirs::data_dir()/bux-pkg. Not path_safe: Darwin "Application Support" has a space.
+payload_root() {
+    _pr_os=$(uname -s)
+    case "$_pr_os" in
+        Linux)
+            printf '%s\n' "${XDG_DATA_HOME:-$HOME/.local/share}/bux-pkg"
+            ;;
+        Darwin)
+            printf '%s\n' "$HOME/Library/Application Support/bux-pkg"
+            ;;
+        *) err "unsupported OS: $_pr_os" ;;
+    esac
+}
+
+guest_triple() {
+    _gt_target=$(host_target)
+    case "$_gt_target" in
+        x86_64-*) printf '%s\n' "x86_64-unknown-linux-musl" ;;
+        aarch64-*) printf '%s\n' "aarch64-unknown-linux-musl" ;;
+        *) err "unsupported target: $_gt_target" ;;
+    esac
+}
+
+# Completeness names ∪ LICENSE-*. Space-separated, no spaces in names.
+payload_allowlist() {
+    _pa_os=$(uname -s)
+    _pa_guest=$(guest_triple)
+    _pa_names="bux bux-shim bux-guest-$_pa_guest LICENSE-MIT LICENSE-APACHE"
+    case "$_pa_os" in
+        Linux)
+            printf '%s\n' "$_pa_names libkrun.so libkrun.so.1 libkrunfw.so libkrunfw.so.5 bwrap"
+            ;;
+        Darwin)
+            printf '%s\n' "$_pa_names libkrun.dylib libkrun.1.dylib libkrunfw.dylib libkrunfw.5.dylib"
+            ;;
+        *) err "unsupported OS: $_pa_os" ;;
+    esac
+}
+
+# stdin: one /releases page (JSON array). stdout: version without v.
+# exit 0 = hit, 2 = no hit on this page, 3 = empty page (stop pagination).
+parse_product_tag() {
+    have python3 || err "python3 is required to select the latest bux release"
+    python3 -c '
+import json, re, sys
+page = json.load(sys.stdin)
+if not isinstance(page, list):
+    sys.exit(1)
+if page == []:
+    sys.exit(3)
+for r in page:
+    if r.get("draft") or r.get("prerelease"):
+        continue
+    tag = r.get("tag_name") or ""
+    if re.match(r"^v[0-9]", tag) and not tag.startswith(
+        ("guest-v", "krun-v", "e2fs-v", "bwrap-v")
+    ):
+        print(tag[1:] if tag.startswith("v") else tag)
+        sys.exit(0)
+sys.exit(2)
+'
+}
+
+# Newest non-draft, non-prerelease GitHub Release whose tag matches ^v[0-9].
+# Paginates /releases — never /releases/latest (that is a guest-* tag).
+latest() {
+    have python3 || err "python3 is required to select the latest bux release"
+    _lat_page=1
+    while :; do
+        _lat_json=$(http "https://api.github.com/repos/$REPO/releases?per_page=100&page=$_lat_page") \
+            || err "failed to fetch releases (network error or rate limited)"
+        _lat_st=0
+        _lat_ver=$(printf '%s' "$_lat_json" | parse_product_tag) || _lat_st=$?
+        if [ "$_lat_st" -eq 0 ]; then
+            version_ok "$_lat_ver" || err "refusing unsafe version from GitHub: $_lat_ver"
+            printf '%s\n' "$_lat_ver"
+            return 0
+        fi
+        if [ "$_lat_st" -eq 3 ]; then
+            err "no product release found (tag matching ^v[0-9])"
+        fi
+        if [ "$_lat_st" -eq 2 ]; then
+            _lat_page=$((_lat_page + 1))
+            continue
+        fi
+        err "failed to parse GitHub releases page $_lat_page"
+    done
+}
+
+sha256_file() {
+    _s256_path=$1
+    if have sha256sum; then
+        sha256sum "$_s256_path" | awk '{print $1}'
+    elif have shasum; then
+        shasum -a 256 "$_s256_path" | awk '{print $1}'
+    else
+        have python3 || err "python3 is required to hash the archive"
+        python3 -c 'import hashlib, sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$_s256_path"
+    fi
+}
+
+# Reject .., absolute paths, extra names, PaxHeader; allow relative same-dir symlinks.
+inspect_archive() {
+    _ia_tar=$1
+    shift
+    have python3 || err "python3 is required to select the latest bux release"
+    python3 - "$_ia_tar" "$@" <<'PY'
+import sys
+import tarfile
+
+archive = sys.argv[1]
+allow = set(sys.argv[2:])
+
+
+def norm(name):
+    n = name.replace("\\", "/")
+    while n.startswith("./"):
+        n = n[2:]
+    if n.endswith("/"):
+        n = n[:-1]
+    return n
+
+
+try:
+    tf = tarfile.open(archive, "r:gz")
+except (tarfile.TarError, OSError) as e:
+    sys.stderr.write("invalid tar.gz: %s\n" % e)
+    sys.exit(1)
+
+with tf:
+    for m in tf.getmembers():
+        n = norm(m.name)
+        if n in ("", "."):
+            if m.isdir():
+                continue
+            sys.stderr.write("invalid archive member: %r\n" % (m.name,))
+            sys.exit(1)
+        parts = n.split("/")
+        if (not n) or n.startswith("/") or ".." in parts or len(parts) != 1:
+            sys.stderr.write("illegal archive path: %r\n" % (m.name,))
+            sys.exit(1)
+        if n == "PaxHeader" or n.startswith("PaxHeader."):
+            sys.stderr.write("unexpected archive member: %s\n" % n)
+            sys.exit(1)
+        if n not in allow:
+            sys.stderr.write("unexpected archive member: %s\n" % n)
+            sys.exit(1)
+        if m.isdir():
+            sys.stderr.write("unexpected directory in archive: %s\n" % n)
+            sys.exit(1)
+        if m.issym() or m.islnk():
+            t = norm(m.linkname)
+            tparts = t.split("/")
+            if (not t) or t.startswith("/") or ".." in tparts or len(tparts) != 1:
+                sys.stderr.write("illegal link target: %r -> %r\n" % (n, m.linkname))
+                sys.exit(1)
+            if t not in allow:
+                sys.stderr.write("link target not allowlisted: %s -> %s\n" % (n, t))
+                sys.exit(1)
+        elif not m.isfile():
+            sys.stderr.write("unsupported archive member type: %s\n" % n)
+            sys.exit(1)
+sys.exit(0)
+PY
+}
+
+_ve_need_reg() {
+    _nr_path=$1
+    [ -f "$_nr_path" ] && [ ! -L "$_nr_path" ] || err "missing regular file: $_nr_path"
+}
+
+_ve_need_any() {
+    _na_path=$1
+    if [ -L "$_na_path" ]; then
+        _na_t=$(readlink "$_na_path")
+        case "$_na_t" in
+            '' | /* | *'/'* | .. | ../* | */.. | */../* )
+                err "illegal symlink target for $_na_path: $_na_t"
+                ;;
+        esac
+        [ -e "$(dirname "$_na_path")/$_na_t" ] || err "broken symlink: $_na_path"
+        return 0
+    fi
+    [ -f "$_na_path" ] || err "missing file: $_na_path"
+}
+
+# After extract, before rename over the live dest.
+verify_extracted() {
+    _ve_dir=$1
+    _ve_ver=$2
+    _ve_os=$(uname -s)
+    _ve_guest=$(guest_triple)
+    _ve_allow=$(payload_allowlist)
+
+    if [ "$_ve_os" = Linux ]; then
+        if [ ! -f "$_ve_dir/bwrap" ] || [ -L "$_ve_dir/bwrap" ]; then
+            err "no Linux bwrap in v$_ve_ver; wait for a product release that includes it, or set BUX_VERSION=…"
+        fi
+    fi
+
+    _ve_need_reg "$_ve_dir/bux"
+    _ve_need_reg "$_ve_dir/bux-shim"
+    _ve_need_reg "$_ve_dir/bux-guest-$_ve_guest"
+    case "$_ve_os" in
+        Linux)
+            _ve_need_reg "$_ve_dir/libkrun.so"
+            _ve_need_reg "$_ve_dir/libkrunfw.so"
+            _ve_need_any "$_ve_dir/libkrun.so.1"
+            _ve_need_any "$_ve_dir/libkrunfw.so.5"
+            _ve_need_reg "$_ve_dir/bwrap"
+            ;;
+        Darwin)
+            _ve_need_reg "$_ve_dir/libkrun.dylib"
+            _ve_need_reg "$_ve_dir/libkrunfw.dylib"
+            _ve_need_any "$_ve_dir/libkrun.1.dylib"
+            _ve_need_any "$_ve_dir/libkrunfw.5.dylib"
+            ;;
+        *) err "unsupported OS: $_ve_os" ;;
+    esac
+
+    for _ve_p in "$_ve_dir"/*; do
+        if [ ! -e "$_ve_p" ] && [ ! -L "$_ve_p" ]; then
+            continue
+        fi
+        _ve_n=$(basename "$_ve_p")
+        if [ -d "$_ve_p" ] && [ ! -L "$_ve_p" ]; then
+            err "unexpected directory in archive: $_ve_n"
+        fi
+        _ve_hit=0
+        for _ve_a in $_ve_allow; do
+            if [ "$_ve_n" = "$_ve_a" ]; then
+                _ve_hit=1
+                break
+            fi
+        done
+        [ "$_ve_hit" = 1 ] || err "unexpected archive member: $_ve_n"
+    done
+}
+
+# Append absolute $1 to shell rc PATH entries when missing.
+add_path() {
+    _ap_dir=$1
+    path_safe "$_ap_dir" || err "refusing unsafe PATH entry: $_ap_dir"
+    case ":$PATH:" in
+        *":$_ap_dir:"*) return 0 ;;
+    esac
+    _ap_line="export PATH=\"$_ap_dir:\$PATH\""
+    _ap_touched=0
+    for _ap_rc in .zshrc .bashrc .bash_profile .profile; do
+        [ -f "$HOME/$_ap_rc" ] || continue
+        _ap_touched=1
+        grep -qF -- "$_ap_line" "$HOME/$_ap_rc" 2>/dev/null && continue
+        printf '\n%s\n' "$_ap_line" >>"$HOME/$_ap_rc"
+        say "  added PATH entry to ~/$_ap_rc"
+    done
+    if [ -d "$HOME/.config/fish" ]; then
+        _ap_touched=1
+        _ap_fc="$HOME/.config/fish/conf.d/$BIN-path.fish"
+        _ap_fish_line=$(printf "fish_add_path -g '%s'" "$_ap_dir")
+        mkdir -p "$(dirname "$_ap_fc")"
+        if [ ! -f "$_ap_fc" ] || ! grep -qF -- "$_ap_fish_line" "$_ap_fc" 2>/dev/null; then
+            printf '%s\n' "$_ap_fish_line" >"$_ap_fc"
+            say "  added PATH entry to ~/.config/fish/conf.d/$BIN-path.fish"
+        fi
+    fi
+    if [ "$_ap_touched" -eq 0 ]; then
+        printf '%s\n' "$_ap_line" >>"$HOME/.profile"
+        say "  created ~/.profile"
+    fi
+    say "  restart your shell to apply"
+}
+
+# Resolve symlink directory: env override or $HOME/.local/bin. Absolute + path_safe.
+install_dir() {
+    eval "_id_val=\"\${${UP}_INSTALL_DIR:-}\""
+    if [ -z "$_id_val" ]; then
+        _id_val="$HOME/.local/bin"
+    fi
+    absolute_path "$_id_val" || err "${UP}_INSTALL_DIR must be an absolute path, got: $_id_val"
+    path_safe "$_id_val" || err "${UP}_INSTALL_DIR has unsafe characters (allowed: A-Za-z0-9/._+-): $_id_val"
+    printf '%s\n' "$_id_val"
+}
+
+install_cli() {
+    have python3 || err "python3 is required to select the latest bux release"
+
+    _ic_root=$(install_dir)
+    _ic_target=$(host_target)
+    _ic_pkg=$(payload_root)
+    _ic_guest=$(guest_triple)
+    eval "_ic_ver=\"\${${UP}_VERSION:-}\""
+    if [ -z "$_ic_ver" ]; then
+        _ic_ver=$(latest)
+    else
+        _ic_ver=${_ic_ver#v}
+        version_ok "$_ic_ver" || err "refusing unsafe ${UP}_VERSION: $_ic_ver"
+    fi
+    _ic_archive="$BIN-$_ic_ver-$_ic_target.tar.gz"
+    _ic_url="https://github.com/$REPO/releases/download/v$_ic_ver/$_ic_archive"
+    _ic_sha_url="$_ic_url.sha256"
+    _ic_dest="$_ic_pkg/$_ic_ver-$_ic_target"
+    _ic_new="$_ic_dest.new"
+    _ic_link="$_ic_root/$BIN"
+
+    say "Installing $BIN v$_ic_ver ($_ic_target)"
+    if [ "$DRY" = 1 ]; then
+        say "[dry-run] download: $_ic_url"
+        say "[dry-run] checksum: $_ic_sha_url"
+        say "[dry-run] payload:  $_ic_dest"
+        say "[dry-run] symlink:  $_ic_link -> $_ic_dest/$BIN"
+        return 0
+    fi
+
+    _ic_tmp=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap 'rm -rf "$_ic_tmp" "$_ic_new"' EXIT
+
+    mkdir -p "$_ic_pkg"
+    chmod 0700 "$_ic_pkg"
+
+    say "  downloading $_ic_archive"
+    http "$_ic_url" "$_ic_tmp/$_ic_archive" || err "failed to download $_ic_url"
+    http "$_ic_sha_url" "$_ic_tmp/$_ic_archive.sha256" || err "failed to download $_ic_sha_url"
+
+    _ic_want=$(awk '{print $1; exit}' "$_ic_tmp/$_ic_archive.sha256")
+    case "$_ic_want" in
+        *[!0-9a-fA-F]* | '' ) err "invalid sha256 file for $_ic_archive" ;;
+    esac
+    [ "${#_ic_want}" -eq 64 ] || err "invalid sha256 file for $_ic_archive"
+    _ic_got=$(sha256_file "$_ic_tmp/$_ic_archive")
+    _ic_want_l=$(printf '%s' "$_ic_want" | tr '[:upper:]' '[:lower:]')
+    _ic_got_l=$(printf '%s' "$_ic_got" | tr '[:upper:]' '[:lower:]')
+    [ "$_ic_want_l" = "$_ic_got_l" ] || err "checksum mismatch for $_ic_archive"
+
+    # Re-read install dir after network I/O (defense in depth).
+    _ic_root=$(install_dir)
+    _ic_link="$_ic_root/$BIN"
+
+    _ic_allow=$(payload_allowlist)
+    # shellcheck disable=SC2086
+    inspect_archive "$_ic_tmp/$_ic_archive" $_ic_allow \
+        || err "archive failed allowlist check"
+
+    rm -rf "$_ic_new"
+    mkdir "$_ic_new"
+    chmod 0700 "$_ic_new"
+
+    say "  extracting"
+    tar xzf "$_ic_tmp/$_ic_archive" -C "$_ic_new" || err "failed to extract $_ic_archive"
+    verify_extracted "$_ic_new" "$_ic_ver"
+
+    chmod 0755 "$_ic_new/bux" "$_ic_new/bux-shim" "$_ic_new/bux-guest-$_ic_guest"
+    if [ -f "$_ic_new/bwrap" ] && [ ! -L "$_ic_new/bwrap" ]; then
+        chmod 0755 "$_ic_new/bwrap"
+    fi
+
+    rm -rf "$_ic_dest"
+    mv "$_ic_new" "$_ic_dest"
+    chmod 0700 "$_ic_dest"
+
+    mkdir -p "$_ic_root"
+    if [ -d "$_ic_link" ] && [ ! -L "$_ic_link" ]; then
+        err "$_ic_link exists and is a directory"
+    fi
+    rm -f "$_ic_link"
+    ln -s "$_ic_dest/bux" "$_ic_link"
+    say "  installed $_ic_link -> $_ic_dest/bux"
+
+    if [ -n "${GITHUB_PATH:-}" ]; then
+        printf '%s\n' "$_ic_root" >>"$GITHUB_PATH"
+        say "  appended $_ic_root to GITHUB_PATH"
+    else
+        add_path "$_ic_root"
+    fi
+    say ""
+    say "$BIN v$_ic_ver installed."
+
+    trap - EXIT
+    rm -rf "$_ic_tmp"
+}
+
+uninstall_cli() {
+    _uc_root=$(install_dir)
+    _uc_path="$_uc_root/$BIN"
+    _uc_pkg=$(payload_root)
+    _uc_fc="$HOME/.config/fish/conf.d/$BIN-path.fish"
+    if [ "$DRY" = 1 ]; then
+        say "[dry-run] remove: $_uc_path"
+        say "[dry-run] remove: $_uc_pkg"
+        [ -f "$_uc_fc" ] && say "[dry-run] remove: $_uc_fc"
+        say "[dry-run] note: shell rc PATH entries would be left in place"
+        say "[dry-run] note: BUX_HOME / runtime data would not be touched"
+        return 0
+    fi
+    if [ -L "$_uc_path" ]; then
+        _uc_link=$(readlink "$_uc_path")
+        case "$_uc_link" in
+            "$_uc_pkg"/*)
+                rm -f "$_uc_path"
+                say "removed $_uc_path"
+                ;;
+            *)
+                say "leaving $_uc_path (not a bux-pkg symlink)"
+                ;;
+        esac
+    elif [ -f "$_uc_path" ]; then
+        rm -f "$_uc_path"
+        say "removed $_uc_path"
+    else
+        say "$_uc_path not found"
+    fi
+    if [ -e "$_uc_pkg" ] || [ -L "$_uc_pkg" ]; then
+        rm -rf "$_uc_pkg"
+        say "removed $_uc_pkg"
+    else
+        say "$_uc_pkg not found"
+    fi
+    if [ -f "$_uc_fc" ]; then
+        rm -f "$_uc_fc"
+        say "removed $_uc_fc"
+    fi
+    say "note: PATH entries in shell rc files were left in place"
+    say "note: BUX_HOME / runtime data were not touched"
+}
+
+usage() {
+    cat <<EOF
+Installer for $BIN.
+
+Usage:
+  curl -fsSL https://sh.qntx.org/bux | sh                            # install
+  curl -fsSL https://sh.qntx.org/bux | sh -s -- --uninstall          # uninstall
+  curl -fsSL https://sh.qntx.org/bux | sh -s -- --dry-run            # preview
+  curl -fsSL https://sh.qntx.org/bux | sh -s -- --help               # show this help
+
+python3 is required to select the latest product release (paginates
+GitHub /releases; this script never uses /releases/latest).
+
+Environment:
+  ${UP}_VERSION       Pin a version (default: newest product tag ^v[0-9])
+  ${UP}_INSTALL_DIR   Symlink directory (default: \$HOME/.local/bin; absolute, safe chars)
+  UNINSTALL=1         Same as --uninstall
+  DRY_RUN=1           Same as --dry-run (install and uninstall)
+  HELP=1              Same as --help
+  NO_COLOR            Disable color output
+  GITHUB_PATH         If set, append install dir (GitHub Actions) instead of shell rc
+
+Payload (not BUX_HOME; uninstall does not wipe runtime data):
+  Linux:  \${XDG_DATA_HOME:-\$HOME/.local/share}/bux-pkg/<ver>-<target>/
+  macOS:  \$HOME/Library/Application Support/bux-pkg/<ver>-<target>/
+EOF
+}
+
+ACT=install
+DRY=0
+[ "${UNINSTALL:-0}" = 1 ] && ACT=uninstall
+[ "${DRY_RUN:-0}" = 1 ] && DRY=1
+[ "${HELP:-0}" = 1 ] && { usage; exit 0; }
+
+if [ "${BUX_INSTALL_SOURCED:-}" = 1 ]; then
+    return 0
+fi
+
+for _arg in "$@"; do
+    case "$_arg" in
+        -h | --help) usage; exit 0 ;;
+        --uninstall) ACT=uninstall ;;
+        --dry-run) DRY=1 ;;
+        *) err "unknown argument: $_arg" ;;
+    esac
+done
+
+case "$ACT" in
+    install) install_cli ;;
+    uninstall) uninstall_cli ;;
+    *) err "unknown action: $ACT" ;;
+esac

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,477 @@
+#!/bin/sh
+# Host-only tests for install.sh / install.ps1. No live GitHub.
+set -eu
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_SH="$ROOT/install.sh"
+INSTALL_PS1="$ROOT/install.ps1"
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+[ -f "$INSTALL_SH" ] || fail "missing $INSTALL_SH"
+[ -f "$INSTALL_PS1" ] || fail "missing $INSTALL_PS1"
+command -v python3 >/dev/null 2>&1 || fail "python3 required"
+
+T="$(mktemp -d)"
+trap 'rm -rf "$T"' EXIT
+
+# Source production helpers. Must be top-level: install.sh `return` would
+# otherwise return from a wrapping function.
+BUX_INSTALL_SOURCED=1
+# shellcheck disable=SC1090
+. "$INSTALL_SH"
+unset BUX_INSTALL_SOURCED
+
+# Shaped like live 2026-09-04 (21 Releases) plus guest-v0.1.0 so that tag
+# cannot win even if it is a non-prerelease.
+FIXTURE_JSON="$T/releases-page1.json"
+cat >"$FIXTURE_JSON" <<'JSON'
+[
+  {"tag_name": "guest-fc094be148bcfc7f3ef50d5e4805a8505afc04ba", "draft": false, "prerelease": false},
+  {"tag_name": "guest-da2fc6aa4dca3c39d09e56b95c30ad49b419832a", "draft": false, "prerelease": false},
+  {"tag_name": "guest-ccea02856a108acf44d0b8882f88168cd9bbbf1d", "draft": false, "prerelease": false},
+  {"tag_name": "krun-v1.19.4", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v1.47.4", "draft": false, "prerelease": false},
+  {"tag_name": "bwrap-v0.12.0", "draft": false, "prerelease": false},
+  {"tag_name": "krun-v0.1.4", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v0.1.5", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v0.1.4", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v0.1.3", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v0.1.2", "draft": false, "prerelease": false},
+  {"tag_name": "bwrap-v0.1.0", "draft": false, "prerelease": false},
+  {"tag_name": "krun-v0.1.3", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v0.1.1", "draft": false, "prerelease": false},
+  {"tag_name": "e2fs-v0.1.0", "draft": false, "prerelease": false},
+  {"tag_name": "guest-v0.1.0", "draft": false, "prerelease": false},
+  {"tag_name": "v0.4.1", "draft": false, "prerelease": false},
+  {"tag_name": "v0.3.0", "draft": false, "prerelease": false},
+  {"tag_name": "v0.2.1", "draft": false, "prerelease": false},
+  {"tag_name": "deps-v0.1.3", "draft": false, "prerelease": false},
+  {"tag_name": "deps-v0.1.2", "draft": false, "prerelease": false},
+  {"tag_name": "deps-v0.1.0", "draft": false, "prerelease": false}
+]
+JSON
+
+write_uname() {
+    _wu_dir=$1
+    _wu_os=$2
+    _wu_arch=$3
+    mkdir -p "$_wu_dir"
+    printf '%s\n' "#!/bin/sh" >"$_wu_dir/uname"
+    printf '%s\n' "case \"\$1\" in" >>"$_wu_dir/uname"
+    printf '%s\n' "  -s) printf '%s\\n' '$_wu_os' ;;" >>"$_wu_dir/uname"
+    printf '%s\n' "  -m) printf '%s\\n' '$_wu_arch' ;;" >>"$_wu_dir/uname"
+    printf '%s\n' "  *) printf '%s\\n' '$_wu_arch' ;;" >>"$_wu_dir/uname"
+    printf '%s\n' "esac" >>"$_wu_dir/uname"
+    chmod 0755 "$_wu_dir/uname"
+}
+
+write_sysctl() {
+    _ws_dir=$1
+    _ws_val=$2
+    mkdir -p "$_ws_dir"
+    printf '%s\n' "#!/bin/sh" >"$_ws_dir/sysctl"
+    printf '%s\n' "if [ \"\$1\" = -n ] && [ \"\$2\" = hw.optional.arm64 ]; then" >>"$_ws_dir/sysctl"
+    printf '%s\n' "  printf '%s\\n' '$_ws_val'" >>"$_ws_dir/sysctl"
+    printf '%s\n' "  exit 0" >>"$_ws_dir/sysctl"
+    printf '%s\n' "fi" >>"$_ws_dir/sysctl"
+    printf '%s\n' "exit 1" >>"$_ws_dir/sysctl"
+    chmod 0755 "$_ws_dir/sysctl"
+}
+
+# Staging dir $1, OS Darwin|Linux, guest triple $3, include_bwrap 0|1, extra name $5.
+make_staging() {
+    _ms_dir=$1
+    _ms_os=$2
+    _ms_guest=$3
+    _ms_bwrap=$4
+    _ms_extra=${5:-}
+    rm -rf "$_ms_dir"
+    mkdir -p "$_ms_dir"
+    printf '%s\n' '#!/bin/sh' 'echo fake-bux' >"$_ms_dir/bux"
+    printf '%s\n' '#!/bin/sh' 'echo fake-shim' >"$_ms_dir/bux-shim"
+    chmod 0755 "$_ms_dir/bux" "$_ms_dir/bux-shim"
+    printf '%s\n' 'guest' >"$_ms_dir/$_ms_guest"
+    chmod 0755 "$_ms_dir/$_ms_guest"
+    printf '%s\n' 'MIT' >"$_ms_dir/LICENSE-MIT"
+    printf '%s\n' 'APACHE' >"$_ms_dir/LICENSE-APACHE"
+    if [ "$_ms_os" = Darwin ]; then
+        printf '%s\n' 'krun' >"$_ms_dir/libkrun.dylib"
+        printf '%s\n' 'krunfw' >"$_ms_dir/libkrunfw.dylib"
+        ln -s libkrun.dylib "$_ms_dir/libkrun.1.dylib"
+        ln -s libkrunfw.dylib "$_ms_dir/libkrunfw.5.dylib"
+    else
+        printf '%s\n' 'krun' >"$_ms_dir/libkrun.so"
+        printf '%s\n' 'krunfw' >"$_ms_dir/libkrunfw.so"
+        ln -s libkrun.so "$_ms_dir/libkrun.so.1"
+        ln -s libkrunfw.so "$_ms_dir/libkrunfw.so.5"
+        if [ "$_ms_bwrap" = 1 ]; then
+            printf '%s\n' '#!/bin/sh' 'echo fake-bwrap' >"$_ms_dir/bwrap"
+            chmod 0755 "$_ms_dir/bwrap"
+        fi
+    fi
+    if [ -n "$_ms_extra" ]; then
+        printf '%s\n' 'extra' >"$_ms_dir/$_ms_extra"
+    fi
+}
+
+pack_tar() {
+    _pt_src=$1
+    _pt_dst=$2
+    # Darwin tar otherwise injects AppleDouble ._* members.
+    COPYFILE_DISABLE=1 tar czf "$_pt_dst" -C "$_pt_src" .
+}
+
+write_sha() {
+    _wsh_tar=$1
+    _wsh_out=$2
+    _wsh_hash=$(
+        if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum "$_wsh_tar" | awk '{print $1}'
+        else
+            shasum -a 256 "$_wsh_tar" | awk '{print $1}'
+        fi
+    )
+    _wsh_base=$(basename "$_wsh_tar")
+    printf '%s  %s\n' "$_wsh_hash" "$_wsh_base" >"$_wsh_out"
+}
+
+# Fake curl: map GitHub URLs onto $T/www. Refuse /releases/latest.
+write_curl() {
+    _wc_dir=$1
+    mkdir -p "$_wc_dir" "$T/www"
+    printf '%s\n' "#!/bin/sh" >"$_wc_dir/curl"
+    cat >>"$_wc_dir/curl" <<CURL
+out=""
+url=""
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        -o) out=\$2; shift 2 ;;
+        -A) shift 2 ;;
+        -fsSL|-f|-s|-S|-L|-q) shift ;;
+        --user-agent) shift 2 ;;
+        -O-|-O) shift ;;
+        -*) shift ;;
+        *) url=\$1; shift ;;
+    esac
+done
+printf '%s\n' "\$url" >>"$T/curl-urls"
+case "\$url" in
+    */releases/latest*)
+        printf '%s\n' "refused /releases/latest: \$url" >&2
+        exit 1
+        ;;
+esac
+src=""
+case "\$url" in
+    *"/releases?per_page=100&page="*)
+        page=\${url##*page=}
+        page=\${page%%&*}
+        src="$T/www/releases-page-\${page}.json"
+        ;;
+    https://github.com/qntx/bux/releases/download/*)
+        src="$T/www/\${url##*/}"
+        ;;
+    *)
+        printf '%s\n' "unexpected url: \$url" >&2
+        exit 1
+        ;;
+esac
+if [ ! -f "\$src" ]; then
+    printf '%s\n' "missing fixture: \$src (url=\$url)" >&2
+    exit 1
+fi
+if [ -n "\$out" ]; then
+    cp "\$src" "\$out"
+else
+    cat "\$src"
+fi
+CURL
+    chmod 0755 "$_wc_dir/curl"
+}
+
+run_install() {
+    # `|| return` so set -e does not abort the test shell on expected failures.
+    env -i \
+        HOME="$HOME" \
+        PATH="$PATH" \
+        BUX_VERSION="${BUX_VERSION:-}" \
+        BUX_INSTALL_DIR="${BUX_INSTALL_DIR:-}" \
+        XDG_DATA_HOME="${XDG_DATA_HOME:-}" \
+        GITHUB_PATH="${GITHUB_PATH:-}" \
+        NO_COLOR=1 \
+        DRY_RUN="${DRY_RUN:-}" \
+        UNINSTALL="${UNINSTALL:-}" \
+        /bin/sh "$INSTALL_SH" "$@" || return $?
+}
+
+# --- parser ---
+
+st=0
+got=$(parse_product_tag <"$FIXTURE_JSON") || st=$?
+[ "$st" = 0 ] || fail "fixture parser exit $st"
+[ "$got" = "0.4.1" ] || fail "fixture first hit want 0.4.1 got $got"
+
+python3 - "$FIXTURE_JSON" <<'PY' || fail "guest/krun tags must be present in fixture"
+import json, sys
+tags = [r["tag_name"] for r in json.load(open(sys.argv[1]))]
+for t in (
+    "guest-fc094be148bcfc7f3ef50d5e4805a8505afc04ba",
+    "guest-v0.1.0",
+    "krun-v1.19.4",
+):
+    if t not in tags:
+        sys.exit(1)
+if tags[0].startswith("v"):
+    sys.exit(1)
+PY
+
+st=0
+got=$(printf '%s' '[]' | parse_product_tag) || st=$?
+[ "$st" = 3 ] || fail "empty page want exit 3 got $st"
+
+st=0
+got=$(printf '%s' '[{"tag_name":"guest-v0.1.0","draft":false,"prerelease":false},{"tag_name":"krun-v1.19.4","draft":false,"prerelease":false}]' | parse_product_tag) || st=$?
+[ "$st" = 2 ] || fail "guest/krun-only page want exit 2 got $st"
+
+st=0
+got=$(printf '%s' '[{"tag_name":"v9.9.9","draft":true,"prerelease":false},{"tag_name":"v8.8.8","draft":false,"prerelease":true},{"tag_name":"v0.4.1","draft":false,"prerelease":false}]' | parse_product_tag) || st=$?
+[ "$st" = 0 ] && [ "$got" = "0.4.1" ] || fail "draft/prerelease skipped, want 0.4.1 got st=$st val=$got"
+
+# Comments may mention /releases/latest as forbidden; the HTTP URL must not.
+if grep -E 'https://api.github.com/repos/[^[:space:]]+/releases/latest' "$INSTALL_SH"; then
+    fail "install.sh must not call /releases/latest"
+fi
+if grep -E 'https://api.github.com/repos/[^[:space:]]+/tags' "$INSTALL_SH"; then
+    fail "install.sh must not use /tags"
+fi
+
+# Pagination: page 1 has no product tag; page 2 has v0.4.1.
+mkdir -p "$T/bin-page"
+write_curl "$T/bin-page"
+printf '%s\n' '[{"tag_name":"guest-fc094be148bcfc7f3ef50d5e4805a8505afc04ba","draft":false,"prerelease":false},{"tag_name":"krun-v1.19.4","draft":false,"prerelease":false}]' >"$T/www/releases-page-1.json"
+cp "$FIXTURE_JSON" "$T/www/releases-page-2.json"
+printf '%s\n' '[]' >"$T/www/releases-page-3.json"
+PATH="$T/bin-page:$PATH"
+st=0
+got=$(latest) || st=$?
+[ "$st" = 0 ] && [ "$got" = "0.4.1" ] || fail "paginated latest want 0.4.1 got st=$st val=$got"
+grep -q 'releases/latest' "$T/curl-urls" && fail "latest() fetched /releases/latest"
+grep -q 'page=1' "$T/curl-urls" || fail "latest() did not fetch page=1"
+grep -q 'page=2' "$T/curl-urls" || fail "latest() did not fetch page=2"
+# Restore PATH after pagination (keep later stubs isolated).
+PATH=$(printf '%s' "$PATH" | sed "s|^$T/bin-page:||")
+
+# --- host_target ---
+
+native=$(host_target)
+case "$native" in
+    x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu | aarch64-apple-darwin) ;;
+    *-unknown-linux-musl) fail "host_target must never be musl: $native" ;;
+    *) fail "host_target not a CD matrix member: $native" ;;
+esac
+
+mkdir -p "$T/ht"
+write_uname "$T/ht" Linux x86_64
+got=$(PATH="$T/ht:$PATH" host_target)
+[ "$got" = "x86_64-unknown-linux-gnu" ] || fail "Linux x86_64 want gnu got $got"
+
+write_uname "$T/ht" Linux aarch64
+got=$(PATH="$T/ht:$PATH" host_target)
+[ "$got" = "aarch64-unknown-linux-gnu" ] || fail "Linux aarch64 want gnu got $got"
+
+write_uname "$T/ht" Darwin arm64
+got=$(PATH="$T/ht:$PATH" host_target)
+[ "$got" = "aarch64-apple-darwin" ] || fail "Darwin arm64 want apple-darwin got $got"
+
+write_uname "$T/ht" Darwin x86_64
+write_sysctl "$T/ht" 1
+got=$(PATH="$T/ht:$PATH" host_target)
+[ "$got" = "aarch64-apple-darwin" ] || fail "Rosetta want aarch64-apple-darwin got $got"
+
+write_sysctl "$T/ht" 0
+st=0
+got=$(PATH="$T/ht:$PATH" host_target 2>"$T/ht.err") || st=$?
+[ "$st" != 0 ] || fail "Intel Mac must err"
+grep -q 'Intel Mac' "$T/ht.err" || fail "Intel Mac error message missing"
+
+# --- Darwin payload path contains a space ---
+
+HOME="$T/darwin-home"
+mkdir -p "$HOME"
+BINDIR="$T/darwin-bin"
+mkdir -p "$BINDIR" "$T/www"
+write_uname "$BINDIR" Darwin arm64
+write_curl "$BINDIR"
+make_staging "$T/stage-darwin" Darwin bux-guest-aarch64-unknown-linux-musl 0
+pack_tar "$T/stage-darwin" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz"
+write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+
+export HOME
+export BUX_VERSION=9.9.9
+export BUX_INSTALL_DIR="$T/darwin-bindir"
+mkdir -p "$BUX_INSTALL_DIR"
+PATH="$BINDIR:$PATH"
+run_install
+
+pkg="$HOME/Library/Application Support/bux-pkg"
+case "$pkg" in
+    *" "*) ;;
+    *) fail "Darwin payload path must contain a space: $pkg" ;;
+esac
+dest="$pkg/9.9.9-aarch64-apple-darwin"
+[ -d "$dest" ] || fail "missing payload dest $dest"
+[ -f "$dest/bux" ] || fail "missing payload bux"
+[ -L "$BUX_INSTALL_DIR/bux" ] || fail "missing symlink $BUX_INSTALL_DIR/bux"
+link=$(readlink "$BUX_INSTALL_DIR/bux")
+[ "$link" = "$dest/bux" ] || fail "symlink want $dest/bux got $link"
+[ ! -e "$pkg/current" ] && [ ! -L "$pkg/current" ] || fail "must not create bux-pkg/current"
+[ -L "$dest/libkrunfw.5.dylib" ] || fail "tar symlink libkrunfw.5.dylib not preserved"
+symtgt=$(readlink "$dest/libkrunfw.5.dylib")
+[ "$symtgt" = "libkrunfw.dylib" ] || fail "symlink target want libkrunfw.dylib got $symtgt"
+mode=$(python3 -c 'import os,sys; print(oct(os.stat(sys.argv[1]).st_mode & 0o777))' "$pkg")
+[ "$mode" = "0o700" ] || fail "bux-pkg mode want 0700 got $mode"
+dev_pkg=$(python3 -c 'import os,sys; print(os.stat(sys.argv[1]).st_dev)' "$pkg")
+dev_dest=$(python3 -c 'import os,sys; print(os.stat(sys.argv[1]).st_dev)' "$dest")
+[ "$dev_pkg" = "$dev_dest" ] || fail "extract dest must share st_dev with bux-pkg"
+case "$dest" in
+    "$pkg"/*) ;;
+    *) fail "extract dest is not a child of bux-pkg: $dest" ;;
+esac
+
+# path_safe applies only to BUX_INSTALL_DIR (space rejected), not payload.
+# Prefix assignment on an exported var persists in this shell; restore after.
+_saved_bindir=$BUX_INSTALL_DIR
+st=0
+BUX_INSTALL_DIR="$T/Application Support/bin"
+run_install 2>"$T/path_safe.err" || st=$?
+BUX_INSTALL_DIR="$_saved_bindir"
+export BUX_INSTALL_DIR
+[ "$st" != 0 ] || fail "BUX_INSTALL_DIR with a space must be rejected"
+grep -q 'unsafe characters' "$T/path_safe.err" || fail "path_safe error missing"
+
+# Uninstall must not wipe BUX_HOME or the sibling runtime data dir.
+export BUX_HOME="$HOME/explicit-bux-home"
+mkdir -p "$BUX_HOME" "$HOME/Library/Application Support/bux"
+printf '%s\n' stay-home >"$BUX_HOME/marker"
+printf '%s\n' stay-data >"$HOME/Library/Application Support/bux/db"
+run_install --uninstall
+[ -L "$BUX_INSTALL_DIR/bux" ] && fail "symlink still present after uninstall"
+[ -e "$pkg" ] && fail "bux-pkg still present after uninstall"
+[ -f "$BUX_HOME/marker" ] || fail "uninstall wiped BUX_HOME"
+[ -f "$HOME/Library/Application Support/bux/db" ] || fail "uninstall wiped runtime data dir"
+unset BUX_HOME
+
+# --- checksum mismatch must not replace dest ---
+
+HOME="$T/cksum-home"
+mkdir -p "$HOME" "$T/cksum-bindir"
+export HOME
+export BUX_INSTALL_DIR="$T/cksum-bindir"
+make_staging "$T/stage-ck" Darwin bux-guest-aarch64-unknown-linux-musl 0
+printf '%s\n' 'first' >"$T/stage-ck/bux"
+chmod 0755 "$T/stage-ck/bux"
+pack_tar "$T/stage-ck" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz"
+write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+run_install
+pkg="$HOME/Library/Application Support/bux-pkg"
+dest="$pkg/9.9.9-aarch64-apple-darwin"
+grep -q first "$dest/bux" || fail "first payload missing"
+
+printf '%s\n' 'second' >"$T/stage-ck/bux"
+chmod 0755 "$T/stage-ck/bux"
+pack_tar "$T/stage-ck" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz"
+printf '%s  %s\n' "0000000000000000000000000000000000000000000000000000000000000000" "bux-9.9.9-aarch64-apple-darwin.tar.gz" >"$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+st=0
+run_install 2>"$T/cksum.err" || st=$?
+[ "$st" != 0 ] || fail "checksum mismatch must err"
+grep -q 'checksum mismatch' "$T/cksum.err" || fail "checksum mismatch message missing"
+grep -q first "$dest/bux" || fail "checksum mismatch replaced dest"
+grep -q second "$dest/bux" && fail "checksum mismatch installed the new payload"
+
+# --- extra archive member rejected; dest not replaced ---
+
+write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+make_staging "$T/stage-extra" Darwin bux-guest-aarch64-unknown-linux-musl 0 evil
+printf '%s\n' 'first' >"$T/stage-ck/bux"
+# dest still has 'first'; extra tarball should fail allowlist
+pack_tar "$T/stage-extra" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz"
+write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+st=0
+run_install 2>"$T/extra.err" || st=$?
+[ "$st" != 0 ] || fail "extra member must err"
+grep -q 'unexpected archive member' "$T/extra.err" || fail "extra member message missing"
+grep -q first "$dest/bux" || fail "extra member replaced dest"
+
+# --- path traversal rejected before extract ---
+
+python3 - "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" <<'PY'
+import tarfile, io, sys
+buf = io.BytesIO()
+with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+    info = tarfile.TarInfo("../evil")
+    data = b"x"
+    info.size = len(data)
+    tf.addfile(info, io.BytesIO(data))
+open(sys.argv[1], "wb").write(buf.getvalue())
+PY
+write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+st=0
+run_install 2>"$T/dotdot.err" || st=$?
+[ "$st" != 0 ] || fail "dotdot member must err"
+grep -q first "$dest/bux" || fail "dotdot member replaced dest"
+
+# --- Linux bwrap required ---
+
+HOME="$T/linux-home"
+mkdir -p "$HOME" "$T/linux-bindir" "$T/linux-bin"
+write_uname "$T/linux-bin" Linux aarch64
+write_curl "$T/linux-bin"
+export HOME
+export BUX_INSTALL_DIR="$T/linux-bindir"
+export XDG_DATA_HOME="$HOME/share"
+PATH="$T/linux-bin:$PATH"
+
+make_staging "$T/stage-linux-nobwrap" Linux bux-guest-aarch64-unknown-linux-musl 0
+pack_tar "$T/stage-linux-nobwrap" "$T/www/bux-9.9.9-aarch64-unknown-linux-gnu.tar.gz"
+write_sha "$T/www/bux-9.9.9-aarch64-unknown-linux-gnu.tar.gz" "$T/www/bux-9.9.9-aarch64-unknown-linux-gnu.tar.gz.sha256"
+st=0
+run_install 2>"$T/nobwrap.err" || st=$?
+[ "$st" != 0 ] || fail "Linux tarball without bwrap must err"
+grep -q 'no Linux bwrap in v9.9.9' "$T/nobwrap.err" || fail "missing bwrap error text"
+[ -L "$BUX_INSTALL_DIR/bux" ] && fail "must not symlink a jailer-broken tree"
+[ -d "$XDG_DATA_HOME/bux-pkg/9.9.9-aarch64-unknown-linux-gnu" ] && fail "must not leave Linux dest without bwrap"
+
+make_staging "$T/stage-linux" Linux bux-guest-aarch64-unknown-linux-musl 1
+pack_tar "$T/stage-linux" "$T/www/bux-9.9.9-aarch64-unknown-linux-gnu.tar.gz"
+write_sha "$T/www/bux-9.9.9-aarch64-unknown-linux-gnu.tar.gz" "$T/www/bux-9.9.9-aarch64-unknown-linux-gnu.tar.gz.sha256"
+run_install
+ldest="$XDG_DATA_HOME/bux-pkg/9.9.9-aarch64-unknown-linux-gnu"
+[ -f "$ldest/bwrap" ] || fail "Linux payload missing bwrap"
+[ -L "$ldest/libkrunfw.so.5" ] || fail "Linux tar symlink not preserved"
+[ -L "$BUX_INSTALL_DIR/bux" ] || fail "Linux symlink missing"
+[ ! -e "$XDG_DATA_HOME/bux-pkg/current" ] || fail "Linux created bux-pkg/current"
+
+# --- install.ps1 refuses Windows ---
+
+grep -q 'does not support Windows' "$INSTALL_PS1" || fail "install.ps1 missing refusal text"
+grep -q 'exit 1' "$INSTALL_PS1" || fail "install.ps1 must exit 1"
+if grep -qi 'Invoke-WebRequest' "$INSTALL_PS1"; then
+    fail "install.ps1 must not download"
+fi
+if command -v pwsh >/dev/null 2>&1; then
+    st=0
+    pwsh -File "$INSTALL_PS1" >/dev/null 2>&1 || st=$?
+    [ "$st" = 1 ] || fail "pwsh install.ps1 want exit 1 got $st"
+fi
+
+# --- help documents python3 ---
+
+help=$(/bin/sh "$INSTALL_SH" --help)
+printf '%s\n' "$help" | grep -q 'python3' || fail "--help must document python3"
+printf '%s\n' "$help" | grep -q 'releases/latest' || fail "--help must mention that /releases/latest is not used"
+
+printf 'ok\n'

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -195,6 +195,7 @@ CURL
 
 run_install() {
     # `|| return` so set -e does not abort the test shell on expected failures.
+    _ri_sh=${INSTALL_UNDER_TEST:-$INSTALL_SH}
     env -i \
         HOME="$HOME" \
         PATH="$PATH" \
@@ -205,7 +206,19 @@ run_install() {
         NO_COLOR=1 \
         DRY_RUN="${DRY_RUN:-}" \
         UNINSTALL="${UNINSTALL:-}" \
-        /bin/sh "$INSTALL_SH" "$@" || return $?
+        /bin/sh "$_ri_sh" "$@" || return $?
+}
+
+# True when inspect rejected ../evil before extract (dest unchanged, no sibling evil).
+dotdot_rejected() {
+    _dd_err=$1
+    _dd_pkg=$2
+    _dd_dest=$3
+    grep -q 'illegal archive path' "$_dd_err" || return 1
+    grep -q '\.\./evil' "$_dd_err" || return 1
+    [ -e "$_dd_pkg/evil" ] && return 1
+    grep -q first "$_dd_dest/bux" || return 1
+    return 0
 }
 
 # --- parser ---
@@ -422,7 +435,59 @@ write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch
 st=0
 run_install 2>"$T/dotdot.err" || st=$?
 [ "$st" != 0 ] || fail "dotdot member must err"
-grep -q first "$dest/bux" || fail "dotdot member replaced dest"
+dotdot_rejected "$T/dotdot.err" "$pkg" "$dest" || fail "inspect must reject ../evil before extract (no $pkg/evil)"
+
+# Stub inspect_archive: the same assertions must fail (otherwise they are not load-bearing).
+awk '
+    /^inspect_archive\(\) \{/ {
+        print
+        print "    return 0"
+        skip=1
+        next
+    }
+    skip && /^}/ { print; skip=0; next }
+    skip { next }
+    { print }
+' "$INSTALL_SH" >"$T/install.stub.sh"
+grep -q 'illegal archive path' "$INSTALL_SH" || fail "production inspect_archive missing"
+if grep -q 'illegal archive path' "$T/install.stub.sh"; then
+    fail "awk did not stub inspect_archive"
+fi
+INSTALL_UNDER_TEST="$T/install.stub.sh"
+st=0
+run_install 2>"$T/dotdot.stub.err" || st=$?
+unset INSTALL_UNDER_TEST
+if dotdot_rejected "$T/dotdot.stub.err" "$pkg" "$dest"; then
+    fail "inspect_archive stubbed to return 0 must fail traversal assertions"
+fi
+grep -q 'illegal archive path' "$T/dotdot.stub.err" && fail "stubbed inspect_archive still emitted inspect error"
+rm -f "$pkg/evil"
+rm -rf "$pkg/9.9.9-aarch64-apple-darwin.new"
+
+# AppleDouble ._* (Darwin CD without COPYFILE_DISABLE) stays rejected.
+make_staging "$T/stage-ad" Darwin bux-guest-aarch64-unknown-linux-musl 0
+printf '%s\n' 'first' >"$T/stage-ad/bux"
+chmod 0755 "$T/stage-ad/bux"
+pack_tar "$T/stage-ad" "$T/www/valid-ad.tar.gz"
+python3 - "$T/www/valid-ad.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" <<'PY'
+import io, sys, tarfile
+src, dst = sys.argv[1], sys.argv[2]
+with tarfile.open(src, "r:gz") as inn, tarfile.open(dst, "w:gz") as out:
+    for m in inn.getmembers():
+        f = inn.extractfile(m) if m.isfile() else None
+        out.addfile(m, f)
+    info = tarfile.TarInfo("._bux")
+    data = b"appledouble"
+    info.size = len(data)
+    out.addfile(info, io.BytesIO(data))
+PY
+write_sha "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz" "$T/www/bux-9.9.9-aarch64-apple-darwin.tar.gz.sha256"
+st=0
+run_install 2>"$T/appledouble.err" || st=$?
+[ "$st" != 0 ] || fail "._bux member must err"
+grep -q 'unexpected archive member' "$T/appledouble.err" || fail "._bux message missing"
+grep -q '\._bux' "$T/appledouble.err" || fail "._bux not named in error"
+grep -q first "$dest/bux" || fail "._bux member replaced dest"
 
 # --- Linux bwrap required ---
 


### PR DESCRIPTION
Custom `install.sh` paginates GitHub `/releases` for `^v[0-9]` (never `/releases/latest`). Payload is `bux-pkg/{ver}-{target}` with same-FS extract. Darwin `COPYFILE_DISABLE=1` on CD tar. Linux archive without regular-file `bwrap` is refused. `install.ps1` exits 1. CI runs `scripts/install_test.sh`.

Stack: execute-plan/6f7864c8 PR 3/8. Base is PR 4.