### PR TITLE
fix: linux CI clippy and spawn_shim test compile

### DIFF
--- a/crates/bux-jail/src/lib.rs
+++ b/crates/bux-jail/src/lib.rs
@@ -292,7 +292,7 @@ fn build_command(
 
     #[cfg(target_os = "linux")]
     {
-        return Err(Error::BwrapUnavailable);
+        Err(Error::BwrapUnavailable)
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/bux-jail/src/lib.rs
+++ b/crates/bux-jail/src/lib.rs
@@ -373,9 +373,7 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     fn fd_count() -> usize {
-        std::fs::read_dir("/proc/self/fd")
-            .map(|d| d.count())
-            .unwrap_or(0)
+        std::fs::read_dir("/proc/self/fd").map_or(0, Iterator::count)
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -691,14 +691,16 @@ mod tests {
     fn spawn_shim_missing_bwrap_does_not_write_json_or_stderr() {
         let dir = tempfile::tempdir().unwrap();
         let config_path = dir.path().join("vm.json");
-        let cfg = crate::state::VmConfig {
+        let cfg = VmConfig {
             network: NetworkSpec::Disabled,
             security: crate::security::SecurityOptions::default()
                 .jailer(true)
                 .landlock(false),
-            ..crate::state::VmConfig::default()
+            ..VmConfig::default()
         };
-        let err = spawn_shim(&cfg, &config_path, dir.path(), None, None, None, None).unwrap_err();
+        let Err(err) = spawn_shim(&cfg, &config_path, dir.path(), None, None, None, None) else {
+            panic!("linux jailer without bwrap must fail closed");
+        };
         assert!(
             matches!(err, crate::Error::SecurityUnavailable(_)),
             "linux jailer without bwrap must fail closed: {err}"

--- a/crates/bux/src/runtime/boot/spawn.rs
+++ b/crates/bux/src/runtime/boot/spawn.rs
@@ -698,9 +698,9 @@ mod tests {
                 .landlock(false),
             ..VmConfig::default()
         };
-        let Err(err) = spawn_shim(&cfg, &config_path, dir.path(), None, None, None, None) else {
-            panic!("linux jailer without bwrap must fail closed");
-        };
+        let err = spawn_shim(&cfg, &config_path, dir.path(), None, None, None, None)
+            .err()
+            .unwrap();
         assert!(
             matches!(err, crate::Error::SecurityUnavailable(_)),
             "linux jailer without bwrap must fail closed: {err}"


### PR DESCRIPTION
`main` CI after #150 is red. Stacked PR #150 had no PR checks (`pull_request` only fires for `main`).

- `ci / ci`: `clippy::needless_return` in linux-only `build_command`
- `test (ubuntu-latest)` / `engine-no-krun`: `unwrap_err()` requires `Debug` on `ShimSpawnResult`

macos jobs were green because those paths are `cfg(linux)`.