### PR TITLE
fix: CD gvproxy needs Go on macOS and arm64 libresolv

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,6 +108,9 @@ jobs:
         with:
           toolchain: 1.97.1
           targets: "${{ matrix.target }}"
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: crates/bux-gvproxy/gvproxy-bridge/go.mod
       - uses: Swatinem/rust-cache@v2
         with: { key: "${{ matrix.target }}" }
       - uses: actions/download-artifact@v8
@@ -133,7 +136,7 @@ jobs:
             | sudo tee /etc/apt/sources.list.d/arm64-cross.sources
           sudo dpkg --add-architecture arm64
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu libcap-ng-dev:arm64
+          sudo apt-get install -y gcc-aarch64-linux-gnu libcap-ng-dev:arm64 libc6-dev:arm64
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
 
       # Separate -p so feature unification does not DT_NEEDED libkrun on bux.

--- a/crates/bux-gvproxy/build.rs
+++ b/crates/bux-gvproxy/build.rs
@@ -17,6 +17,7 @@
     clippy::unwrap_used,
     clippy::unwrap_in_result,
     clippy::let_underscore_must_use,
+    clippy::missing_docs_in_private_items,
     missing_docs,
     unsafe_code,
     reason = "build scripts may panic/expect on unrecoverable setup failures"

--- a/crates/bux-gvproxy/build.rs
+++ b/crates/bux-gvproxy/build.rs
@@ -27,6 +27,39 @@ use std::fs;
 use std::path::Path;
 use std::process::Command;
 
+fn go_os(os: &str) -> &'static str {
+    match os {
+        "linux" => "linux",
+        "macos" => "darwin",
+        other => panic!("unsupported GOOS from CARGO_CFG_TARGET_OS={other}"),
+    }
+}
+
+fn go_arch(arch: &str) -> &'static str {
+    match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => panic!("unsupported GOARCH from CARGO_CFG_TARGET_ARCH={other}"),
+    }
+}
+
+fn apply_go_target(cmd: &mut Command) {
+    let os = env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS");
+    let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH");
+    cmd.env("CGO_ENABLED", "1");
+    cmd.env("GOOS", go_os(&os));
+    cmd.env("GOARCH", go_arch(&arch));
+    if let Ok(target) = env::var("TARGET") {
+        let key = format!(
+            "CARGO_TARGET_{}_LINKER",
+            target.replace('-', "_").to_ascii_uppercase()
+        );
+        if let Ok(cc) = env::var(&key) {
+            cmd.env("CC", cc);
+        }
+    }
+}
+
 /// Builds libgvproxy from Go sources as a C static archive.
 fn build_gvproxy(source_dir: &Path, output_path: &Path) {
     println!("cargo:warning=Building libgvproxy from Go sources...");
@@ -46,6 +79,7 @@ fn build_gvproxy(source_dir: &Path, output_path: &Path) {
     // Build as C archive (static library).
     let mut cmd = Command::new("go");
     cmd.args(["build", "-buildmode=c-archive"]);
+    apply_go_target(&mut cmd);
 
     if source_dir.join("vendor").exists() {
         cmd.arg("-mod=vendor");


### PR DESCRIPTION
## Summary
- `v0.9.0` product CD failed: macOS `go: NotFound`; aarch64-linux cross `could not find native static library resolv`.
- Install Go from `gvproxy-bridge/go.mod` on CD build jobs.
- Cross job installs `libc6-dev:arm64`.
- `bux-gvproxy` build.rs sets `GOOS`/`GOARCH`/`CC` from the Cargo target.

`guest-v0.2.0` already published. After merge, move `v0.9.0` to this commit and re-push the tag (no GitHub Release exists yet).

## Test plan
- [ ] PR CI green
- [ ] Re-run product CD on `v0.9.0` after retag: linux x86_64, linux aarch64 cross, macos aarch64