### PR TITLE
fix(oci): SafeRoot extract; reject symlink escape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -412,7 +412,9 @@ name = "bux-oci"
 version = "0.9.0"
 dependencies = [
  "flate2",
+ "libc",
  "oci-client",
+ "pathrs",
  "rusqlite",
  "serde",
  "serde_json",
@@ -421,6 +423,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1481,6 +1484,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +1960,24 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "pathrs"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd74b8fd656302d50059a07147444e46d6c2f162656271cf626e8ff3fad4cce8"
+dependencies = [
+ "bitflags",
+ "itertools 0.15.0",
+ "libc",
+ "memchr",
+ "once_cell",
+ "rustix",
+ "rustversion",
+ "static_assertions",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "pem"
@@ -2649,6 +2679,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/crates/bux-oci/Cargo.toml
+++ b/crates/bux-oci/Cargo.toml
@@ -19,6 +19,11 @@ sha2.workspace = true
 tar.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tracing.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+pathrs = "0.2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/bux-oci/src/error.rs
+++ b/crates/bux-oci/src/error.rs
@@ -30,4 +30,8 @@ pub enum OciError {
     /// JSON parsing error.
     #[error(transparent)]
     Json(#[from] serde_json::Error),
+
+    /// Layer extract refused a path (escape, hop limit, or invalid whiteout).
+    #[error("extract: {0}")]
+    Extract(String),
 }

--- a/crates/bux-oci/src/extract.rs
+++ b/crates/bux-oci/src/extract.rs
@@ -1,9 +1,10 @@
 //! OCI layer extraction with whiteout handling.
 //!
-//! Paths are resolved with [`crate::SafeRoot`]. Device, FIFO, and socket
-//! members are skipped. Directory modes are applied once after the last layer.
+//! Paths are resolved with a rooted walker. Device and FIFO members are
+//! skipped. Directory modes are applied once after the last layer.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
+use std::ffi::OsString;
 use std::fs::{self, File, OpenOptions, Permissions};
 use std::io::{self, BufReader, Read};
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
@@ -13,7 +14,7 @@ use flate2::read::GzDecoder;
 use tar::{Archive, EntryType};
 use tracing::{debug, error};
 
-use crate::safe_root::SafeRoot;
+use crate::safe_root::{SYMLINK_HOP_LIMIT, SafeRoot, hop_limit_error};
 use crate::{OciError, Result};
 
 /// Media types recognized as gzip-compressed layers.
@@ -30,8 +31,8 @@ fn is_gzip(media_type: &str) -> bool {
 /// Extracts layer tarballs from disk into a rootfs directory (streaming, low memory).
 ///
 /// Each `(path, media_type)` pair is a layer tarball on disk. Layers are applied
-/// in order with full OCI whiteout semantics. One [`SafeRoot`] is used for every
-/// layer; directory modes are chmod'd deepest-first after the last layer.
+/// in order with full OCI whiteout semantics. One rooted resolver is used for
+/// every layer; directory modes are chmod'd deepest-first after the last layer.
 ///
 /// # Errors
 ///
@@ -86,16 +87,21 @@ impl LayerExtractor {
 
     fn extract_tarball(&mut self, path: &Path, gzip: bool) -> Result<()> {
         let file = BufReader::new(File::open(path)?);
-        if gzip {
+        let result = if gzip {
             self.extract_reader(GzDecoder::new(file))
         } else {
             self.extract_reader(file)
+        };
+        if result.is_err() {
+            self.deferred_dirs.clear();
         }
+        result
     }
 
     fn extract_reader(&mut self, reader: impl Read) -> Result<()> {
         let mut archive = Archive::new(reader);
         let mut unpacked = HashSet::new();
+        let mut written_rels = HashSet::new();
         let mut deferred_hardlinks = Vec::new();
 
         for raw_entry in archive.entries()? {
@@ -113,55 +119,43 @@ impl LayerExtractor {
             if apply_whiteout(&self.root, &normalized, &unpacked, entry_type)? {
                 continue;
             }
+            if skip_member(entry_type, &normalized) {
+                continue;
+            }
+
+            if entry_type == EntryType::Link {
+                self.apply_hardlink(
+                    &raw_path,
+                    &normalized,
+                    &entry,
+                    &mut deferred_hardlinks,
+                    &mut written_rels,
+                    &mut unpacked,
+                )?;
+                continue;
+            }
 
             let safe_path = self.place_leaf(&normalized, entry_type == EntryType::Directory)?;
-            let applied = match entry_type {
-                EntryType::Directory => {
-                    self.create_directory(&safe_path, mode)?;
-                    true
-                }
+            match entry_type {
+                EntryType::Directory => self.create_directory(&safe_path, mode)?,
                 EntryType::Regular | EntryType::GNUSparse | EntryType::Continuous => {
                     write_regular(&safe_path, mode, &mut entry)?;
-                    true
                 }
-                EntryType::Link => {
-                    self.apply_hardlink(
-                        &raw_path,
-                        &normalized,
-                        &safe_path,
-                        &entry,
-                        &mut deferred_hardlinks,
-                    )?;
-                    true
-                }
-                EntryType::Symlink => {
-                    create_symlink(&raw_path, &safe_path, &entry)?;
-                    true
-                }
-                EntryType::Block | EntryType::Char | EntryType::Fifo => {
-                    debug!(
-                        path = %normalized.display(),
-                        ?entry_type,
-                        "skipping device/fifo tar member"
-                    );
-                    false
-                }
-                EntryType::XGlobalHeader | EntryType::XHeader => false,
+                EntryType::Symlink => create_symlink(&raw_path, &safe_path, &entry)?,
                 other => {
                     debug!(
                         path = %normalized.display(),
                         ?other,
                         "skipping unhandled tar member"
                     );
-                    false
+                    continue;
                 }
-            };
-            if applied {
-                remember_unpacked(&mut unpacked, self.root.root_path(), &safe_path);
             }
+            written_rels.insert(normalized.clone());
+            remember_unpacked(&mut unpacked, self.root.root_path(), &safe_path);
         }
 
-        self.flush_hardlinks(deferred_hardlinks)
+        self.flush_hardlinks(deferred_hardlinks, &written_rels)
     }
 
     fn place_leaf(&self, normalized: &Path, keep_dir: bool) -> Result<PathBuf> {
@@ -187,9 +181,10 @@ impl LayerExtractor {
         &self,
         raw_path: &Path,
         normalized: &Path,
-        safe_path: &Path,
         entry: &tar::Entry<'_, R>,
         deferred: &mut Vec<DeferredHardlink>,
+        written_rels: &mut HashSet<PathBuf>,
+        unpacked: &mut HashSet<PathBuf>,
     ) -> Result<()> {
         let target = entry.link_name()?.ok_or_else(|| {
             OciError::Extract(format!("hardlink without target: {}", raw_path.display()))
@@ -204,7 +199,10 @@ impl LayerExtractor {
         let target_safe = self.root.resolve_or_root(&tp)?.join(&tl);
         ensure_inside(self.root.root_path(), &target_safe)?;
         if fs::symlink_metadata(&target_safe).is_ok() {
-            fs::hard_link(&target_safe, safe_path)?;
+            let safe_path = self.place_leaf(normalized, false)?;
+            fs::hard_link(&target_safe, &safe_path)?;
+            written_rels.insert(normalized.to_path_buf());
+            remember_unpacked(unpacked, self.root.root_path(), &safe_path);
         } else {
             deferred.push(DeferredHardlink {
                 link_rel: normalized.to_path_buf(),
@@ -214,22 +212,26 @@ impl LayerExtractor {
         Ok(())
     }
 
-    fn flush_hardlinks(&self, deferred: Vec<DeferredHardlink>) -> Result<()> {
+    fn flush_hardlinks(
+        &self,
+        deferred: Vec<DeferredHardlink>,
+        written_rels: &HashSet<PathBuf>,
+    ) -> Result<()> {
         for item in deferred {
+            if written_rels.contains(&item.link_rel) {
+                continue;
+            }
             let (tp, tl) = split_parent_leaf(&item.target_rel);
             let target_safe = self.root.resolve_or_root(&tp)?.join(&tl);
             ensure_inside(self.root.root_path(), &target_safe)?;
             if fs::symlink_metadata(&target_safe).is_err() {
-                continue;
+                return Err(OciError::Extract(format!(
+                    "hardlink target missing: {}",
+                    item.target_rel.display()
+                )));
             }
-            let (lp, ll) = split_parent_leaf(&item.link_rel);
-            let link_safe = self.root.resolve_or_root(&lp)?.join(&ll);
-            ensure_inside(self.root.root_path(), &link_safe)?;
-            if let Some(parent) = link_safe.parent() {
-                ensure_dir(parent, self.root.root_path())?;
-            }
-            remove_nofollow(&link_safe, false)?;
-            fs::hard_link(&target_safe, &link_safe)?;
+            let safe_path = self.place_leaf(&item.link_rel, false)?;
+            fs::hard_link(&target_safe, &safe_path)?;
         }
         Ok(())
     }
@@ -262,7 +264,36 @@ fn write_regular<R: Read>(
         .mode(mode & 0o7777)
         .open(safe_path)?;
     io::copy(entry, &mut file)?;
+    fs::set_permissions(safe_path, Permissions::from_mode(mode & 0o7777))?;
     Ok(())
+}
+
+fn skip_member(entry_type: EntryType, normalized: &Path) -> bool {
+    match entry_type {
+        EntryType::Block | EntryType::Char | EntryType::Fifo => {
+            debug!(
+                path = %normalized.display(),
+                ?entry_type,
+                "skipping device/fifo tar member"
+            );
+            true
+        }
+        EntryType::XGlobalHeader | EntryType::XHeader => true,
+        EntryType::Directory
+        | EntryType::Regular
+        | EntryType::GNUSparse
+        | EntryType::Continuous
+        | EntryType::Link
+        | EntryType::Symlink => false,
+        other => {
+            debug!(
+                path = %normalized.display(),
+                ?other,
+                "skipping unhandled tar member"
+            );
+            true
+        }
+    }
 }
 
 fn create_symlink<R: Read>(
@@ -443,20 +474,55 @@ fn refuse_whiteout_escape(root: &SafeRoot, parent_rel: &Path) -> Result<()> {
     )))
 }
 
+fn push_path_components(out: &mut VecDeque<OsString>, path: &Path) {
+    for c in path.components() {
+        match c {
+            Component::Normal(s) => out.push_back(s.to_os_string()),
+            Component::ParentDir => out.push_back(OsString::from("..")),
+            _ => {}
+        }
+    }
+}
+
+fn prepend_path_components(remaining: &mut VecDeque<OsString>, path: &Path) {
+    let mut parts = VecDeque::new();
+    push_path_components(&mut parts, path);
+    while let Some(part) = parts.pop_back() {
+        remaining.push_front(part);
+    }
+}
+
 fn whiteout_parent_escapes(root: &Path, parent_rel: &Path) -> Result<bool> {
-    let mut cur = root.to_path_buf();
-    for comp in parent_rel.components() {
-        let Component::Normal(c) = comp else {
+    let mut resolved = PathBuf::new();
+    let mut hops: u32 = 0;
+    let mut remaining = VecDeque::new();
+    push_path_components(&mut remaining, parent_rel);
+
+    while let Some(comp) = remaining.pop_front() {
+        if comp == ".." {
+            if resolved.as_os_str().is_empty() {
+                return Ok(true);
+            }
+            resolved.pop();
             continue;
-        };
-        cur.push(c);
-        match fs::symlink_metadata(&cur) {
+        }
+        resolved.push(&comp);
+        let full = root.join(&resolved);
+        match fs::symlink_metadata(&full) {
             Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
             Err(e) => return Err(e.into()),
             Ok(meta) if meta.file_type().is_symlink() => {
-                let target = fs::read_link(&cur)?;
-                if symlink_target_escapes(root, &cur, &target) {
-                    return Ok(true);
+                hops += 1;
+                if hops > SYMLINK_HOP_LIMIT {
+                    return Err(hop_limit_error(parent_rel));
+                }
+                let target = fs::read_link(&full)
+                    .map_err(|e| OciError::Extract(format!("readlink {}: {e}", full.display())))?;
+                resolved.pop();
+                match classify_host_target(root, &root.join(&resolved), &target) {
+                    HostFollow::Escape => return Ok(true),
+                    HostFollow::Rel => prepend_path_components(&mut remaining, &target),
+                    HostFollow::Abs(in_root) => resolved = in_root,
                 }
             }
             Ok(_) => {}
@@ -465,17 +531,18 @@ fn whiteout_parent_escapes(root: &Path, parent_rel: &Path) -> Result<bool> {
     Ok(false)
 }
 
-fn symlink_target_escapes(root: &Path, link_path: &Path, target: &Path) -> bool {
-    if target.is_absolute() {
-        return !target.starts_with(root);
-    }
-    let mut acc = link_path.parent().unwrap_or(link_path).to_path_buf();
+enum HostFollow {
+    Escape,
+    Rel,
+    Abs(PathBuf),
+}
+
+fn relative_target_escapes(root: &Path, link_parent: &Path, target: &Path) -> bool {
+    let mut acc = link_parent.to_path_buf();
     for comp in target.components() {
         match comp {
+            Component::ParentDir if acc == root => return true,
             Component::ParentDir => {
-                if acc == root {
-                    return true;
-                }
                 acc.pop();
             }
             Component::Normal(c) => acc.push(c),
@@ -485,10 +552,52 @@ fn symlink_target_escapes(root: &Path, link_path: &Path, target: &Path) -> bool 
     !acc.starts_with(root)
 }
 
+fn classify_host_target(root: &Path, link_parent: &Path, target: &Path) -> HostFollow {
+    if !target.is_absolute() {
+        if relative_target_escapes(root, link_parent, target) {
+            return HostFollow::Escape;
+        }
+        return HostFollow::Rel;
+    }
+    let norm = lexical_normalize(target);
+    if !norm.starts_with(root) {
+        return HostFollow::Escape;
+    }
+    HostFollow::Abs(
+        norm.strip_prefix(root)
+            .map(Path::to_path_buf)
+            .unwrap_or_default(),
+    )
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut acc = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::Prefix(_) | Component::RootDir => acc.push(comp),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                acc.pop();
+            }
+            Component::Normal(c) => acc.push(c),
+        }
+    }
+    acc
+}
+
 fn clear_dir(dir: &Path, unpacked: &HashSet<PathBuf>) -> Result<()> {
     for entry in fs::read_dir(dir)? {
         let path = entry?.path();
+        let meta = match fs::symlink_metadata(&path) {
+            Ok(m) => m,
+            Err(e) if e.kind() == io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e.into()),
+        };
+        let is_real_dir = meta.is_dir() && !meta.file_type().is_symlink();
         if unpacked.contains(&path) {
+            if is_real_dir {
+                clear_dir(&path, unpacked)?;
+            }
             continue;
         }
         remove_nofollow(&path, false)?;

--- a/crates/bux-oci/src/extract.rs
+++ b/crates/bux-oci/src/extract.rs
@@ -1,16 +1,20 @@
 //! OCI layer extraction with whiteout handling.
 //!
-//! Supports both file-based (streaming from disk) and in-memory layer extraction.
-//! Handles all standard OCI/Docker layer media types:
-//! - `application/vnd.oci.image.layer.v1.tar+gzip`
-//! - `application/vnd.docker.image.rootfs.diff.tar.gzip`
-//! - Uncompressed tar fallback
+//! Paths are resolved with [`crate::SafeRoot`]. Device, FIFO, and socket
+//! members are skipped. Directory modes are applied once after the last layer.
 
-use std::fs::{self, File};
+use std::collections::{BTreeMap, HashSet};
+use std::fs::{self, File, OpenOptions, Permissions};
 use std::io::{self, BufReader, Read};
-use std::path::Path;
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+use std::path::{Component, Path, PathBuf};
 
 use flate2::read::GzDecoder;
+use tar::{Archive, EntryType};
+use tracing::{debug, error};
+
+use crate::safe_root::SafeRoot;
+use crate::{OciError, Result};
 
 /// Media types recognized as gzip-compressed layers.
 const GZIP_MEDIA_TYPES: &[&str] = &[
@@ -26,86 +30,468 @@ fn is_gzip(media_type: &str) -> bool {
 /// Extracts layer tarballs from disk into a rootfs directory (streaming, low memory).
 ///
 /// Each `(path, media_type)` pair is a layer tarball on disk. Layers are applied
-/// in order with full OCI whiteout semantics.
-pub(crate) fn extract_layer_files(
+/// in order with full OCI whiteout semantics. One [`SafeRoot`] is used for every
+/// layer; directory modes are chmod'd deepest-first after the last layer.
+///
+/// # Errors
+///
+/// Returns an error if a tarball cannot be read, a path escapes the rootfs, or
+/// a filesystem operation fails.
+pub fn extract_layer_files(
     layers: &[(impl AsRef<Path>, impl AsRef<str>)],
     rootfs: &Path,
-) -> crate::Result<()> {
+) -> Result<()> {
     fs::create_dir_all(rootfs)?;
+    let mut extractor = LayerExtractor::open(rootfs)?;
     for (path, media_type) in layers {
-        let file = BufReader::new(File::open(path.as_ref())?);
-        if is_gzip(media_type.as_ref()) {
-            apply_tar(GzDecoder::new(file), rootfs)?;
-        } else {
-            apply_tar(file, rootfs)?;
+        extractor.extract_tarball(path.as_ref(), is_gzip(media_type.as_ref()))?;
+    }
+    extractor.finalize()
+}
+
+struct LayerExtractor {
+    root: SafeRoot,
+    deferred_dirs: BTreeMap<PathBuf, u32>,
+}
+
+impl std::fmt::Debug for LayerExtractor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LayerExtractor")
+            .field("root", &self.root)
+            .field("deferred_dirs", &self.deferred_dirs.len())
+            .finish()
+    }
+}
+
+impl Drop for LayerExtractor {
+    fn drop(&mut self) {
+        if !self.deferred_dirs.is_empty() {
+            error!("LayerExtractor dropped without finalize");
         }
     }
+}
+
+struct DeferredHardlink {
+    link_rel: PathBuf,
+    target_rel: PathBuf,
+}
+
+impl LayerExtractor {
+    fn open(rootfs: &Path) -> Result<Self> {
+        Ok(Self {
+            root: SafeRoot::open(rootfs)?,
+            deferred_dirs: BTreeMap::new(),
+        })
+    }
+
+    fn extract_tarball(&mut self, path: &Path, gzip: bool) -> Result<()> {
+        let file = BufReader::new(File::open(path)?);
+        if gzip {
+            self.extract_reader(GzDecoder::new(file))
+        } else {
+            self.extract_reader(file)
+        }
+    }
+
+    fn extract_reader(&mut self, reader: impl Read) -> Result<()> {
+        let mut archive = Archive::new(reader);
+        let mut unpacked = HashSet::new();
+        let mut deferred_hardlinks = Vec::new();
+
+        for raw_entry in archive.entries()? {
+            let mut entry = raw_entry?;
+            let raw_path = entry.path()?.into_owned();
+            let Some(normalized) = SafeRoot::normalize(&raw_path) else {
+                continue;
+            };
+            if normalized.as_os_str().is_empty() {
+                continue;
+            }
+
+            let entry_type = entry.header().entry_type();
+            let mode = entry.header().mode().unwrap_or(0o644);
+            if apply_whiteout(&self.root, &normalized, &unpacked, entry_type)? {
+                continue;
+            }
+
+            let safe_path = self.place_leaf(&normalized, entry_type == EntryType::Directory)?;
+            let applied = match entry_type {
+                EntryType::Directory => {
+                    self.create_directory(&safe_path, mode)?;
+                    true
+                }
+                EntryType::Regular | EntryType::GNUSparse | EntryType::Continuous => {
+                    write_regular(&safe_path, mode, &mut entry)?;
+                    true
+                }
+                EntryType::Link => {
+                    self.apply_hardlink(
+                        &raw_path,
+                        &normalized,
+                        &safe_path,
+                        &entry,
+                        &mut deferred_hardlinks,
+                    )?;
+                    true
+                }
+                EntryType::Symlink => {
+                    create_symlink(&raw_path, &safe_path, &entry)?;
+                    true
+                }
+                EntryType::Block | EntryType::Char | EntryType::Fifo => {
+                    debug!(
+                        path = %normalized.display(),
+                        ?entry_type,
+                        "skipping device/fifo tar member"
+                    );
+                    false
+                }
+                EntryType::XGlobalHeader | EntryType::XHeader => false,
+                other => {
+                    debug!(
+                        path = %normalized.display(),
+                        ?other,
+                        "skipping unhandled tar member"
+                    );
+                    false
+                }
+            };
+            if applied {
+                remember_unpacked(&mut unpacked, self.root.root_path(), &safe_path);
+            }
+        }
+
+        self.flush_hardlinks(deferred_hardlinks)
+    }
+
+    fn place_leaf(&self, normalized: &Path, keep_dir: bool) -> Result<PathBuf> {
+        let (parent_rel, leaf) = split_parent_leaf(normalized);
+        let safe_parent = self.root.resolve_or_root(&parent_rel)?;
+        ensure_dir(&safe_parent, self.root.root_path())?;
+        let safe_path = safe_parent.join(&leaf);
+        ensure_inside(self.root.root_path(), &safe_path)?;
+        remove_nofollow(&safe_path, keep_dir)?;
+        Ok(safe_path)
+    }
+
+    fn create_directory(&mut self, safe_path: &Path, mode: u32) -> Result<()> {
+        if fs::symlink_metadata(safe_path).is_err() {
+            fs::create_dir(safe_path)?;
+        }
+        self.deferred_dirs
+            .insert(safe_path.to_path_buf(), mode & 0o7777);
+        Ok(())
+    }
+
+    fn apply_hardlink<R: Read>(
+        &self,
+        raw_path: &Path,
+        normalized: &Path,
+        safe_path: &Path,
+        entry: &tar::Entry<'_, R>,
+        deferred: &mut Vec<DeferredHardlink>,
+    ) -> Result<()> {
+        let target = entry.link_name()?.ok_or_else(|| {
+            OciError::Extract(format!("hardlink without target: {}", raw_path.display()))
+        })?;
+        let target_rel = SafeRoot::normalize(&target).ok_or_else(|| {
+            OciError::Extract(format!(
+                "hardlink target escapes rootfs: {}",
+                target.display()
+            ))
+        })?;
+        let (tp, tl) = split_parent_leaf(&target_rel);
+        let target_safe = self.root.resolve_or_root(&tp)?.join(&tl);
+        ensure_inside(self.root.root_path(), &target_safe)?;
+        if fs::symlink_metadata(&target_safe).is_ok() {
+            fs::hard_link(&target_safe, safe_path)?;
+        } else {
+            deferred.push(DeferredHardlink {
+                link_rel: normalized.to_path_buf(),
+                target_rel,
+            });
+        }
+        Ok(())
+    }
+
+    fn flush_hardlinks(&self, deferred: Vec<DeferredHardlink>) -> Result<()> {
+        for item in deferred {
+            let (tp, tl) = split_parent_leaf(&item.target_rel);
+            let target_safe = self.root.resolve_or_root(&tp)?.join(&tl);
+            ensure_inside(self.root.root_path(), &target_safe)?;
+            if fs::symlink_metadata(&target_safe).is_err() {
+                continue;
+            }
+            let (lp, ll) = split_parent_leaf(&item.link_rel);
+            let link_safe = self.root.resolve_or_root(&lp)?.join(&ll);
+            ensure_inside(self.root.root_path(), &link_safe)?;
+            if let Some(parent) = link_safe.parent() {
+                ensure_dir(parent, self.root.root_path())?;
+            }
+            remove_nofollow(&link_safe, false)?;
+            fs::hard_link(&target_safe, &link_safe)?;
+        }
+        Ok(())
+    }
+
+    fn finalize(mut self) -> Result<()> {
+        let dirs = std::mem::take(&mut self.deferred_dirs);
+        let mut sorted: Vec<(PathBuf, u32)> = dirs.into_iter().collect();
+        sorted.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+        for (path, mode) in sorted {
+            match fs::symlink_metadata(&path) {
+                Ok(m) if m.is_dir() => {
+                    fs::set_permissions(&path, Permissions::from_mode(mode))?;
+                }
+                _ => {}
+            }
+        }
+        Ok(())
+    }
+}
+
+fn write_regular<R: Read>(
+    safe_path: &Path,
+    mode: u32,
+    entry: &mut tar::Entry<'_, R>,
+) -> Result<()> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(mode & 0o7777)
+        .open(safe_path)?;
+    io::copy(entry, &mut file)?;
     Ok(())
 }
 
-/// Applies a single tar stream to `rootfs` with OCI whiteout processing.
-///
-/// Whiteout semantics (OCI Image Spec v1.1):
-/// - `.wh.<name>` — removes the named sibling entry from a lower layer.
-/// - `.wh..wh..opq` — marks the directory as opaque (clears inherited contents).
-#[allow(
-    clippy::excessive_nesting,
-    reason = "inherent in tar iteration + whiteout processing"
-)]
-fn apply_tar(reader: impl Read, rootfs: &Path) -> crate::Result<()> {
-    let mut archive = tar::Archive::new(reader);
-    archive.set_preserve_permissions(true);
-    archive.set_overwrite(true);
+fn create_symlink<R: Read>(
+    raw_path: &Path,
+    safe_path: &Path,
+    entry: &tar::Entry<'_, R>,
+) -> Result<()> {
+    let target = entry.link_name()?.ok_or_else(|| {
+        OciError::Extract(format!("symlink without target: {}", raw_path.display()))
+    })?;
+    std::os::unix::fs::symlink(&target, safe_path)?;
+    Ok(())
+}
 
-    for raw_entry in archive.entries()? {
-        let mut entry = raw_entry?;
-        let rel = entry.path()?.into_owned();
+fn split_parent_leaf(rel: &Path) -> (PathBuf, PathBuf) {
+    let parent = rel.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+    let leaf = rel.file_name().map_or_else(PathBuf::new, PathBuf::from);
+    (parent, leaf)
+}
 
-        let file_name = match rel.file_name().and_then(|n| n.to_str()) {
-            Some(name) => name.to_owned(),
-            None => continue,
-        };
+fn ensure_inside(root: &Path, path: &Path) -> Result<()> {
+    if path.starts_with(root) {
+        return Ok(());
+    }
+    error!(
+        root = %root.display(),
+        path = %path.display(),
+        "extract write-escape"
+    );
+    Err(OciError::Extract(format!(
+        "path escapes rootfs: {}",
+        path.display()
+    )))
+}
 
-        // Opaque whiteout: clear the parent directory contents.
-        if file_name == ".wh..wh..opq" {
-            if let Some(parent) = rel.parent().map(|p| rootfs.join(p)).filter(|p| p.exists()) {
-                clear_dir(&parent)?;
-            }
-            continue;
+fn ensure_dir(path: &Path, root: &Path) -> Result<()> {
+    if fs::create_dir_all(path).is_ok() {
+        return Ok(());
+    }
+    let mut cursor = path;
+    while cursor.starts_with(root) && cursor != root {
+        if let Ok(m) = fs::symlink_metadata(cursor)
+            && !m.is_dir()
+        {
+            fs::remove_file(cursor)?;
+            break;
         }
+        match cursor.parent() {
+            Some(p) => cursor = p,
+            None => break,
+        }
+    }
+    fs::create_dir_all(path)?;
+    Ok(())
+}
 
-        // Regular whiteout: remove the named entry from a lower layer.
-        if let Some(target_name) = file_name.strip_prefix(".wh.") {
-            if let Some(t) = rel
-                .parent()
-                .map(|p| rootfs.join(p).join(target_name))
-                .filter(|t| t.exists())
-            {
-                if t.is_dir() {
-                    fs::remove_dir_all(&t).ok();
-                } else {
-                    fs::remove_file(&t).ok();
+fn remove_nofollow(path: &Path, keep_if_dir: bool) -> Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) => {
+            let is_real_dir = meta.is_dir() && !meta.file_type().is_symlink();
+            if keep_if_dir && is_real_dir {
+                return Ok(());
+            }
+            let first = if is_real_dir {
+                fs::remove_dir_all(path)
+            } else {
+                fs::remove_file(path)
+            };
+            match first {
+                Err(e) if e.kind() == io::ErrorKind::PermissionDenied => {
+                    if let Some(parent) = path.parent() {
+                        make_user_writable(parent);
+                    }
+                    make_user_writable(path);
+                    if is_real_dir {
+                        fs::remove_dir_all(path)?;
+                    } else {
+                        fs::remove_file(path)?;
+                    }
+                }
+                Err(e) => return Err(e.into()),
+                Ok(()) => {}
+            }
+            Ok(())
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e.into()),
+    }
+}
+
+fn make_user_writable(path: &Path) {
+    if let Ok(meta) = fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            return;
+        }
+        let mode = meta.permissions().mode();
+        if mode & 0o200 == 0
+            && let Err(e) = fs::set_permissions(path, Permissions::from_mode(mode | 0o200))
+        {
+            debug!(error = %e, path = %path.display(), "chmod u+w for unlink");
+        }
+    }
+}
+
+fn remember_unpacked(unpacked: &mut HashSet<PathBuf>, root: &Path, path: &Path) {
+    let mut current = path;
+    while current != root {
+        unpacked.insert(current.to_path_buf());
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent;
+    }
+}
+
+fn apply_whiteout(
+    root: &SafeRoot,
+    rel: &Path,
+    unpacked: &HashSet<PathBuf>,
+    entry_type: EntryType,
+) -> Result<bool> {
+    if !matches!(entry_type, EntryType::Regular | EntryType::GNUSparse) {
+        return Ok(false);
+    }
+    let Some(base) = rel.file_name().and_then(|n| n.to_str()) else {
+        return Ok(false);
+    };
+
+    if base == ".wh..wh..opq" {
+        let parent_rel = rel.parent().unwrap_or_else(|| Path::new(""));
+        apply_opaque_whiteout(root, parent_rel, unpacked)?;
+        return Ok(true);
+    }
+
+    if let Some(target_name) = base.strip_prefix(".wh.") {
+        if target_name.is_empty() || target_name == "." || target_name == ".." {
+            return Err(OciError::Extract(format!("invalid whiteout name: {base}")));
+        }
+        let parent_rel = rel.parent().unwrap_or_else(|| Path::new(""));
+        refuse_whiteout_escape(root, parent_rel)?;
+        let target_safe = root.resolve_or_root(parent_rel)?.join(target_name);
+        ensure_inside(root.root_path(), &target_safe)?;
+        if fs::symlink_metadata(&target_safe).is_ok() {
+            remove_nofollow(&target_safe, false)?;
+        }
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+fn apply_opaque_whiteout(
+    root: &SafeRoot,
+    dir_rel: &Path,
+    unpacked: &HashSet<PathBuf>,
+) -> Result<()> {
+    refuse_whiteout_escape(root, dir_rel)?;
+    let dir_abs = root.resolve_or_root(dir_rel)?;
+    ensure_inside(root.root_path(), &dir_abs)?;
+    if !dir_abs.exists() {
+        return Ok(());
+    }
+    clear_dir(&dir_abs, unpacked)
+}
+
+/// Whiteouts that would follow a host-escaping symlink must fail, not re-anchor.
+fn refuse_whiteout_escape(root: &SafeRoot, parent_rel: &Path) -> Result<()> {
+    if !whiteout_parent_escapes(root.root_path(), parent_rel)? {
+        return Ok(());
+    }
+    error!(
+        path = %parent_rel.display(),
+        "extract write-escape"
+    );
+    Err(OciError::Extract(format!(
+        "path escapes rootfs: {}",
+        parent_rel.display()
+    )))
+}
+
+fn whiteout_parent_escapes(root: &Path, parent_rel: &Path) -> Result<bool> {
+    let mut cur = root.to_path_buf();
+    for comp in parent_rel.components() {
+        let Component::Normal(c) = comp else {
+            continue;
+        };
+        cur.push(c);
+        match fs::symlink_metadata(&cur) {
+            Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+            Err(e) => return Err(e.into()),
+            Ok(meta) if meta.file_type().is_symlink() => {
+                let target = fs::read_link(&cur)?;
+                if symlink_target_escapes(root, &cur, &target) {
+                    return Ok(true);
                 }
             }
-            continue;
+            Ok(_) => {}
         }
-
-        // Normal entry: extract into rootfs.
-        entry.unpack_in(rootfs)?;
     }
-
-    Ok(())
+    Ok(false)
 }
 
-/// Removes all contents of a directory without removing the directory itself.
-fn clear_dir(dir: &Path) -> io::Result<()> {
+fn symlink_target_escapes(root: &Path, link_path: &Path, target: &Path) -> bool {
+    if target.is_absolute() {
+        return !target.starts_with(root);
+    }
+    let mut acc = link_path.parent().unwrap_or(link_path).to_path_buf();
+    for comp in target.components() {
+        match comp {
+            Component::ParentDir => {
+                if acc == root {
+                    return true;
+                }
+                acc.pop();
+            }
+            Component::Normal(c) => acc.push(c),
+            _ => {}
+        }
+    }
+    !acc.starts_with(root)
+}
+
+fn clear_dir(dir: &Path, unpacked: &HashSet<PathBuf>) -> Result<()> {
     for entry in fs::read_dir(dir)? {
         let path = entry?.path();
-        if path.is_dir() {
-            fs::remove_dir_all(&path)?;
-        } else {
-            fs::remove_file(&path)?;
+        if unpacked.contains(&path) {
+            continue;
         }
+        remove_nofollow(&path, false)?;
     }
     Ok(())
 }

--- a/crates/bux-oci/src/lib.rs
+++ b/crates/bux-oci/src/lib.rs
@@ -1,8 +1,10 @@
 //! OCI image management for the bux micro-VM sandbox.
 //!
-//! Pulls, caches, and extracts OCI container images to a directory. The
-//! managed Runtime converts that directory into an ext4 base plus QCOW2
-//! overlay (`DiskManager::create_managed_base`). Powered by [`oci_client`].
+//! Pulls, caches, and extracts OCI container images to a directory. Layer
+//! extract resolves members with [`SafeRoot`] so a crafted symlink cannot
+//! write the host. The managed Runtime converts that directory into an ext4
+//! base plus QCOW2 overlay (`DiskManager::create_managed_base`). Powered by
+//! [`oci_client`].
 //!
 //! # Architecture
 //!
@@ -23,6 +25,7 @@
 mod config;
 mod error;
 mod extract;
+mod safe_root;
 mod store;
 
 use std::path::{Path, PathBuf};
@@ -33,6 +36,8 @@ use oci_client::secrets::RegistryAuth as ClientRegistryAuth;
 
 pub use config::{ImageConfig, OciConfig, PullResult, RegistryAuth};
 pub use error::{OciError, Result};
+pub use extract::extract_layer_files;
+pub use safe_root::SafeRoot;
 pub use store::ImageMeta;
 use store::Store;
 
@@ -167,11 +172,9 @@ impl Oci {
 
             // Run extraction in a blocking task (CPU-bound tar I/O).
             let staging_clone = staging.clone();
-            tokio::task::spawn_blocking(move || {
-                extract::extract_layer_files(&layer_files, &staging_clone)
-            })
-            .await
-            .map_err(|e| OciError::Io(std::io::Error::other(e)))??;
+            tokio::task::spawn_blocking(move || extract_layer_files(&layer_files, &staging_clone))
+                .await
+                .map_err(|e| OciError::Io(std::io::Error::other(e)))??;
 
             self.store.commit_rootfs(&manifest_digest)?;
         }

--- a/crates/bux-oci/src/lib.rs
+++ b/crates/bux-oci/src/lib.rs
@@ -1,10 +1,10 @@
 //! OCI image management for the bux micro-VM sandbox.
 //!
 //! Pulls, caches, and extracts OCI container images to a directory. Layer
-//! extract resolves members with [`SafeRoot`] so a crafted symlink cannot
-//! write the host. The managed Runtime converts that directory into an ext4
-//! base plus QCOW2 overlay (`DiskManager::create_managed_base`). Powered by
-//! [`oci_client`].
+//! extract resolves members inside the destination root so a crafted symlink
+//! cannot write the host. The managed Runtime converts that directory into an
+//! ext4 base plus QCOW2 overlay (`DiskManager::create_managed_base`). Powered
+//! by [`oci_client`].
 //!
 //! # Architecture
 //!
@@ -37,7 +37,6 @@ use oci_client::secrets::RegistryAuth as ClientRegistryAuth;
 pub use config::{ImageConfig, OciConfig, PullResult, RegistryAuth};
 pub use error::{OciError, Result};
 pub use extract::extract_layer_files;
-pub use safe_root::SafeRoot;
 pub use store::ImageMeta;
 use store::Store;
 

--- a/crates/bux-oci/src/safe_root/fallback.rs
+++ b/crates/bux-oci/src/safe_root/fallback.rs
@@ -1,0 +1,25 @@
+//! Non-Linux: walk only.
+
+use super::path;
+use crate::Result;
+use std::path::{Path, PathBuf};
+
+pub(super) struct Backend {
+    root: PathBuf,
+}
+
+impl Backend {
+    #[allow(
+        clippy::unnecessary_wraps,
+        reason = "signature matches the Linux backend"
+    )]
+    pub(super) fn open(root: &Path) -> Result<Self> {
+        Ok(Self {
+            root: root.to_path_buf(),
+        })
+    }
+
+    pub(super) fn resolve(&self, rel: &Path) -> Result<PathBuf> {
+        path::resolve_walk(&self.root, rel)
+    }
+}

--- a/crates/bux-oci/src/safe_root/linux.rs
+++ b/crates/bux-oci/src/safe_root/linux.rs
@@ -35,6 +35,9 @@ impl Backend {
             {
                 path::resolve_walk(&self.root_path, rel)
             }
+            Err(e) if e.kind() == pathrs::error::ErrorKind::OsError(Some(libc::ELOOP)) => {
+                Err(path::hop_limit_error(rel))
+            }
             Err(e) => Err(OciError::Extract(format!(
                 "pathrs resolve {}: {e}",
                 rel.display()

--- a/crates/bux-oci/src/safe_root/linux.rs
+++ b/crates/bux-oci/src/safe_root/linux.rs
@@ -1,0 +1,44 @@
+//! Linux: pathrs (`openat2(RESOLVE_IN_ROOT)`), walk when the path does not exist.
+
+use super::path;
+use crate::{OciError, Result};
+use std::os::fd::{AsFd, AsRawFd};
+use std::path::{Path, PathBuf};
+
+pub(super) struct Backend {
+    root: pathrs::Root,
+    root_path: PathBuf,
+}
+
+impl Backend {
+    pub(super) fn open(root: &Path) -> Result<Self> {
+        let inner = pathrs::Root::open(root)
+            .map_err(|e| OciError::Extract(format!("pathrs open {}: {e}", root.display())))?;
+        Ok(Self {
+            root: inner,
+            root_path: root.to_path_buf(),
+        })
+    }
+
+    pub(super) fn resolve(&self, rel: &Path) -> Result<PathBuf> {
+        match self.root.resolve(rel) {
+            Ok(handle) => {
+                let fd = handle.as_fd();
+                let proc_path = format!("/proc/self/fd/{}", fd.as_raw_fd());
+                std::fs::read_link(&proc_path).map_err(|e| {
+                    OciError::Extract(format!("readlink /proc/self/fd for {}: {e}", rel.display()))
+                })
+            }
+            Err(e)
+                if e.kind() == pathrs::error::ErrorKind::OsError(Some(libc::ENOENT))
+                    || e.kind() == pathrs::error::ErrorKind::OsError(Some(libc::ENOTDIR)) =>
+            {
+                path::resolve_walk(&self.root_path, rel)
+            }
+            Err(e) => Err(OciError::Extract(format!(
+                "pathrs resolve {}: {e}",
+                rel.display()
+            ))),
+        }
+    }
+}

--- a/crates/bux-oci/src/safe_root/mod.rs
+++ b/crates/bux-oci/src/safe_root/mod.rs
@@ -21,8 +21,10 @@ use std::fmt;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+pub(crate) use path::{SYMLINK_HOP_LIMIT, hop_limit_error};
+
 /// Directory tree that tar members are resolved against.
-pub struct SafeRoot {
+pub(crate) struct SafeRoot {
     root: PathBuf,
     backend: imp::Backend,
 }
@@ -42,7 +44,7 @@ impl SafeRoot {
     ///
     /// Returns an error if the directory cannot be created, canonicalized, or
     /// opened by the platform backend.
-    pub fn open(root: &Path) -> Result<Self> {
+    pub(crate) fn open(root: &Path) -> Result<Self> {
         fs::create_dir_all(root)?;
         let root = fs::canonicalize(root)?;
         Ok(Self {
@@ -58,7 +60,7 @@ impl SafeRoot {
     ///
     /// Returns an error if `rel` walks above the root, the hop limit is
     /// exceeded, or a filesystem error occurs while walking.
-    pub fn resolve(&self, rel: &Path) -> Result<PathBuf> {
+    pub(crate) fn resolve(&self, rel: &Path) -> Result<PathBuf> {
         let rel = path::normalize_relative(rel)
             .ok_or_else(|| OciError::Extract(format!("path escapes rootfs: {}", rel.display())))?;
         if rel.as_os_str().is_empty() {
@@ -90,7 +92,7 @@ impl SafeRoot {
 
     /// Strip leading `/` and collapse `.` / `..`. `None` if `..` walks above root.
     #[must_use]
-    pub fn normalize(path: &Path) -> Option<PathBuf> {
+    pub(crate) fn normalize(path: &Path) -> Option<PathBuf> {
         path::normalize_relative(path)
     }
 

--- a/crates/bux-oci/src/safe_root/mod.rs
+++ b/crates/bux-oci/src/safe_root/mod.rs
@@ -1,0 +1,104 @@
+//! Rooted path resolution for OCI layer extraction.
+//!
+//! [`SafeRoot`] follows symlinks inside the extract root and re-anchors
+//! absolute targets at that root. Callers then use ordinary `std::fs` on the
+//! returned path.
+
+mod path;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+use linux as imp;
+
+#[cfg(not(target_os = "linux"))]
+mod fallback;
+#[cfg(not(target_os = "linux"))]
+use fallback as imp;
+
+use crate::{OciError, Result};
+use std::fmt;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Directory tree that tar members are resolved against.
+pub struct SafeRoot {
+    root: PathBuf,
+    backend: imp::Backend,
+}
+
+impl fmt::Debug for SafeRoot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SafeRoot")
+            .field("root", &self.root)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SafeRoot {
+    /// Open `root`, creating it if needed. The stored path is canonical.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the directory cannot be created, canonicalized, or
+    /// opened by the platform backend.
+    pub fn open(root: &Path) -> Result<Self> {
+        fs::create_dir_all(root)?;
+        let root = fs::canonicalize(root)?;
+        Ok(Self {
+            backend: imp::Backend::open(&root)?,
+            root,
+        })
+    }
+
+    /// Follow every symlink, including the final component. Absolute targets
+    /// are re-anchored at the extract root.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `rel` walks above the root, the hop limit is
+    /// exceeded, or a filesystem error occurs while walking.
+    pub fn resolve(&self, rel: &Path) -> Result<PathBuf> {
+        let rel = path::normalize_relative(rel)
+            .ok_or_else(|| OciError::Extract(format!("path escapes rootfs: {}", rel.display())))?;
+        if rel.as_os_str().is_empty() {
+            return Ok(self.root.clone());
+        }
+        let resolved = self.backend.resolve(&rel)?;
+        if !resolved.starts_with(&self.root) {
+            tracing::error!(
+                root = %self.root.display(),
+                path = %resolved.display(),
+                "extract write-escape"
+            );
+            return Err(OciError::Extract(format!(
+                "path escapes rootfs: {}",
+                resolved.display()
+            )));
+        }
+        Ok(resolved)
+    }
+
+    /// Like [`Self::resolve`], but an empty `rel` is the root itself.
+    pub(crate) fn resolve_or_root(&self, rel: &Path) -> Result<PathBuf> {
+        if rel.as_os_str().is_empty() {
+            Ok(self.root.clone())
+        } else {
+            self.resolve(rel)
+        }
+    }
+
+    /// Strip leading `/` and collapse `.` / `..`. `None` if `..` walks above root.
+    #[must_use]
+    pub fn normalize(path: &Path) -> Option<PathBuf> {
+        path::normalize_relative(path)
+    }
+
+    pub(crate) fn root_path(&self) -> &Path {
+        &self.root
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, reason = "tests")]
+mod tests;

--- a/crates/bux-oci/src/safe_root/path.rs
+++ b/crates/bux-oci/src/safe_root/path.rs
@@ -8,7 +8,14 @@ use std::path::{Component, Path, PathBuf};
 use crate::{OciError, Result};
 
 /// 256th follow is treated as a cycle or a crafted chain.
-pub(super) const SYMLINK_HOP_LIMIT: u32 = 255;
+pub(crate) const SYMLINK_HOP_LIMIT: u32 = 255;
+
+pub(crate) fn hop_limit_error(rel: &Path) -> OciError {
+    OciError::Extract(format!(
+        "symlink hop limit exceeded resolving {}",
+        rel.display()
+    ))
+}
 
 /// Strip `/`, collapse `.` / `..`. `None` if `..` walks above the root.
 pub(super) fn normalize_relative(path: &Path) -> Option<PathBuf> {
@@ -55,10 +62,7 @@ pub(super) fn resolve_walk(root: &Path, rel: &Path) -> Result<PathBuf> {
             Ok(meta) if meta.file_type().is_symlink() => {
                 hops += 1;
                 if hops > SYMLINK_HOP_LIMIT {
-                    return Err(OciError::Extract(format!(
-                        "symlink hop limit exceeded resolving {}",
-                        rel.display()
-                    )));
+                    return Err(hop_limit_error(rel));
                 }
                 let target = std::fs::read_link(&full)
                     .map_err(|e| OciError::Extract(format!("readlink {}: {e}", full.display())))?;

--- a/crates/bux-oci/src/safe_root/path.rs
+++ b/crates/bux-oci/src/safe_root/path.rs
@@ -1,0 +1,90 @@
+//! Rooted path walk: follow in-root symlinks; re-anchor absolute targets.
+
+use std::collections::VecDeque;
+use std::ffi::OsString;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use crate::{OciError, Result};
+
+/// 256th follow is treated as a cycle or a crafted chain.
+pub(super) const SYMLINK_HOP_LIMIT: u32 = 255;
+
+/// Strip `/`, collapse `.` / `..`. `None` if `..` walks above the root.
+pub(super) fn normalize_relative(path: &Path) -> Option<PathBuf> {
+    let mut components = Vec::new();
+    for comp in path.components() {
+        match comp {
+            Component::RootDir | Component::Prefix(_) | Component::CurDir => {}
+            Component::ParentDir => {
+                components.pop()?;
+            }
+            Component::Normal(c) => components.push(c.to_os_string()),
+        }
+    }
+    Some(components.into_iter().collect())
+}
+
+fn push_components(remaining: &mut VecDeque<OsString>, path: &Path) {
+    for c in path.components() {
+        match c {
+            Component::Normal(s) => remaining.push_back(s.to_os_string()),
+            Component::ParentDir => remaining.push_back(OsString::from("..")),
+            _ => {}
+        }
+    }
+}
+
+/// Follow every component, including the last. Missing components stay as a
+/// path under `root` (the parent of a file being created does not exist yet).
+pub(super) fn resolve_walk(root: &Path, rel: &Path) -> Result<PathBuf> {
+    let mut resolved = PathBuf::new();
+    let mut hops: u32 = 0;
+    let mut remaining = VecDeque::new();
+    push_components(&mut remaining, rel);
+
+    while let Some(comp) = remaining.pop_front() {
+        if comp == ".." {
+            resolved.pop();
+            continue;
+        }
+        resolved.push(&comp);
+
+        let full = root.join(&resolved);
+        match std::fs::symlink_metadata(&full) {
+            Ok(meta) if meta.file_type().is_symlink() => {
+                hops += 1;
+                if hops > SYMLINK_HOP_LIMIT {
+                    return Err(OciError::Extract(format!(
+                        "symlink hop limit exceeded resolving {}",
+                        rel.display()
+                    )));
+                }
+                let target = std::fs::read_link(&full)
+                    .map_err(|e| OciError::Extract(format!("readlink {}: {e}", full.display())))?;
+                resolved.pop();
+                if target.is_absolute() {
+                    resolved = PathBuf::new();
+                }
+                let mut parts = VecDeque::new();
+                push_components(&mut parts, &target);
+                while let Some(part) = parts.pop_back() {
+                    remaining.push_front(part);
+                }
+            }
+            Ok(_) => {}
+            Err(e)
+                if e.kind() == io::ErrorKind::NotFound
+                    || e.kind() == io::ErrorKind::NotADirectory => {}
+            Err(e) => {
+                return Err(OciError::Extract(format!(
+                    "resolve {} under {}: {e}",
+                    rel.display(),
+                    root.display()
+                )));
+            }
+        }
+    }
+
+    Ok(root.join(resolved))
+}

--- a/crates/bux-oci/src/safe_root/tests.rs
+++ b/crates/bux-oci/src/safe_root/tests.rs
@@ -1,0 +1,220 @@
+//! Tests for rooted path resolution.
+
+use super::SafeRoot;
+use std::path::Path;
+
+fn create_symlink(root: &Path, link: &str, target: &str) {
+    let link_path = root.join(link);
+    if let Some(parent) = link_path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::os::unix::fs::symlink(target, link_path).unwrap();
+}
+
+#[test]
+fn resolve_simple_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = SafeRoot::open(tmp.path()).unwrap();
+    let resolved = root.resolve(Path::new("a/b")).unwrap();
+    assert_eq!(resolved, root.root_path().join("a/b"));
+}
+
+#[test]
+fn resolve_absolute_symlink_reanchors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("extract");
+    let root = SafeRoot::open(&dest).unwrap();
+
+    std::fs::create_dir_all(dest.join("real")).unwrap();
+    std::os::unix::fs::symlink("/real", dest.join("link")).unwrap();
+
+    let resolved = root.resolve(Path::new("link/file")).unwrap();
+    assert_eq!(resolved, root.root_path().join("real/file"));
+}
+
+#[test]
+fn resolve_chained_absolute_symlink() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("extract");
+    let host_side = tmp.path().join("host");
+    std::fs::create_dir_all(&host_side).unwrap();
+    let root = SafeRoot::open(&dest).unwrap();
+
+    std::os::unix::fs::symlink("b", dest.join("a")).unwrap();
+    std::os::unix::fs::symlink(host_side.to_str().unwrap(), dest.join("b")).unwrap();
+
+    let resolved = root.resolve(Path::new("a/file")).unwrap();
+    let host_side = std::fs::canonicalize(&host_side).unwrap();
+    assert!(
+        !resolved.starts_with(&host_side),
+        "escaped to host: {}",
+        resolved.display()
+    );
+}
+
+#[test]
+fn resolve_hop_limit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("extract");
+    let root = SafeRoot::open(&dest).unwrap();
+
+    std::os::unix::fs::symlink("b", dest.join("a")).unwrap();
+    std::os::unix::fs::symlink("a", dest.join("b")).unwrap();
+
+    let result = root.resolve(Path::new("a/file"));
+    assert!(result.is_err(), "circular symlink must hit hop limit");
+}
+
+#[test]
+fn resolve_escaping_path_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = SafeRoot::open(tmp.path()).unwrap();
+    let result = root.resolve(Path::new("../../etc/passwd"));
+    assert!(result.is_err());
+}
+
+#[test]
+fn absolute_symlink_stored_verbatim() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("extract");
+    let root = SafeRoot::open(&dest).unwrap();
+
+    std::os::unix::fs::symlink("/bin/busybox", dest.join("sh")).unwrap();
+
+    let target = std::fs::read_link(dest.join("sh")).unwrap();
+    assert_eq!(target, std::path::PathBuf::from("/bin/busybox"));
+
+    let resolved = root.resolve(Path::new("sh/sub")).unwrap();
+    assert!(resolved.starts_with(root.root_path()));
+}
+
+/// A resolve error must not be papered over with `root.join(rel)`.
+#[test]
+fn hardlink_resolve_fallback_must_not_escape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("extract");
+    let host_dir = tmp.path().join("host");
+    std::fs::create_dir_all(&host_dir).unwrap();
+    std::fs::write(host_dir.join("secret"), b"host data").unwrap();
+
+    let root = SafeRoot::open(&dest).unwrap();
+    std::os::unix::fs::symlink(&host_dir, dest.join("a")).unwrap();
+
+    let resolved = root.resolve(Path::new("a"));
+    let host_dir = std::fs::canonicalize(&host_dir).unwrap();
+    if let Ok(p) = &resolved {
+        assert!(
+            !p.starts_with(&host_dir),
+            "resolve escaped to host: {}",
+            p.display()
+        );
+    }
+}
+
+#[test]
+fn resolve_nonexistent_parent_returns_path_not_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dest = tmp.path().join("extract");
+    let root = SafeRoot::open(&dest).unwrap();
+
+    let result = root.resolve(Path::new("usr/bin"));
+    assert!(
+        result.is_ok(),
+        "missing parents must resolve, got: {:?}",
+        result.err()
+    );
+    let resolved = result.unwrap();
+    assert!(
+        resolved.starts_with(root.root_path()),
+        "resolved path should be under root"
+    );
+}
+
+#[test]
+fn resolve_symlink_cases() {
+    struct Case<'a> {
+        name: &'a str,
+        links: &'a [(&'a str, &'a str)],
+        rel: &'a str,
+        expected: &'a str,
+    }
+
+    let cases = [
+        Case {
+            name: "absolute symlink is re-anchored",
+            links: &[("a", "/b")],
+            rel: "a/c/data",
+            expected: "b/c/data",
+        },
+        Case {
+            name: "relative symlink parent traversal stays in root",
+            links: &[("a", "../b")],
+            rel: "a/c/data",
+            expected: "b/c/data",
+        },
+        Case {
+            name: "deep relative breakout collapses to root",
+            links: &[("a", "../../../../test")],
+            rel: "a/c/data",
+            expected: "test/c/data",
+        },
+        Case {
+            name: "absolute symlink to root",
+            links: &[("a", "/")],
+            rel: "a/c/data",
+            expected: "c/data",
+        },
+        Case {
+            name: "absolute symlink with parent traversal",
+            links: &[("a", "/../../")],
+            rel: "a/c/data",
+            expected: "c/data",
+        },
+        Case {
+            name: "relative symlink with parent traversal",
+            links: &[("a", "../../")],
+            rel: "a/c/data",
+            expected: "c/data",
+        },
+        Case {
+            name: "absolute chain stays rooted",
+            links: &[("a", "b"), ("b", "/c"), ("c", "d")],
+            rel: "a/e",
+            expected: "d/e",
+        },
+        Case {
+            name: "breakout through missing component is re-cleaned",
+            links: &[("slash", "/"), ("sym", "/idontexist/../slash")],
+            rel: "sym/file",
+            expected: "file",
+        },
+        Case {
+            name: "symlink target is resolved component by component",
+            links: &[("sym", "/foo/bar"), ("hello", "/sym/../baz")],
+            rel: "hello",
+            expected: "foo/baz",
+        },
+    ];
+
+    for case in cases {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = SafeRoot::open(tmp.path()).unwrap();
+        for (link, target) in case.links {
+            create_symlink(tmp.path(), link, target);
+        }
+
+        let actual = root.resolve(Path::new(case.rel)).unwrap();
+        let expected = root.root_path().join(case.expected);
+        assert_eq!(actual, expected, "{}", case.name);
+    }
+}
+
+#[test]
+fn resolve_circular_symlink_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = SafeRoot::open(tmp.path()).unwrap();
+    create_symlink(tmp.path(), "a", "b");
+    create_symlink(tmp.path(), "b", "a");
+
+    assert!(root.resolve(Path::new("a/file")).is_err());
+}

--- a/crates/bux-oci/tests/symlink_escape.rs
+++ b/crates/bux-oci/tests/symlink_escape.rs
@@ -1,0 +1,333 @@
+//! GHSA-f396 class: extract must not write or delete the host via symlinks.
+
+#![allow(
+    unused_crate_dependencies,
+    clippy::unwrap_used,
+    clippy::tests_outside_test_module,
+    reason = "Cargo tests/ binary; lib deps are unused here"
+)]
+
+use std::fs::{self, Permissions};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use bux_oci::{OciError, extract_layer_files};
+
+const LAYER: &str = "application/vnd.oci.image.layer.v1.tar";
+
+enum Ent {
+    Dir {
+        name: String,
+        mode: u32,
+    },
+    File {
+        name: String,
+        data: Vec<u8>,
+        mode: u32,
+    },
+    Symlink {
+        name: String,
+        target: String,
+    },
+}
+
+fn write_tar(tar_path: &Path, ents: &[Ent]) {
+    let mut builder = tar::Builder::new(Vec::new());
+    for ent in ents {
+        match ent {
+            Ent::Dir { name, mode } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_entry_type(tar::EntryType::Directory);
+                header.set_mode(*mode);
+                header.set_size(0);
+                header.set_cksum();
+                builder.append(&header, &[][..]).unwrap();
+            }
+            Ent::File { name, data, mode } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_entry_type(tar::EntryType::Regular);
+                header.set_mode(*mode);
+                header.set_size(data.len() as u64);
+                header.set_cksum();
+                builder.append(&header, data.as_slice()).unwrap();
+            }
+            Ent::Symlink { name, target } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_link_name(target).unwrap();
+                header.set_entry_type(tar::EntryType::Symlink);
+                header.set_size(0);
+                header.set_cksum();
+                builder.append(&header, &[][..]).unwrap();
+            }
+        }
+    }
+    let data = builder.into_inner().unwrap();
+    fs::write(tar_path, data).unwrap();
+}
+
+/// `Header::set_path` refuses `..`; a hostile layer can still encode it.
+fn write_dotdot_tar(tar_path: &Path, data: &[u8]) {
+    let mut builder = tar::Builder::new(Vec::new());
+    let mut header = tar::Header::new_gnu();
+    {
+        let old = header.as_old_mut();
+        for (dst, src) in old.name.iter_mut().zip(b"../outside") {
+            *dst = *src;
+        }
+    }
+    header.set_entry_type(tar::EntryType::Regular);
+    header.set_mode(0o644);
+    header.set_size(data.len() as u64);
+    header.set_cksum();
+    builder.append(&header, data).unwrap();
+    fs::write(tar_path, builder.into_inner().unwrap()).unwrap();
+}
+
+fn extract(layers: &[PathBuf], rootfs: &Path) {
+    let pairs: Vec<(&Path, &str)> = layers.iter().map(|p| (p.as_path(), LAYER)).collect();
+    extract_layer_files(&pairs, rootfs).unwrap();
+}
+
+fn extract_err(layers: &[PathBuf], rootfs: &Path) -> OciError {
+    let pairs: Vec<(&Path, &str)> = layers.iter().map(|p| (p.as_path(), LAYER)).collect();
+    extract_layer_files(&pairs, rootfs).unwrap_err()
+}
+
+#[test]
+fn symlink_escape_does_not_write_host() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let host = tmp.path().join("bux-oci-escape-target");
+    fs::create_dir_all(&host).unwrap();
+    let pwned = host.join("pwned");
+    assert!(!pwned.exists());
+
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[
+            Ent::Symlink {
+                name: "evil".into(),
+                target: host.to_string_lossy().into_owned(),
+            },
+            Ent::File {
+                name: "evil/pwned".into(),
+                data: b"pwned".to_vec(),
+                mode: 0o644,
+            },
+        ],
+    );
+
+    match extract_layer_files(&[(&tar, LAYER)], &rootfs) {
+        Ok(()) | Err(_) => {}
+    }
+    assert!(
+        !pwned.exists(),
+        "host must not be written through an extract symlink"
+    );
+}
+
+#[test]
+fn symlink_escape_whiteout_does_not_delete_host() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let host = tmp.path().join("host");
+    fs::create_dir_all(&host).unwrap();
+    let victim = host.join("keep-me");
+    fs::write(&victim, b"host").unwrap();
+
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[
+            Ent::Symlink {
+                name: "evil".into(),
+                target: host.to_string_lossy().into_owned(),
+            },
+            Ent::File {
+                name: "evil/.wh.keep-me".into(),
+                data: vec![],
+                mode: 0o644,
+            },
+        ],
+    );
+
+    match extract_layer_files(&[(&tar, LAYER)], &rootfs) {
+        Ok(()) | Err(_) => {}
+    }
+    assert!(
+        victim.exists(),
+        "whiteout must not delete a host file through a symlink"
+    );
+}
+
+#[test]
+fn absolute_symlink_is_reanchored() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let probe = "bux-oci-reanchor-probe";
+    let host_probe = Path::new("/etc").join(probe);
+
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[
+            Ent::Symlink {
+                name: "link".into(),
+                target: "/etc".into(),
+            },
+            Ent::File {
+                name: format!("link/{probe}"),
+                data: b"inside-rootfs".to_vec(),
+                mode: 0o644,
+            },
+        ],
+    );
+
+    extract(&[tar], &rootfs);
+    assert_eq!(
+        fs::read(rootfs.join("etc").join(probe)).unwrap(),
+        b"inside-rootfs"
+    );
+    assert!(
+        !host_probe.exists(),
+        "re-anchored write must not land on the host"
+    );
+}
+
+#[test]
+fn dotdot_entry_skipped() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let outside = tmp.path().join("outside");
+
+    let tar = tmp.path().join("layer.tar");
+    write_dotdot_tar(&tar, b"nope");
+
+    extract(&[tar], &rootfs);
+    assert!(!outside.exists(), "../outside must not be created");
+    assert!(
+        !rootfs.join("outside").exists(),
+        "skipped .. entry must not land inside rootfs either"
+    );
+}
+
+#[test]
+fn opaque_whiteout_clears_only_in_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let host = tmp.path().join("host");
+    fs::create_dir_all(&host).unwrap();
+    let host_file = host.join("secret");
+    fs::write(&host_file, b"host").unwrap();
+
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[
+            Ent::Symlink {
+                name: "dir".into(),
+                target: host.to_string_lossy().into_owned(),
+            },
+            Ent::File {
+                name: "dir/.wh..wh..opq".into(),
+                data: vec![],
+                mode: 0o644,
+            },
+        ],
+    );
+
+    let err = extract_err(&[tar], &rootfs);
+    assert!(
+        matches!(err, OciError::Extract(ref s) if s.contains("escapes")),
+        "opaque whiteout through a host symlink must fail closed, got {err}"
+    );
+    assert!(host_file.exists(), "host directory must not be cleared");
+}
+
+#[test]
+fn safe_root_hop_limit() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let tar = tmp.path().join("layer.tar");
+
+    let mut ents = Vec::new();
+    for i in 0..256 {
+        ents.push(Ent::Symlink {
+            name: format!("n{i}"),
+            target: format!("n{}", i + 1),
+        });
+    }
+    ents.push(Ent::File {
+        name: "n0/leaf".into(),
+        data: b"x".to_vec(),
+        mode: 0o644,
+    });
+    write_tar(&tar, &ents);
+
+    let err = extract_err(&[tar], &rootfs);
+    assert!(
+        matches!(err, OciError::Extract(ref s) if s.contains("hop limit")),
+        "256-hop chain must hit hop limit, got {err}"
+    );
+}
+
+#[test]
+fn cross_layer_dir_mode_finalize() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+
+    let layer1 = tmp.path().join("l1.tar");
+    write_tar(
+        &layer1,
+        &[
+            Ent::Dir {
+                name: "usr".into(),
+                mode: 0o755,
+            },
+            Ent::Dir {
+                name: "usr/bin".into(),
+                mode: 0o555,
+            },
+        ],
+    );
+    let layer2 = tmp.path().join("l2.tar");
+    write_tar(
+        &layer2,
+        &[Ent::File {
+            name: "usr/bin/tool".into(),
+            data: b"ok".to_vec(),
+            mode: 0o755,
+        }],
+    );
+
+    extract(&[layer1, layer2], &rootfs);
+    assert_eq!(fs::read(rootfs.join("usr/bin/tool")).unwrap(), b"ok");
+    let mode = fs::symlink_metadata(rootfs.join("usr/bin"))
+        .unwrap()
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o555,
+        "last declared dir mode applied after last layer"
+    );
+    fs::set_permissions(rootfs.join("usr/bin"), Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn extract_uses_safe_root_not_unpack_in() {
+    let src = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/extract.rs"));
+    assert!(
+        !src.contains("unpack_in"),
+        "unpack_in is not RESOLVE_IN_ROOT"
+    );
+    assert!(
+        !src.contains("rootfs.join"),
+        "host-view rootfs.join must stay deleted"
+    );
+    assert!(src.contains("SafeRoot"), "extract must go through SafeRoot");
+}

--- a/crates/bux-oci/tests/symlink_escape.rs
+++ b/crates/bux-oci/tests/symlink_escape.rs
@@ -29,6 +29,13 @@ enum Ent {
         name: String,
         target: String,
     },
+    Link {
+        name: String,
+        target: String,
+    },
+    Char {
+        name: String,
+    },
 }
 
 fn write_tar(tar_path: &Path, ents: &[Ent]) {
@@ -58,6 +65,23 @@ fn write_tar(tar_path: &Path, ents: &[Ent]) {
                 header.set_path(name).unwrap();
                 header.set_link_name(target).unwrap();
                 header.set_entry_type(tar::EntryType::Symlink);
+                header.set_size(0);
+                header.set_cksum();
+                builder.append(&header, &[][..]).unwrap();
+            }
+            Ent::Link { name, target } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_link_name(target).unwrap();
+                header.set_entry_type(tar::EntryType::Link);
+                header.set_size(0);
+                header.set_cksum();
+                builder.append(&header, &[][..]).unwrap();
+            }
+            Ent::Char { name } => {
+                let mut header = tar::Header::new_gnu();
+                header.set_path(name).unwrap();
+                header.set_entry_type(tar::EntryType::Char);
                 header.set_size(0);
                 header.set_cksum();
                 builder.append(&header, &[][..]).unwrap();
@@ -155,12 +179,54 @@ fn symlink_escape_whiteout_does_not_delete_host() {
         ],
     );
 
-    match extract_layer_files(&[(&tar, LAYER)], &rootfs) {
-        Ok(()) | Err(_) => {}
-    }
+    let err = extract_err(&[tar], &rootfs);
+    assert!(
+        matches!(err, OciError::Extract(ref s) if s.contains("escapes")),
+        "whiteout through a host symlink must fail closed, got {err}"
+    );
     assert!(
         victim.exists(),
         "whiteout must not delete a host file through a symlink"
+    );
+}
+
+#[test]
+fn symlink_escape_whiteout_two_hop_does_not_delete_host() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let host = tmp.path().join("host");
+    fs::create_dir_all(&host).unwrap();
+    let victim = host.join("keep-me");
+    fs::write(&victim, b"host").unwrap();
+
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[
+            Ent::Symlink {
+                name: "b".into(),
+                target: host.to_string_lossy().into_owned(),
+            },
+            Ent::Symlink {
+                name: "a".into(),
+                target: "b".into(),
+            },
+            Ent::File {
+                name: "a/.wh.keep-me".into(),
+                data: vec![],
+                mode: 0o644,
+            },
+        ],
+    );
+
+    let err = extract_err(&[tar], &rootfs);
+    assert!(
+        matches!(err, OciError::Extract(ref s) if s.contains("escapes")),
+        "two-hop whiteout through a host symlink must fail closed, got {err}"
+    );
+    assert!(
+        victim.exists(),
+        "whiteout must not delete a host file through a two-hop symlink"
     );
 }
 
@@ -316,6 +382,135 @@ fn cross_layer_dir_mode_finalize() {
         "last declared dir mode applied after last layer"
     );
     fs::set_permissions(rootfs.join("usr/bin"), Permissions::from_mode(0o755)).unwrap();
+}
+
+#[test]
+fn skip_device_does_not_unlink_lower_layer() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let layer1 = tmp.path().join("l1.tar");
+    write_tar(
+        &layer1,
+        &[
+            Ent::Dir {
+                name: "dev".into(),
+                mode: 0o755,
+            },
+            Ent::File {
+                name: "dev/null".into(),
+                data: b"keep".to_vec(),
+                mode: 0o644,
+            },
+        ],
+    );
+    let layer2 = tmp.path().join("l2.tar");
+    write_tar(
+        &layer2,
+        &[Ent::Char {
+            name: "dev/null".into(),
+        }],
+    );
+    extract(&[layer1, layer2], &rootfs);
+    assert_eq!(fs::read(rootfs.join("dev/null")).unwrap(), b"keep");
+}
+
+#[test]
+fn opaque_whiteout_preserves_same_layer_nested() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let layer1 = tmp.path().join("l1.tar");
+    write_tar(
+        &layer1,
+        &[
+            Ent::Dir {
+                name: "dir".into(),
+                mode: 0o755,
+            },
+            Ent::Dir {
+                name: "dir/sub".into(),
+                mode: 0o755,
+            },
+            Ent::File {
+                name: "dir/sub/lower".into(),
+                data: b"old".to_vec(),
+                mode: 0o644,
+            },
+        ],
+    );
+    let layer2 = tmp.path().join("l2.tar");
+    write_tar(
+        &layer2,
+        &[
+            Ent::File {
+                name: "dir/sub/a".into(),
+                data: b"new".to_vec(),
+                mode: 0o644,
+            },
+            Ent::File {
+                name: "dir/.wh..wh..opq".into(),
+                data: vec![],
+                mode: 0o644,
+            },
+        ],
+    );
+    extract(&[layer1, layer2], &rootfs);
+    assert_eq!(fs::read(rootfs.join("dir/sub/a")).unwrap(), b"new");
+    assert!(
+        !rootfs.join("dir/sub/lower").exists(),
+        "opaque whiteout must still clear lower-layer nested names"
+    );
+}
+
+#[test]
+fn deferred_hardlink_does_not_clobber_later_file() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[
+            Ent::File {
+                name: "target".into(),
+                data: b"A".to_vec(),
+                mode: 0o644,
+            },
+            Ent::Link {
+                name: "dest".into(),
+                target: "later".into(),
+            },
+            Ent::File {
+                name: "later".into(),
+                data: b"B".to_vec(),
+                mode: 0o644,
+            },
+            Ent::File {
+                name: "dest".into(),
+                data: b"C".to_vec(),
+                mode: 0o644,
+            },
+        ],
+    );
+    extract(&[tar], &rootfs);
+    assert_eq!(fs::read(rootfs.join("dest")).unwrap(), b"C");
+}
+
+#[test]
+fn missing_hardlink_target_is_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    let rootfs = tmp.path().join("rootfs");
+    let tar = tmp.path().join("layer.tar");
+    write_tar(
+        &tar,
+        &[Ent::Link {
+            name: "link".into(),
+            target: "nowhere".into(),
+        }],
+    );
+    let err = extract_err(&[tar], &rootfs);
+    assert!(
+        matches!(err, OciError::Extract(ref s) if s.contains("hardlink target missing")),
+        "missing hardlink target must fail, got {err}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- OCI layer extract no longer uses `unpack_in` / `rootfs.join`.
- One `SafeRoot` for all layers (pathrs `openat2(RESOLVE_IN_ROOT)` on Linux, walk on Darwin). Directory modes `finalize` after the last layer.
- Fail-closed on host write-escape and whiteout-through-escaping-symlink. Device/fifo skipped without unlinking lower-layer names. Hardlinks jailed; last writer wins.

GHSA-f396 class. Independent of the jailer rewrite. Does not merge the unfinished Linux jailer stack.

## Test plan
- [ ] `cargo test -p bux-oci` (15 unit + 13 integration, including `symlink_escape_*`)
- [ ] CI `ci / ci` + ubuntu/macos `test`